### PR TITLE
Fix uri encoding

### DIFF
--- a/RestSharp/Extensions/StringExtensions.cs
+++ b/RestSharp/Extensions/StringExtensions.cs
@@ -43,9 +43,13 @@ namespace RestSharp.Extensions
 			return HttpUtility.UrlDecode(input);
 		}
 
+        /// <summary>
+        /// Uses Uri.EscapeDataString() based on recommendations on MSDN
+        /// http://blogs.msdn.com/b/yangxind/archive/2006/11/09/don-t-use-net-system-uri-unescapedatastring-in-url-decoding.aspx
+        /// </summary>
 		public static string UrlEncode(this string input)
 		{
-			return HttpUtility.UrlEncode(input);
+			return Uri.EscapeDataString(input);
 		}
 
 		public static string HtmlDecode(this string input)


### PR DESCRIPTION
Apparently this is the best way to handle URI encoding of strings due to some poor implementation in the HttpUtility class.  It seems odd, but I found several blogs mentioning this.  One in included in the code comments
