### PR TITLE
Empty result content due to RestSharp connection error.

### DIFF
--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -40,7 +40,7 @@ namespace RestSharp.Deserializers
 
 		public T Deserialize<T>(RestResponse response) where T : new()
 		{
-			if (response.Content == null)
+			if (string.IsNullOrEmpty( response.Content ))
 				return default(T);
 
 			var doc = XDocument.Parse(response.Content);


### PR DESCRIPTION
Changed xml deserializer to check IsEmptyOrNull instead of just null on the response content. This
was causing an issue deserializing an error string from RestSharp itself
when it could not connect to the server.
