### PR TITLE
JsonDeserializer RootElement property should allow nested element

### DIFF
--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -66,7 +66,7 @@ namespace RestSharp.Deserializers
 			JToken root = json.Root;
 
 			if (RootElement.HasValue())
-				root = json[RootElement];
+				root = json.SelectToken(RootElement);
 
 			return root;
 		}


### PR DESCRIPTION
Modified FindRoot in JsonDeserializer.cs to allow a nested dot separated path statement by using JSON.NET's SelectToken function instead of only looking for top level matches.

Resolves [issue 68](http://github.com/johnsheehan/RestSharp/issues#issue/68).
