### PR TITLE
Untitled

### DIFF
--- a/RestSharp/Authenticators/OAuth1Authenticator.cs
+++ b/RestSharp/Authenticators/OAuth1Authenticator.cs
@@ -207,14 +207,15 @@ namespace RestSharp.Authenticators
 			parameters.Sort((l, r) => l.Name.CompareTo(r.Name));
 
 			var parameterCount = 0;
-			foreach (var parameter in parameters.Where(parameter =>
+            var oathParameters = parameters.Where(parameter =>
 													   !parameter.Name.IsNullOrBlank() &&
 													   !parameter.Value.IsNullOrBlank() &&
 														parameter.Name.StartsWith("oauth_")
-													   ))
+													   ).ToList();
+			foreach (var parameter in oathParameters)
 			{
 				parameterCount++;
-				var format = parameterCount < parameters.Count ? "{0}=\"{1}\"," : "{0}=\"{1}\"";
+                var format = parameterCount < oathParameters.Count ? "{0}=\"{1}\"," : "{0}=\"{1}\"";
 				sb.Append(format.FormatWith(parameter.Name, parameter.Value));
 			}
 


### PR DESCRIPTION
Fixed bug with extra comma being appended to OAuth Authentication Header which caused DotNetOpenAuth (the biggest house of cards in the world) to error out.
