### PR TITLE
Another OAuth2 Authorization Authenticator

### DIFF
--- a/RestSharp/Authenticators/OAuth2Authenticator.cs
+++ b/RestSharp/Authenticators/OAuth2Authenticator.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+
 namespace RestSharp
 {
 	/// <summary>
@@ -64,4 +67,40 @@ namespace RestSharp
 			request.AddParameter("oauth_token", AccessToken, ParameterType.GetOrPost);
 		}
 	}
+
+    /// <summary>
+    /// The OAuth 2 authenticator using the authorization request header field.
+    /// </summary>
+    /// <remarks>
+    /// Based on http://tools.ietf.org/html/draft-ietf-oauth-v2-10#section-5.1.1
+    /// </remarks>
+    public class OAuth2AuthorizationRequestHeaderAuthenticator : OAuth2Authenticator
+    {
+        /// <summary>
+        /// Stores the Authoriztion header value as "OAuth accessToken". used for performance.
+        /// </summary>
+        private readonly string _authorizationValue;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OAuth2AuthorizationRequestHeaderAuthenticator"/> class.
+        /// </summary>
+        /// <param name="accessToken">
+        /// The access token.
+        /// </param>
+        public OAuth2AuthorizationRequestHeaderAuthenticator(string accessToken)
+            : base(accessToken)
+        {
+            // Conatenate during constructor so that it is only done once. can improve performance.
+            _authorizationValue = "OAuth " + accessToken;
+        }
+
+        public override void Authenticate(RestRequest request)
+        {
+            // only add the Authorization parameter if it hasn't been added.
+            if (!request.Parameters.Any(p => p.Name.Equals("Authorization", StringComparison.InvariantCultureIgnoreCase)))
+            {
+                request.AddParameter("Authorization", _authorizationValue, ParameterType.HttpHeader);
+            }
+        }
+    }
 }


### PR DESCRIPTION
I have added support for another OAuth2 Authenticator called OAuth2AuthorizationRequestHeaderAuthenticator (pretty long name but thats the best i could think of that says what it means)

Rather than using querystring or post body to add the oauth2 access token, it uses the http Authorization headers.

When I was using OAuth2UriQueryParameterAuthenticator and uploading photos to facebook I encountered some problems with it. 

OAuth2UriQueryParameterAuthenticator adds access token using the following way.
request.AddParameter("oauth_token", AccessToken, ParameterType.GetOrPost);

so when i call  request.AddFile and looked using fiddler, I didn't see any oauth_token either in url string or in POST body. Might be can add another ParameterType.QueryString
bascially OAuth2UriQueryParameterAuthenticator doesnt work if you add files but works for normal GET/POST/DELETE.

According to the OAuth2 documentation, it says resource servers must support "Authorization" request header field while others are optional. So having OAuth2AuthorizationRequestHeaderAuthenticator means that RestSharp can now communicate with any OAuth2 compliant servers.

So might be in the wiki you could tell that OAuth2AuthorizationRequestHeaderAuthenticator is preferrable.

And another thing, there is a problem with AddFile not woking coz, the content-lenght is always set to 0 during post, I have fixed it internaly in my RestSharp fork (haven't commited to github yet). but still need to find a better way to solve it.
