### PR TITLE
Fixes Post Content being truncated

### DIFF
--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -189,11 +189,13 @@ namespace RestSharp
 			if (HasBody)
 			{
 				var encoding = Encoding.UTF8;
-				webRequest.ContentLength = RequestBody.Length;
+				var bytes = encoding.GetBytes(RequestBody);
+
+				webRequest.ContentLength = bytes.Length;
 
 				using (var requestStream = webRequest.GetRequestStream())
 				{
-					requestStream.Write(encoding.GetBytes(RequestBody), 0, RequestBody.Length);
+					requestStream.Write(bytes, 0, bytes.Length);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes issue 101: Json body get truncated when contains unicode characters that encode to more than one byte 
