### PR TITLE
Fix empty list deserialization

### DIFF
--- a/RestSharp.Tests/SampleClasses/ListSamples.cs
+++ b/RestSharp.Tests/SampleClasses/ListSamples.cs
@@ -18,6 +18,12 @@ namespace RestSharp.Tests.SampleClasses
 		public List<Image> Images { get; set; }
 	}
 
+	public class EmptyListSample
+	{
+		public List<image> images { get; set; }
+		public List<Image> Images { get; set; }
+	}
+
 	public class Image
 	{
 		public string Src { get; set; }

--- a/RestSharp.Tests/XmlTests.cs
+++ b/RestSharp.Tests/XmlTests.cs
@@ -181,6 +181,34 @@ namespace RestSharp.Tests
 		}
 
 		[Fact]
+		public void Can_Deserialize_Nested_List_Without_Elements_To_Empty_List()
+		{
+			var doc = CreateXmlWithEmptyNestedList();
+
+			var xml = new XmlDeserializer();
+			var output = xml.Deserialize<EmptyListSample>(new RestResponse { Content = doc });
+
+			Assert.NotNull(output.images);
+			Assert.NotNull(output.Images);
+			Assert.Empty(output.images);
+			Assert.Empty(output.Images);
+		}
+
+		[Fact]
+		public void Can_Deserialize_Inline_List_Without_Elements_To_Empty_List()
+		{
+			var doc = CreateXmlWithEmptyInlineList();
+
+			var xml = new XmlDeserializer();
+			var output = xml.Deserialize<EmptyListSample>(new RestResponse { Content = doc });
+
+			Assert.NotNull(output.images);
+			Assert.NotNull(output.Images);
+			Assert.Empty(output.images);
+			Assert.Empty(output.Images);
+		}
+
+		[Fact]
 		public void Can_Deserialize_Empty_Elements_to_Nullable_Values()
 		{
 			var doc = CreateXmlWithNullValues();
@@ -698,6 +726,28 @@ namespace RestSharp.Tests
 					 new XElement("StartDate", new DateTime(2010, 2, 21, 9, 35, 00).ToString()),
 					 new XElement("UniqueId", new Guid(GuidString))
 					 );
+
+			doc.Add(root);
+
+			return doc.ToString();
+		}
+
+		private static string CreateXmlWithEmptyNestedList()
+		{
+			var doc = new XDocument();
+			var root = new XElement("EmptyListSample");
+
+			root.Add(new XElement("Images"));
+
+			doc.Add(root);
+
+			return doc.ToString();
+		}
+
+		private static string CreateXmlWithEmptyInlineList()
+		{
+			var doc = new XDocument();
+			var root = new XElement("EmptyListSample");
 
 			doc.Add(root);
 

--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -107,17 +107,16 @@ namespace RestSharp.Deserializers
 					if (type.IsGenericType)
 					{
 						var genericType = type.GetGenericArguments()[0];
-
 						var first = GetElementByName(root, genericType.Name);
+						var list = (IList)Activator.CreateInstance(type);
+
 						if (first != null)
 						{
 							var elements = root.Elements(first.Name);
-
-							var list = (IList)Activator.CreateInstance(type);
 							PopulateListFromElements(genericType, elements, list);
-							prop.SetValue(x, list, null);
-
 						}
+
+						prop.SetValue(x, list, null);
 					}
 					continue;
 				}
@@ -181,10 +180,13 @@ namespace RestSharp.Deserializers
 					var list = (IList)Activator.CreateInstance(type);
 
 					var container = GetElementByName(root, prop.Name.AsNamespaced(Namespace));
-					var first = container.Elements().FirstOrDefault();
 
-					var elements = container.Elements(first.Name);
-					PopulateListFromElements(t, elements, list);
+					if (container.HasElements)
+					{
+						var first = container.Elements().FirstOrDefault();
+						var elements = container.Elements(first.Name);
+						PopulateListFromElements(t, elements, list);
+					}
 
 					prop.SetValue(x, list, null);
 				}


### PR DESCRIPTION
I've faced this bug while parsing responses from a RESTful service. It's sent me a response like this:

``` xml
<payment_method>
    ...
    <messages type="array" />
    ...
</payment_method>
```

And I've had a POCO object for this response:

``` cs
public class PaymentMethod
{
    // ...
    public List<Message> Messages { get; set; }
    // ...
}
```

And when I try to use `Deserialize` method it throws a NullReferenceException at [186 line](https://github.com/restsharp/RestSharp/blob/master/RestSharp/Deserializers/XmlDeserializer.cs#L186) in XmlDeserializer.cs:

``` cs
var first = container.Elements().FirstOrDefault();

var elements = container.Elements(first.Name);
```

It seems like `first` is null and have no `Name` property. So I've rewrote this piece of code to work correctly with empty lists.

Also I've rewrote some other pieces of code so after deserializing empty list an appropriate property will be initialized as empty list instead of null value.

And of course I've wrote unit tests for all of that.  
