### PR TITLE
Fixing Amazon S3 upload problem

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -163,22 +163,23 @@ namespace RestSharp
 		private void WriteMultipartFormDataAsync(Stream requestStream)
 		{
 			var encoding = Encoding.UTF8;
-			foreach (var file in Files)
-			{
-				// Add just the first part of this param, since we will write the file data directly to the Stream
-				var header = GetMultipartFileHeader(file);
-				requestStream.Write(encoding.GetBytes(header), 0, header.Length);
-
-				// Write the file data directly to the Stream, rather than serializing it to a string.
-				file.Writer(requestStream);
-				var lineEnding = Environment.NewLine;
-				requestStream.Write(encoding.GetBytes(lineEnding), 0, lineEnding.Length);
-			}
-
+			
 			foreach (var param in Parameters)
 			{
 				var postData = GetMultipartFormData(param);
 				requestStream.Write(encoding.GetBytes(postData), 0, postData.Length);
+			}
+
+			foreach (var file in Files)
+			{
+			    // Add just the first part of this param, since we will write the file data directly to the Stream
+			    var header = GetMultipartFileHeader(file);
+			    requestStream.Write(encoding.GetBytes(header), 0, header.Length);
+
+			    // Write the file data directly to the Stream, rather than serializing it to a string.
+			    file.Writer(requestStream);
+			    var lineEnding = Environment.NewLine;
+			    requestStream.Write(encoding.GetBytes(lineEnding), 0, lineEnding.Length);
 			}
 
 			var footer = GetMultipartFooter();

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -163,24 +163,24 @@ namespace RestSharp
 			var encoding = Encoding.UTF8;
 			using (Stream formDataStream = webRequest.GetRequestStream())
 			{
-				foreach (var file in Files)
-				{
-					// Add just the first part of this param, since we will write the file data directly to the Stream
-					string header = GetMultipartFileHeader (file);
-					var headerBytes = encoding.GetBytes(header);
-
-					formDataStream.Write(headerBytes, 0, headerBytes.Length);
-					// Write the file data directly to the Stream, rather than serializing it to a string.
-					file.Writer(formDataStream);
-					string lineEnding = Environment.NewLine;
-					formDataStream.Write(encoding.GetBytes(lineEnding), 0, lineEnding.Length);
-				}
-
 				foreach (var param in Parameters)
 				{
 					var postData = GetMultipartFormData (param);
 					var postDataBytes = encoding.GetBytes(postData);
 					formDataStream.Write(postDataBytes, 0, postDataBytes.Length);
+				}
+
+				foreach (var file in Files)
+				{
+				    // Add just the first part of this param, since we will write the file data directly to the Stream
+				    string header = GetMultipartFileHeader(file);
+				    var headerBytes = encoding.GetBytes(header);
+
+				    formDataStream.Write(headerBytes, 0, headerBytes.Length);
+				    // Write the file data directly to the Stream, rather than serializing it to a string.
+				    file.Writer(formDataStream);
+				    string lineEnding = Environment.NewLine;
+				    formDataStream.Write(encoding.GetBytes(lineEnding), 0, lineEnding.Length);
 				}
 
 				string footer = GetMultipartFooter();


### PR DESCRIPTION
Hi,

I've been trying to use RestSharp to upload files to Amazon S3, but the way the requests are being formatted causes the POST to be rejected.  Basically, the additional parameters that I need to pass with things like the upload policy, signature, file location, etc. are being placed after the file data.  Amazon expects to see these parameters before the file data when it processes the POST message, so it assumes they weren't sent and stops prematurely.

This commit changes the order of the parameters and file data and fixes the Amazon upload problem.
