### PR TITLE
Bug multipart last parameter newline

### DIFF
--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -195,7 +195,7 @@ namespace RestSharp
 					formDataStream.Write(encoding.GetBytes(postData), 0, postData.Length);
 				}
 
-				string footer = String.Format("{1}--{0}--{1}", FormBoundary, Environment.NewLine);
+				string footer = String.Format("--{0}--{1}", FormBoundary, Environment.NewLine);
 				formDataStream.Write(encoding.GetBytes(footer), 0, footer.Length);
 			}
 		}


### PR DESCRIPTION
This fixes a bug where there is an extra newline after the last parameter of a multi-part form data message.  The change is simply to remove it.
