### PR TITLE
Bug nullref extractresponse

### DIFF
--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -129,20 +129,18 @@ namespace RestSharp
 
 		private HttpWebResponse GetRawResponse(HttpWebRequest request)
 		{
-			HttpWebResponse raw = null;
 			try
 			{
-				raw = (HttpWebResponse)request.GetResponse();
+				return (HttpWebResponse)request.GetResponse();
 			}
 			catch (WebException ex)
 			{
 				if (ex.Response is HttpWebResponse)
 				{
-					raw = ex.Response as HttpWebResponse;
+					return ex.Response as HttpWebResponse;
 				}
+                throw;
 			}
-
-			return raw;
 		}
 
 		private void PreparePostData(HttpWebRequest webRequest)


### PR DESCRIPTION
I was experiencing a problem in the 'Http.GetResponse' callstack, where, on certain invalid server responses, 'Http.GetRawResponse' would return null, and then a null ref exception would occur inside of 'Http.ExtractResponseData'.

This solution allows the application error handling take over, by setting the error message and exception on the response object.
