### PR TITLE
Changed how parameters are ordered for message signing.

### DIFF
--- a/RestSharp/Authenticators/OAuth/OAuthTools.cs
+++ b/RestSharp/Authenticators/OAuth/OAuthTools.cs
@@ -142,7 +142,7 @@ namespace RestSharp.Authenticators.OAuth
 
             copy.RemoveAll(exclusions);
             copy.ForEach(p => p.Value = UrlEncodeStrict(p.Value));
-            copy.Sort((x, y) => x.Name.Equals(y.Name) ? x.Value.CompareTo(y.Value) : x.Name.CompareTo(y.Name));
+            copy.Sort((x, y) => string.CompareOrdinal(x.Name, y.Name) != 0 ? string.CompareOrdinal(x.Name, y.Name) : string.CompareOrdinal(x.Value, y.Value));
             return copy;
         }
 


### PR DESCRIPTION
Changed how parameters are ordered for message signing. OAuth states it should be lexicographical byte ordering. I don't know what that means but StackOverflow says to use "string.CompareOrdinal" : http://stackoverflow.com/questions/839429/oauth-lexicographical-byte-value-ordering-in-c  Note this isn't the most efficient sort because string.CompareOrdinal is called more then necessary, but I don't have time to refactor I just want it to work.
