### PR TITLE
Update the Json.NET references in the Windows Phone projects

### DIFF
--- a/RestSharp.WindowsPhone.Mango/RestSharp.WindowsPhone.Mango.csproj
+++ b/RestSharp.WindowsPhone.Mango/RestSharp.WindowsPhone.Mango.csproj
@@ -43,8 +43,8 @@
     <DocumentationFile>Bin\Release\RestSharp.WindowsPhone.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json.WindowsPhone">
-      <HintPath>..\packages\Newtonsoft.Json.4.0.2\lib\sl3-wp\Newtonsoft.Json.WindowsPhone.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.4.0.3\lib\sl4\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="system" />

--- a/RestSharp.WindowsPhone/RestSharp.WindowsPhone.csproj
+++ b/RestSharp.WindowsPhone/RestSharp.WindowsPhone.csproj
@@ -44,8 +44,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="Newtonsoft.Json.WindowsPhone, Version=4.0.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.4.0.2\lib\sl3-wp\Newtonsoft.Json.WindowsPhone.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.4.0.3\lib\sl3-wp\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="system" />


### PR DESCRIPTION
Update the Json.NET references in the Windows Phone projects, fixing the problem regarding the Json.NET assemblies name changing (thus RestSharp was complaining about a missing Json.NET assembly file).
