### PR TITLE
fixed nullable check in XmlAttributeDeserializer

### DIFF
--- a/RestSharp/Deserializers/XmlAttributeDeserializer.cs
+++ b/RestSharp/Deserializers/XmlAttributeDeserializer.cs
@@ -107,11 +107,16 @@ namespace RestSharp.Deserializers
 					continue;
 				}
 
-				// check for nullable and extract underlying type
-				if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
-				{
-					type = type.GetGenericArguments()[0];
-				}
+                // check for nullable and extract underlying type
+                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                {
+                    type = type.GetGenericArguments()[0];
+
+                    if (string.IsNullOrEmpty(value.ToString()))
+                    {
+                        continue;
+                    }
+                }
 
 				if (type.IsPrimitive)
 				{


### PR DESCRIPTION
Was causing an exception if the string returned was empty on a nullable value, now it returns correctly
