### PR TITLE
Encode parameter names when creating the base signing string

### DIFF
--- a/RestSharp.IntegrationTests/oAuth1Tests.cs
+++ b/RestSharp.IntegrationTests/oAuth1Tests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
+using RestSharp.Authenticators.OAuth;
 using Xunit;
 using System.Net;
 using RestSharp.Contrib;
@@ -160,5 +162,14 @@ namespace RestSharp.IntegrationTests
 			Assert.NotNull(queueResponse.Data);
 			Assert.Equal(2, queueResponse.Data.Items.Count);
 		}
+
+        [Fact]
+        public void Properly_Encodes_Parameter_Names()
+        {
+            var postData = new WebParameterCollection { { "name[first]", "Chuck" }, { "name[last]", "Testa" }};
+            var sortedParams = OAuthTools.SortParametersExcludingSignature(postData);
+
+            Assert.Equal("name%5Bfirst%5D", sortedParams[0].Name);
+        }
 	}
 }

--- a/RestSharp/Authenticators/OAuth/OAuthTools.cs
+++ b/RestSharp/Authenticators/OAuth/OAuthTools.cs
@@ -141,7 +141,7 @@ namespace RestSharp.Authenticators.OAuth
             var exclusions = copy.Where(n => n.Name.EqualsIgnoreCase("oauth_signature"));
 
             copy.RemoveAll(exclusions);
-            copy.ForEach(p => p.Value = UrlEncodeStrict(p.Value));
+            copy.ForEach(p => { p.Name = UrlEncodeStrict(p.Name); p.Value = UrlEncodeStrict(p.Value); });
             copy.Sort((x, y) => string.CompareOrdinal(x.Name, y.Name) != 0 ? string.CompareOrdinal(x.Name, y.Name) : string.CompareOrdinal(x.Value, y.Value));
             return copy;
         }

--- a/RestSharp/Authenticators/OAuth/WebPair.cs
+++ b/RestSharp/Authenticators/OAuth/WebPair.cs
@@ -9,6 +9,6 @@
         }
 
         public string Value { get; set; }
-        public string Name { get; private set; }
+        public string Name { get; set; }
     }
 }

--- a/RestSharp/Properties/AssemblyInfo.cs
+++ b/RestSharp/Properties/AssemblyInfo.cs
@@ -14,3 +14,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d2b12a34-b748-47f9-8ad6-f84da992c64b")]
+
+[assembly: InternalsVisibleTo("RestSharp.IntegrationTests")]


### PR DESCRIPTION
Per [OAuth spec 3.4.1.3.2](http://tools.ietf.org/html/rfc5849#section-3.4.1.3.2) both the parameter names and values should be encoded as part of parameter normalization.

We ran into oauth issues when trying to access an API that used square brackets in the parameter names. Currently only the parameter value was being encoded. Also encoding the parameter name fixes the issues accessing the API.

Also added a test, but had to make the internals visible to the test assembly in order to confirm the proper encoding.
