### PR TITLE
Bug multipart contentlength

### DIFF
--- a/RestSharp.IntegrationTests/FileTests.cs
+++ b/RestSharp.IntegrationTests/FileTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using Xunit;
 
@@ -17,6 +18,19 @@ namespace RestSharp.IntegrationTests
 
 			var expected = File.ReadAllBytes(Environment.CurrentDirectory + "\\Assets\\Koala.jpg");
 			Assert.Equal(expected, response);
+		}
+
+		[Fact]
+		public void Handles_MultipartFormData_With_File(){
+			var client = new RestClient(BaseUrl);
+			var request = new RestRequest("upload"){Method = Method.POST}; // non-existent URL
+
+			request.AddFile("Assets\\Koala.jpg");
+			request.AddParameter("parameter", "parameter value");
+
+			var response = client.Execute(request);
+
+			Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
 		}
 	}
 }

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -224,7 +224,10 @@ namespace RestSharp
 			webRequest.Method = method;
 
 			// make sure Content-Length header is always sent since default is -1
-			webRequest.ContentLength = 0;
+			if(!HasFiles)
+			{
+				webRequest.ContentLength = 0;
+			}
 
 			webRequest.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip | DecompressionMethods.None;
 


### PR DESCRIPTION
Fixes a bug where if there are files to be uploaded, the ContentLength was being set to zero rather than left at the default (-1).  When the ContentLength is set, the 'GetRequestStream' call on the request object (in Http.Sync.cs) immediately sends the request, rather than allowing RestSharp to write to the request stream.
