### PR TITLE
Extended JsonDeserializer to handle Json.NET's JsonPropertyAttribute

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -40,12 +40,13 @@ namespace RestSharp.Tests
 
 	        var json = new JsonDeserializer {RootElement = "data"};
 
-	        var output = json.Deserialize<JsonWithAttributesSample>(new RestResponse {Content = doc});
+	        var output = json.Deserialize<List<JsonWithAttributesSample>>(new RestResponse {Content = doc});
 
-            Assert.True(output.GetType() == typeof(JsonWithAttributesSample));
-            Assert.Equal(123456, output.ClientId);
-            Assert.Equal("sampleClient", output.ClientName);
-            Assert.Equal(50.0, output.HourlyRate);
+            Assert.True(output.GetType() == typeof(List<JsonWithAttributesSample>));
+            Assert.Equal(123456, output[0].ClientId);
+            Assert.Equal("sampleClient", output[0].ClientName);
+            Assert.Equal(50.0, output[0].HourlyRate);
+            Assert.Equal(7654, output[0].NestedClass.Id);
 	    }
 
 		[Fact]

--- a/RestSharp.Tests/RestSharp.Tests.csproj
+++ b/RestSharp.Tests/RestSharp.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="JsonTests.cs" />
     <Compile Include="NamespacedXmlTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SampleClasses\NestedClassSample.cs" />
     <Compile Include="SampleClasses\foursq.cs" />
     <Compile Include="SampleClasses\googleweather.cs" />
     <Compile Include="SampleClasses\JsonLists.cs" />

--- a/RestSharp.Tests/SampleClasses/JsonWithAttributesSample.cs
+++ b/RestSharp.Tests/SampleClasses/JsonWithAttributesSample.cs
@@ -18,5 +18,8 @@ namespace RestSharp.Tests.SampleClasses
             NullValueHandling = NullValueHandling.Ignore)]
         public double HourlyRate { get; set; }
 
+        [JsonProperty(PropertyName = "nestedThing")]
+        public NestedClassSample NestedClass { get; set; }
+
     }
 }

--- a/RestSharp.Tests/SampleClasses/NestedClassSample.cs
+++ b/RestSharp.Tests/SampleClasses/NestedClassSample.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace RestSharp.Tests.SampleClasses
+{
+    public class NestedClassSample
+    {
+        [JsonProperty(PropertyName = "identifier")]
+        public int Id { get; set; }
+
+    }
+}

--- a/RestSharp.Tests/SampleData/jsonWithAttributesSample.txt
+++ b/RestSharp.Tests/SampleData/jsonWithAttributesSample.txt
@@ -1,8 +1,14 @@
 ﻿{
 	"related_data_updated_at":"2011-06-01T09:11:13-06:00",
-	"data": {
-		"hourly_rate":50.0,
-		"name":"sampleClient",
-		"id":123456
-	}
+	"data": [
+		{
+			"hourly_rate":50.0,
+			"name":"sampleClient",
+			"id":123456,
+			"nestedThing": {
+				"identifier": 7654
+			}
+		}
+	]
 }
+

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -101,7 +101,8 @@ namespace RestSharp.Deserializers
                     if (0 < attrs.Length)
                     {
                         var attr = (Newtonsoft.Json.JsonPropertyAttribute) attrs[0];
-                        value = json[attr.PropertyName];
+                        actualName = attr.PropertyName;
+                        value = json[actualName];
                     }
                 }
 


### PR DESCRIPTION
Hey John.  Json.NET includes the ability to map JSON properties to .NET properties with different names via an attribute called JsonPropertyAttribute.  I wrote a test and extended JsonDeserializer.

Let me know if you need more info
