### PR TITLE
XML Deserialization of nullable types with attributes

### DIFF
--- a/RestSharp.Tests/XmlTests.cs
+++ b/RestSharp.Tests/XmlTests.cs
@@ -508,6 +508,32 @@ namespace RestSharp.Tests
 				Assert.True(output.Value);
 		}
 
+        [Fact]
+        public void Can_Deserialize_Empty_Elements_With_Attributes_to_Nullable_Values()
+        {
+            var doc = CreateXmlWithAttributesAndNullValues();
+
+            var xml = new XmlDeserializer();
+            var output = xml.Deserialize<NullableValues>(new RestResponse { Content = doc });
+
+            Assert.Null(output.Id);
+            Assert.Null(output.StartDate);
+            Assert.Null(output.UniqueId);
+        }
+
+        [Fact]
+        public void Can_Deserialize_Mixture_Of_Empty_Elements_With_Attributes_And_Populated_Elements()
+        {
+            var doc = CreateXmlWithAttributesAndNullValuesAndPopulatedValues();
+
+            var xml = new XmlDeserializer();
+            var output = xml.Deserialize<NullableValues>(new RestResponse { Content = doc });
+
+            Assert.Null(output.Id);
+            Assert.Null(output.StartDate);
+            Assert.Equal(new Guid(GuidString), output.UniqueId);
+        }
+
 		private static string CreateUnderscoresXml()
 		{
 			var doc = new XDocument();
@@ -753,5 +779,39 @@ namespace RestSharp.Tests
 
 			return doc.ToString();
 		}
+
+        private static string CreateXmlWithAttributesAndNullValues()
+        {
+            var doc = new XDocument();
+            var root = new XElement("NullableValues");
+
+            var idElement = new XElement("Id", null);
+            idElement.SetAttributeValue("SomeAttribute", "SomeAttribute_Value");
+            root.Add(idElement,
+                     new XElement("StartDate", null),
+                     new XElement("UniqueId", null)
+                );
+
+            doc.Add(root);
+
+            return doc.ToString();
+        }
+
+        private static string CreateXmlWithAttributesAndNullValuesAndPopulatedValues()
+        {
+            var doc = new XDocument();
+            var root = new XElement("NullableValues");
+
+            var idElement = new XElement("Id", null);
+            idElement.SetAttributeValue("SomeAttribute", "SomeAttribute_Value");
+            root.Add(idElement,
+                     new XElement("StartDate", null),
+                     new XElement("UniqueId", new Guid(GuidString))
+                );
+
+            doc.Add(root);
+
+            return doc.ToString();
+        }
 	}
 }

--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -124,7 +124,13 @@ namespace RestSharp.Deserializers
 				// check for nullable and extract underlying type
 				if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
 				{
-					type = type.GetGenericArguments()[0];
+                    // if the value is empty, set the property to null...
+                    if (value == null || String.IsNullOrEmpty(value.ToString()))
+                    {
+                        prop.SetValue(x, null, null);
+                        continue;
+                    }
+                    type = type.GetGenericArguments()[0];
 				}
 
 				if (type == typeof(bool))


### PR DESCRIPTION
Hi there,

When trying to deserialize a nullable type, if the element has any attributes, the value is set to "", which is problematic.

here's a test:

```
[Fact]
public void Can_Deserialize_Empty_Elements_With_Attributes_to_Nullable_Values()
{
    var doc = CreateXmlWithAttributesAndNullValues();

    var xml = new XmlDeserializer();
    var output = xml.Deserialize<NullableValues>(new RestResponse { Content = doc });

    Assert.Null(output.Id);
    Assert.Null(output.StartDate);
    Assert.Null(output.UniqueId);
}

private static string CreateXmlWithAttributesAndNullValuesAndPopulatedValues()
{
    var doc = new XDocument();
    var root = new XElement("NullableValues");

    var idElement = new XElement("Id", null);
    idElement.SetAttributeValue("SomeAttribute", "SomeAttribute_Value");
    root.Add(idElement,
             new XElement("StartDate", null),
             new XElement("UniqueId", new Guid(GuidString))
        );

    doc.Add(root);

    return doc.ToString();
}
```

I have attached a pull request, with a further test and a fix.

Please give me a shout if you would like me to change anything, or if there's any problem

Thanks guys!
