### PR TITLE
Connectivity detection and status

### DIFF
--- a/RestSharp/Enum.cs
+++ b/RestSharp/Enum.cs
@@ -75,6 +75,7 @@ namespace RestSharp
 		None,
 		Completed,
 		Error,
-		TimedOut
+		TimedOut,
+		NoConnectivity
 	}
 }


### PR DESCRIPTION
I've added a network connectivity detection and response status code to the response object. There were times when wifi or 3G was not available on the phone and these scenarios threw a non descriptive exception. There is now a new enum for NoConnectivity status.

If we want to keep the ResponseStatus simple to None, Completed, Error, perhaps we can add a new property that would give a more detailed description of the error status which would include TimedOut and NoConnectivity and any others that may arise.

Andrew.
