### PR TITLE
Add new AddCookie shortcut to IRestRequest/RestRequest

### DIFF
--- a/RestSharp/IRestRequest.cs
+++ b/RestSharp/IRestRequest.cs
@@ -115,7 +115,7 @@ namespace RestSharp
 		/// <param name="name">The parameter name to use in the request</param>
 		/// <param name="path">Full path to file to upload</param>
 		/// <returns>This request</returns>
-		RestRequest AddFile(string name, string path);
+		IRestRequest AddFile (string name, string path);
 
 		/// <summary>
 		/// Adds the bytes to the Files collection with the specified file name
@@ -124,7 +124,7 @@ namespace RestSharp
 		/// <param name="bytes">The file data</param>
 		/// <param name="fileName">The file name to use for the uploaded file</param>
 		/// <returns>This request</returns>
-		RestRequest AddFile(string name, byte[] bytes, string fileName);
+		IRestRequest AddFile (string name, byte[] bytes, string fileName);
 
 		/// <summary>
 		/// Adds the bytes to the Files collection with the specified file name and content type
@@ -134,7 +134,7 @@ namespace RestSharp
 		/// <param name="fileName">The file name to use for the uploaded file</param>
 		/// <param name="contentType">The MIME type of the file to upload</param>
 		/// <returns>This request</returns>
-		RestRequest AddFile(string name, byte[] bytes, string fileName, string contentType);
+		IRestRequest AddFile (string name, byte[] bytes, string fileName, string contentType);
 #endif
 
 		/// <summary>
@@ -143,14 +143,14 @@ namespace RestSharp
 		/// <param name="obj">The object to serialize</param>
 		/// <param name="xmlNamespace">The XML namespace to use when serializing</param>
 		/// <returns>This request</returns>
-		RestRequest AddBody(object obj, string xmlNamespace);
+		IRestRequest AddBody (object obj, string xmlNamespace);
 
 		/// <summary>
 		/// Serializes obj to data format specified by RequestFormat and adds it to the request body.
 		/// </summary>
 		/// <param name="obj">The object to serialize</param>
 		/// <returns>This request</returns>
-		RestRequest AddBody(object obj);
+		IRestRequest AddBody (object obj);
 
 		/// <summary>
 		/// Calls AddParameter() for all public, readable properties specified in the white list
@@ -161,21 +161,21 @@ namespace RestSharp
 		/// <param name="obj">The object with properties to add as parameters</param>
 		/// <param name="whitelist">The names of the properties to include</param>
 		/// <returns>This request</returns>
-		RestRequest AddObject(object obj, params string[] whitelist);
+		IRestRequest AddObject (object obj, params string[] whitelist);
 
 		/// <summary>
 		/// Calls AddParameter() for all public, readable properties of obj
 		/// </summary>
 		/// <param name="obj">The object with properties to add as parameters</param>
 		/// <returns>This request</returns>
-		RestRequest AddObject(object obj);
+		IRestRequest AddObject (object obj);
 
 		/// <summary>
 		/// Add the parameter to the request
 		/// </summary>
 		/// <param name="p">Parameter to add</param>
 		/// <returns></returns>
-		RestRequest AddParameter(Parameter p);
+		IRestRequest AddParameter (Parameter p);
 
 		/// <summary>
 		/// Adds a HTTP parameter to the request (QueryString for GET, DELETE, OPTIONS and HEAD; Encoded form for POST and PUT)
@@ -183,7 +183,7 @@ namespace RestSharp
 		/// <param name="name">Name of the parameter</param>
 		/// <param name="value">Value of the parameter</param>
 		/// <returns>This request</returns>
-		RestRequest AddParameter(string name, object value);
+		IRestRequest AddParameter (string name, object value);
 
 		/// <summary>
 		/// Adds a parameter to the request. There are five types of parameters:
@@ -197,7 +197,7 @@ namespace RestSharp
 		/// <param name="value">Value of the parameter</param>
 		/// <param name="type">The type of parameter to add</param>
 		/// <returns>This request</returns>
-		RestRequest AddParameter(string name, object value, ParameterType type);
+		IRestRequest AddParameter (string name, object value, ParameterType type);
 
 		/// <summary>
 		/// Shortcut to AddParameter(name, value, HttpHeader) overload
@@ -205,7 +205,7 @@ namespace RestSharp
 		/// <param name="name">Name of the header to add</param>
 		/// <param name="value">Value of the header to add</param>
 		/// <returns></returns>
-		RestRequest AddHeader(string name, string value);
+		IRestRequest AddHeader (string name, string value);
 
 		/// <summary>
 		/// Shortcut to AddParameter(name, value, Cookie) overload
@@ -213,7 +213,7 @@ namespace RestSharp
 		/// <param name="name">Name of the cookie to add</param>
 		/// <param name="value">Value of the cookie to add</param>
 		/// <returns></returns>
-		RestRequest AddCookie (string name, string value);
+		IRestRequest AddCookie (string name, string value);
 
 		/// <summary>
 		/// Shortcut to AddParameter(name, value, UrlSegment) overload
@@ -221,9 +221,9 @@ namespace RestSharp
 		/// <param name="name">Name of the segment to add</param>
 		/// <param name="value">Value of the segment to add</param>
 		/// <returns></returns>
-		RestRequest AddUrlSegment(string name, string value);
+		IRestRequest AddUrlSegment(string name, string value);
 
-		Action<RestResponse> OnBeforeDeserialization { get; set; }
+		Action<IRestResponse> OnBeforeDeserialization { get; set; }
 		void IncreaseNumAttempts();
 	}
 }

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -114,7 +114,7 @@ namespace RestSharp
 			/// <param name="name">The parameter name to use in the request</param>
 			/// <param name="path">Full path to file to upload</param>
 			/// <returns>This request</returns>
-		public RestRequest AddFile(string name, string path)
+		public IRestRequest AddFile (string name, string path)
 		{
 			return AddFile(new FileParameter
 			{
@@ -137,7 +137,7 @@ namespace RestSharp
 		/// <param name="bytes">The file data</param>
 		/// <param name="fileName">The file name to use for the uploaded file</param>
 		/// <returns>This request</returns>
-		public RestRequest AddFile(string name, byte[] bytes, string fileName)
+		public IRestRequest AddFile (string name, byte[] bytes, string fileName)
 		{
 			return AddFile(FileParameter.Create(name, bytes, fileName));
 		}
@@ -150,7 +150,7 @@ namespace RestSharp
 		/// <param name="fileName">The file name to use for the uploaded file</param>
 		/// <param name="contentType">The MIME type of the file to upload</param>
 		/// <returns>This request</returns>
-		public RestRequest AddFile(string name, byte[] bytes, string fileName, string contentType)
+		public IRestRequest AddFile (string name, byte[] bytes, string fileName, string contentType)
 		{
 			return AddFile(FileParameter.Create(name, bytes, fileName, contentType));
 		}
@@ -162,7 +162,7 @@ namespace RestSharp
 		/// <param name="writer">A function that writes directly to the stream.  Should NOT close the stream.</param>
 		/// <param name="fileName">The file name to use for the uploaded file</param>
 		/// <returns>This request</returns>
-		public RestRequest AddFile(string name, Action<Stream> writer, string fileName)
+		public IRestRequest AddFile (string name, Action<Stream> writer, string fileName)
 		{
 			return AddFile(name, writer, fileName, null);
 		}
@@ -175,12 +175,12 @@ namespace RestSharp
 		/// <param name="fileName">The file name to use for the uploaded file</param>
 		/// <param name="contentType">The MIME type of the file to upload</param>
 		/// <returns>This request</returns>
-		public RestRequest AddFile(string name, Action<Stream> writer, string fileName, string contentType)
+		public IRestRequest AddFile (string name, Action<Stream> writer, string fileName, string contentType)
 		{
 			return AddFile(new FileParameter { Name = name, Writer = writer, FileName = fileName, ContentType = contentType });
 		}
 
-		private RestRequest AddFile(FileParameter file)
+		private IRestRequest AddFile (FileParameter file)
 		{
 			Files.Add(file);
 			return this;
@@ -192,7 +192,7 @@ namespace RestSharp
 		/// <param name="obj">The object to serialize</param>
 		/// <param name="xmlNamespace">The XML namespace to use when serializing</param>
 		/// <returns>This request</returns>
-		public RestRequest AddBody(object obj, string xmlNamespace)
+		public IRestRequest AddBody (object obj, string xmlNamespace)
 		{
 			string serialized;
 			string contentType;
@@ -227,7 +227,7 @@ namespace RestSharp
 		/// </summary>
 		/// <param name="obj">The object to serialize</param>
 		/// <returns>This request</returns>
-		public RestRequest AddBody(object obj)
+		public IRestRequest AddBody (object obj)
 		{
 			return AddBody(obj, "");
 		}
@@ -241,7 +241,7 @@ namespace RestSharp
 		/// <param name="obj">The object with properties to add as parameters</param>
 		/// <param name="whitelist">The names of the properties to include</param>
 		/// <returns>This request</returns>
-		public RestRequest AddObject(object obj, params string[] whitelist)
+		public IRestRequest AddObject (object obj, params string[] whitelist)
 		{
 			// automatically create parameters from object props
 			var type = obj.GetType();
@@ -276,7 +276,7 @@ namespace RestSharp
 		/// </summary>
 		/// <param name="obj">The object with properties to add as parameters</param>
 		/// <returns>This request</returns>
-		public RestRequest AddObject(object obj)
+		public IRestRequest AddObject (object obj)
 		{
 			AddObject(obj, new string[] { });
 			return this;
@@ -287,7 +287,7 @@ namespace RestSharp
 		/// </summary>
 		/// <param name="p">Parameter to add</param>
 		/// <returns></returns>
-		public RestRequest AddParameter(Parameter p)
+		public IRestRequest AddParameter (Parameter p)
 		{
 			Parameters.Add(p);
 			return this;
@@ -299,7 +299,7 @@ namespace RestSharp
 		/// <param name="name">Name of the parameter</param>
 		/// <param name="value">Value of the parameter</param>
 		/// <returns>This request</returns>
-		public RestRequest AddParameter(string name, object value)
+		public IRestRequest AddParameter (string name, object value)
 		{
 			return AddParameter(new Parameter { Name = name, Value = value, Type = ParameterType.GetOrPost });
 		}
@@ -315,7 +315,7 @@ namespace RestSharp
 		/// <param name="value">Value of the parameter</param>
 		/// <param name="type">The type of parameter to add</param>
 		/// <returns>This request</returns>
-		public RestRequest AddParameter(string name, object value, ParameterType type)
+		public IRestRequest AddParameter (string name, object value, ParameterType type)
 		{
 			return AddParameter(new Parameter { Name = name, Value = value, Type = type });
 		}
@@ -326,7 +326,7 @@ namespace RestSharp
 		/// <param name="name">Name of the header to add</param>
 		/// <param name="value">Value of the header to add</param>
 		/// <returns></returns>
-		public RestRequest AddHeader(string name, string value)
+		public IRestRequest AddHeader (string name, string value)
 		{
 			return AddParameter(name, value, ParameterType.HttpHeader);
 		}
@@ -337,7 +337,7 @@ namespace RestSharp
 		/// <param name="name">Name of the cookie to add</param>
 		/// <param name="value">Value of the cookie to add</param>
 		/// <returns></returns>
-		public RestRequest AddCookie (string name, string value)
+		public IRestRequest AddCookie (string name, string value)
 		{
 			return AddParameter(name, value, ParameterType.Cookie);
 		}
@@ -348,7 +348,7 @@ namespace RestSharp
 		/// <param name="name">Name of the segment to add</param>
 		/// <param name="value">Value of the segment to add</param>
 		/// <returns></returns>
-		public RestRequest AddUrlSegment(string name, string value)
+		public IRestRequest AddUrlSegment (string name, string value)
 		{
 			return AddParameter(name, value, ParameterType.UrlSegment);
 		}
@@ -415,7 +415,7 @@ namespace RestSharp
 		/// <summary>
 		/// A function to run prior to deserializing starting (e.g. change settings if error encountered)
 		/// </summary>
-		public Action<RestResponse> OnBeforeDeserialization { get; set; }
+		public Action<IRestResponse> OnBeforeDeserialization { get; set; }
 
 		/// <summary>
 		/// Used by the default deserializers to explicitly set which date format string to use when parsing dates.


### PR DESCRIPTION
IRestRequest and RestRequest currently have shortcuts for the general AddParameter method for AddUrlSegment, AddHeader, etc. but don't have one for AddCookie. This small patch adds that shortcut.
