### PR TITLE
Fix for deserializing string-like values

### DIFF
--- a/RestSharp/Extensions/MiscExtensions.cs
+++ b/RestSharp/Extensions/MiscExtensions.cs
@@ -78,7 +78,7 @@ namespace RestSharp.Extensions
 		/// <returns></returns>
 		public static string AsString(this JToken token)
 		{
-			return token.ToString();
+			return token.Value<string>();
 		}
 	}
 }


### PR DESCRIPTION
Fix for deserializing string-like values. This removes the surrounding double-quotes around strings that aren't part of the original value.

When deserializing strings from JTokens, jToken.ToString() would result in a value like "/"SomeString/"". Notice the extra surrounding quotes. This will resolve that issue.
