### PR TITLE
Added EnsureCallbacksOnUI flag so that WP7's BeginInvoke logic is optional

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -298,13 +298,16 @@ namespace RestSharp
 		private void ExecuteCallback(HttpResponse response, Action<HttpResponse> callback)
 		{
 #if WINDOWS_PHONE
-			var dispatcher = Deployment.Current.Dispatcher;
-			dispatcher.BeginInvoke(() =>
-			{
-#endif
-			callback(response);
-#if WINDOWS_PHONE
-			});
+            if (EnsureCallbacksOnUI)
+            {
+                var dispatcher = Deployment.Current.Dispatcher;
+                dispatcher.BeginInvoke(() => callback(response));
+            } else
+            {
+                callback(response);
+            }
+#else
+            callback(response);
 #endif
 		}
 

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -100,6 +100,12 @@ namespace RestSharp
 		/// </summary>
 		public bool FollowRedirects { get; set; }
 #endif
+#if WINDOWS_PHONE
+        /// <summary>
+        /// Whether or not to force callbacks to be invoked on the UI thread
+        /// </summary>
+        public bool EnsureCallbacksOnUI { get; set; }
+#endif
 #if FRAMEWORK
 		/// <summary>
 		/// Maximum number of automatic redirects to follow if FollowRedirects is true

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -29,6 +29,9 @@ namespace RestSharp
 #if !SILVERLIGHT
 		bool FollowRedirects { get; set; }
 #endif
+#if WINDOWS_PHONE
+        bool EnsureCallbacksOnUI { get; set; }
+#endif
 #if FRAMEWORK
 		int? MaxRedirects { get; set; }
 #endif

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -212,6 +212,17 @@ namespace RestSharp
 		/// </summary>
 		public bool FollowRedirects { get; set; }
 
+#if WINDOWS_PHONE
+        /// <summary>
+        /// Whether or not to force callbacks to be invoked on the UI thread
+        /// </summary>
+        private bool _ensureCallbacksOnUI = true;
+        public bool EnsureCallbacksOnUI
+        {
+            get { return _ensureCallbacksOnUI; }
+            set { _ensureCallbacksOnUI = value; }
+        }
+#endif
 		/// <summary>
 		/// Maximum number of redirects to follow if FollowRedirects is true
 		/// </summary>
@@ -340,6 +351,9 @@ namespace RestSharp
 
 #if !SILVERLIGHT
 			http.FollowRedirects = FollowRedirects;
+#endif
+#if WINDOWS_PHONE
+		    http.EnsureCallbacksOnUI = EnsureCallbacksOnUI;
 #endif
 #if FRAMEWORK
 			http.MaxRedirects = MaxRedirects;


### PR DESCRIPTION
Hi John,

I added an extra flag for WP7 so that I can have my callbacks process the response off the UI thread without starting another background thread. If the patch needs to be tweaked at all, please let me know.

Thanks!
