### PR TITLE
Made the XmlAttributeDeserializer support inline lists

### DIFF
--- a/RestSharp.Tests/RestSharp.Tests.csproj
+++ b/RestSharp.Tests/RestSharp.Tests.csproj
@@ -52,9 +52,8 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=3.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\References\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json.Net35, Version=4.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\References\Newtonsoft.Json.Net35.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/RestSharp.Tests/XmlTests.cs
+++ b/RestSharp.Tests/XmlTests.cs
@@ -54,6 +54,19 @@ namespace RestSharp.Tests
 			Assert.Equal(4, output.Images.Count);
 		}
 
+        [Fact]
+        public void Can_Deserialize_Parentless_aka_Inline_List_Items_Without_Matching_Class_Name_Using_XmlAttributeDeserializer()
+        {
+            var xmlpath = Environment.CurrentDirectory + @"\SampleData\InlineListSample.xml";
+            var doc = XDocument.Load(xmlpath);
+
+            var xml = new XmlAttributeDeserializer();
+            var output = xml.Deserialize<InlineListSample>(new RestResponse { Content = doc.ToString() });
+
+            Assert.NotEmpty(output.Images);
+            Assert.Equal(4, output.Images.Count);
+        }
+
 		[Fact]
 		public void Can_Deserialize_Parentless_aka_Inline_List_Items_With_Matching_Class_Name()
 		{
@@ -67,6 +80,19 @@ namespace RestSharp.Tests
 			Assert.Equal(4, output.images.Count);
 		}
 
+        [Fact]
+        public void Can_Deserialize_Parentless_aka_Inline_List_Items_With_Matching_Class_Name_Using_XmlAttributeDeserializer()
+        {
+            var xmlpath = Environment.CurrentDirectory + @"\SampleData\InlineListSample.xml";
+            var doc = XDocument.Load(xmlpath);
+
+            var xml = new XmlAttributeDeserializer();
+            var output = xml.Deserialize<InlineListSample>(new RestResponse { Content = doc.ToString() });
+
+            Assert.NotEmpty(output.images);
+            Assert.Equal(4, output.images.Count);
+        }
+
 		[Fact]
 		public void Can_Deserialize_Nested_List_Items_Without_Matching_Class_Name()
 		{
@@ -79,6 +105,7 @@ namespace RestSharp.Tests
 			Assert.NotEmpty(output.Images);
 			Assert.Equal(4, output.Images.Count);
 		}
+
 
 		[Fact]
 		public void Can_Deserialize_Nested_List_Items_With_Matching_Class_Name()

--- a/RestSharp/Deserializers/XmlAttributeDeserializer.cs
+++ b/RestSharp/Deserializers/XmlAttributeDeserializer.cs
@@ -104,7 +104,23 @@ namespace RestSharp.Deserializers
 
 				if (value == null)
 				{
-					continue;
+                    // special case for inline list items
+                    if (type.IsGenericType)
+                    {
+                        var genericType = type.GetGenericArguments()[0];
+
+                        var first = GetElementByName(root, genericType.Name);
+                        if (first != null)
+                        {
+                            var elements = root.Elements(first.Name);
+
+                            var list = (IList)Activator.CreateInstance(type);
+                            PopulateListFromElements(genericType, elements, list);
+                            prop.SetValue(x, list, null);
+
+                        }
+                    }
+                    continue;
 				}
 
                 // check for nullable and extract underlying type


### PR DESCRIPTION
Code was already there for this in the default XmlSerializer, so I just ported it over and duplicated the two unit tests that already tested this for the XmlSerializer, to use the XmlAttributeDeserializer.
