### PR TITLE
Added a test for the nil attributes problem.

### DIFF
--- a/RestSharp.Tests/XmlTests.cs
+++ b/RestSharp.Tests/XmlTests.cs
@@ -180,6 +180,19 @@ namespace RestSharp.Tests
 			Assert.Equal(4, output.images.Count);
 		}
 
+        [Fact]
+        public void Can_Deserialize_Nil_Elements_to_Nullable_Values()
+        {
+            var doc = CreateXmlWithNilValues();
+
+            var xml = new XmlDeserializer();
+            var output = xml.Deserialize<NullableValues>(new RestResponse { Content = doc });
+
+            Assert.Null(output.Id);
+            Assert.Null(output.StartDate);
+            Assert.Null(output.UniqueId);
+        }
+
 		[Fact]
 		public void Can_Deserialize_Empty_Elements_to_Nullable_Values()
 		{
@@ -648,7 +661,8 @@ namespace RestSharp.Tests
 			return doc.ToString();
 		}
 
-		private static string CreateXmlWithNullValues()
+        
+	    private static string CreateXmlWithNullValues()
 		{
 			var doc = new XDocument();
 			var root = new XElement("NullableValues");
@@ -662,6 +676,26 @@ namespace RestSharp.Tests
 
 			return doc.ToString();
 		}
+
+        private static string CreateXmlWithNilValues()
+        {
+            var doc = new XDocument();
+            
+            var root = new XElement("NullableValues");
+            root.Add(new XAttribute(XNamespace.Xmlns + "xsi", "http://www.w3.org/2001/XMLSchema-instance"));
+
+            XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
+            var nil = new XAttribute(xsi + "nil", true);
+
+            root.Add(new XElement("Id", nil),
+                     new XElement("StartDate", nil),
+                     new XElement("UniqueId", nil)
+                );
+
+            doc.Add(root);
+
+            return doc.ToString();
+        }
 
 		private static string CreateXmlWithoutEmptyValues()
 		{


### PR DESCRIPTION
I've added a test for the nill attribute problem described here:
http://groups.google.com/group/restsharp/browse_thread/thread/db8fb0a99a96d516/9b3b22dfe4a4626d

The xml looks like this:

&lt;NullableValues xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;&gt;
  &lt;Id xsi:nil=&quot;true&quot; /&gt;
  &lt;StartDate xsi:nil=&quot;true&quot; /&gt;
  &lt;UniqueId xsi:nil=&quot;true&quot; /&gt;
&lt;/NullableValues&gt;

I've tried to fix it , but i notice also that you remove all namespaces attributes and things like that in the deserializer.

I am not sure if there is a reason to not deserialize this properly, so i do this pull request so you can analize whenever you can.

Thank you very much
