### PR TITLE
fix for Can_Deserialize_Names_With_Underscores_Without_Matching_Case_On_Default_Root

### DIFF
--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -298,11 +298,15 @@ namespace RestSharp.Deserializers
 				return root;
 			}
 
-			// try looking for element that matches sanitized property name (Order by depth)
-			var element = root.Descendants()
-								.OrderBy(d => d.Ancestors().Count())
-								.FirstOrDefault(d => d.Name.LocalName.RemoveUnderscoresAndDashes() == name.LocalName);
-			if (element != null)
+            // try looking for element that matches sanitized property name (Order by depth)
+            var element = root.Descendants()
+                              .OrderBy(d => d.Ancestors().Count())
+                              .FirstOrDefault(d => d.Name.LocalName.RemoveUnderscoresAndDashes() == name.LocalName) 
+                              ?? root.Descendants()
+                              .OrderBy(d => d.Ancestors().Count())
+                              .FirstOrDefault(d => d.Name.LocalName.RemoveUnderscoresAndDashes() == name.LocalName.ToLower());
+
+		    if (element != null)
 			{
 				return element;
 			}


### PR DESCRIPTION
Here's a fix for Can_Deserialize_Names_With_Underscores_Without_Matching_Case_On_Default_Root failing.

I don't get why github is saying I'm asking you to pull 5 commits :/
