### PR TITLE
Feature filestreaming

### DIFF
--- a/RestSharp/Extensions/MiscExtensions.cs
+++ b/RestSharp/Extensions/MiscExtensions.cs
@@ -56,6 +56,22 @@ namespace RestSharp.Extensions
 		}
 
 		/// <summary>
+		/// Copies bytes from one stream to another
+		/// </summary>
+		/// <param name="input">The input stream.</param>
+		/// <param name="output">The output stream.</param>
+		public static void CopyTo(this Stream input, Stream output)
+		{
+			var buffer = new byte[32768];
+			while(true)
+			{
+				var read = input.Read(buffer, 0, buffer.Length);
+				if(read <= 0)
+					return;
+				output.Write(buffer, 0, read);
+			}
+		}
+		/// <summary>
 		/// Gets string value from JToken
 		/// </summary>
 		/// <param name="token"></param>

--- a/RestSharp/FileParameter.cs
+++ b/RestSharp/FileParameter.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.IO;
 
 namespace RestSharp
 {
@@ -10,10 +8,38 @@ namespace RestSharp
 	/// </summary>
 	public class FileParameter
 	{
+		///<summary>
+		/// Creates a file parameter from an array of bytes.
+		///</summary>
+		///<param name="data">The data to use as the file's contents.</param>
+		///<param name="filename">The filename to use in the request.</param>
+		///<param name="contentType">The content type to use in the request.</param>
+		///<returns>The <see cref="FileParameter"/></returns>
+		public static FileParameter Create(byte[] data, string filename, string contentType)
+		{
+			return new FileParameter
+			{
+				Writer = s => s.Write(data, 0, data.Length),
+				FileName = filename,
+				ContentType = contentType
+			};
+		}
+
+		///<summary>
+		/// Creates a file parameter from an array of bytes.
+		///</summary>
+		///<param name="data">The data to use as the file's contents.</param>
+		///<param name="filename">The filename to use in the request.</param>
+		///<returns>The <see cref="FileParameter"/> using the default content type.</returns>
+		public static FileParameter Create(byte[] data, string filename)
+		{
+			return Create(data, filename, null);
+		}
+
 		/// <summary>
-		/// Raw data for file
+		/// Provides raw data for file
 		/// </summary>
-		public byte[] Data { get; set; }
+		public Action<Stream> Writer { get; set; }
 		/// <summary>
 		/// Name of the file to use when uploading
 		/// </summary>

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -167,8 +167,6 @@ namespace RestSharp
 				foreach (var file in Files)
 				{
 					var fileName = file.FileName;
-					var data = file.Data;
-					var length = data.Length;
 					var contentType = file.ContentType;
 					// Add just the first part of this param, since we will write the file data directly to the Stream
 					string header = string.Format("--{0}{3}Content-Disposition: form-data; name=\"{1}\"; filename=\"{1}\"{3}Content-Type: {2}{3}{3}",
@@ -179,7 +177,7 @@ namespace RestSharp
 
 					formDataStream.Write(encoding.GetBytes(header), 0, header.Length);
 					// Write the file data directly to the Stream, rather than serializing it to a string.
-					formDataStream.Write(data, 0, length);
+					file.Writer(formDataStream);
 					string lineEnding = Environment.NewLine;
 					formDataStream.Write(encoding.GetBytes(lineEnding), 0, lineEnding.Length);
 				}

--- a/RestSharp/HttpFile.cs
+++ b/RestSharp/HttpFile.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.IO;
 
 namespace RestSharp
 {
@@ -11,9 +9,9 @@ namespace RestSharp
 	public class HttpFile
 	{
 		/// <summary>
-		/// Raw data for file
+		/// Provides raw data for file
 		/// </summary>
-		public byte[] Data { get; set; }
+		public Action<Stream> Writer { get; set; }
 		/// <summary>
 		/// Name of the file to use when uploading
 		/// </summary>

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -332,7 +332,7 @@ namespace RestSharp
 
 			foreach (var file in request.Files)
 			{
-				http.Files.Add(new HttpFile { ContentType = file.ContentType, Data = file.Data, FileName = file.FileName });
+				http.Files.Add(new HttpFile { ContentType = file.ContentType, Writer = file.Writer, FileName = file.FileName });
 			}
 
 			var body = (from p in request.Parameters


### PR DESCRIPTION
Add additional API method overload to the 'AddFile' section of a RestRequest.  This allows for direct streaming, so the entire file doesn't need to be read into memory at once in case it's a really large file, or in case it's not really in a file at all, but is streaming from some other source.
