### PR TITLE
use CRFL for line endings to conform to RFC2046 (MIME)

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -148,7 +148,7 @@ namespace RestSharp
 			{
 				length += GetMultipartFileHeader(file).Length;
 				length += file.ContentLength;
-				length += Environment.NewLine.Length;
+				length += "\r\n".Length;
 			}
 
 			foreach (var param in Parameters)
@@ -171,7 +171,7 @@ namespace RestSharp
 
 				// Write the file data directly to the Stream, rather than serializing it to a string.
 				file.Writer(requestStream);
-				var lineEnding = Environment.NewLine;
+				var lineEnding = "\r\n";
 				requestStream.Write(encoding.GetBytes(lineEnding), 0, lineEnding.Length);
 			}
 

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -172,7 +172,7 @@ namespace RestSharp
 					formDataStream.Write(headerBytes, 0, headerBytes.Length);
 					// Write the file data directly to the Stream, rather than serializing it to a string.
 					file.Writer(formDataStream);
-					string lineEnding = Environment.NewLine;
+					const string lineEnding = "\r\n";
 					formDataStream.Write(encoding.GetBytes(lineEnding), 0, lineEnding.Length);
 				}
 

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -173,19 +173,19 @@ namespace RestSharp
 		
 		private string GetMultipartFileHeader (HttpFile file)
 		{
-			return string.Format ("--{0}{4}Content-Disposition: form-data; name=\"{1}\"; filename=\"{2}\"{4}Content-Type: {3}{4}{4}", 
-				FormBoundary, file.Name, file.FileName, file.ContentType ?? "application/octet-stream", Environment.NewLine);
+			return string.Format ("--{0}{4}Content-Disposition: form-data; name=\"{1}\"; filename=\"{2}\"{4}Content-Type: {3}{4}{4}",
+				FormBoundary, file.Name, file.FileName, file.ContentType ?? "application/octet-stream", "\r\n");
 		}
 		
 		private string GetMultipartFormData (HttpParameter param)
 		{
 			return string.Format ("--{0}{3}Content-Disposition: form-data; name=\"{1}\"{3}{3}{2}{3}",
-				FormBoundary, param.Name, param.Value, Environment.NewLine);
+				FormBoundary, param.Name, param.Value, "\r\n");
 		}
 		
 		private string GetMultipartFooter ()
 		{
-			return string.Format ("--{0}--{1}", FormBoundary, Environment.NewLine);
+			return string.Format ("--{0}--{1}", FormBoundary, "\r\n");
 		}
 		
 		private readonly IDictionary<string, Action<HttpWebRequest, string>> _restrictedHeaderActions;


### PR DESCRIPTION
From the RFC:

   4.1.1.  Representation of Line Breaks

   The canonical form of any MIME "text" subtype MUST always represent a
   line break as a CRLF sequence.  Similarly, any occurrence of CRLF in
   MIME "text" MUST represent a line break.  Use of CR and LF outside of
   line break sequences is also forbidden.

   This rule applies regardless of format or character set or sets
   involved.

Also, from the W3C:

   http://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2

   As with all MIME transmissions, "CR LF" (i.e., `%0D%0A') is used to
   separate lines of data.
