### PR TITLE
Add support for the PATCH http method/verb.

### DIFF
--- a/RestSharp/Enum.cs
+++ b/RestSharp/Enum.cs
@@ -47,7 +47,8 @@ namespace RestSharp
 		PUT,
 		DELETE,
 		HEAD,
-		OPTIONS
+		OPTIONS,
+		PATCH
 	}
 
 	/// <summary>

--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -72,6 +72,11 @@ namespace RestSharp
 			return PutPostInternalAsync("PUT", action);
 		}
 
+		public HttpWebRequest PatchAsync(Action<HttpResponse> action)
+		{
+			return PutPostInternalAsync("PATCH", action);
+		}
+
 		private HttpWebRequest GetStyleMethodInternalAsync(string method, Action<HttpResponse> callback)
 		{
 			HttpWebRequest webRequest = null;

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -79,6 +79,14 @@ namespace RestSharp
 			return GetStyleMethodInternal("DELETE");
 		}
 
+		/// <summary>
+		/// Execute a PATCH request
+		/// </summary>
+		public HttpResponse Patch()
+		{
+			return PostPutInternal("PATCH");
+		}
+
 		private HttpResponse GetStyleMethodInternal(string method)
 		{
 			var webRequest = ConfigureWebRequest(method, Url);

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -50,6 +50,7 @@ namespace RestSharp
 		HttpWebRequest OptionsAsync(Action<HttpResponse> action);
 		HttpWebRequest PostAsync(Action<HttpResponse> action);
 		HttpWebRequest PutAsync(Action<HttpResponse> action);
+		HttpWebRequest PatchAsync(Action<HttpResponse> action);
 
 #if FRAMEWORK
 		HttpResponse Delete();
@@ -58,6 +59,7 @@ namespace RestSharp
 		HttpResponse Options();
 		HttpResponse Post();
 		HttpResponse Put();
+		HttpResponse Patch();
 
 		IWebProxy Proxy { get; set; }
 #endif

--- a/RestSharp/RestClient.Async.cs
+++ b/RestSharp/RestClient.Async.cs
@@ -73,6 +73,9 @@ namespace RestSharp
 				case Method.OPTIONS:
 					webRequest = http.OptionsAsync(r => ProcessResponse(r, asyncHandle, callback));
 					break;
+				case Method.PATCH:
+					webRequest = http.PatchAsync(r => ProcessResponse(r, asyncHandle, callback));
+					break;
 			}
 			
 			asyncHandle.WebRequest = webRequest;

--- a/RestSharp/RestClient.Sync.cs
+++ b/RestSharp/RestClient.Sync.cs
@@ -99,6 +99,9 @@ namespace RestSharp
 				case Method.OPTIONS:
 					httpResponse = http.Options();
 					break;
+				case Method.PATCH:
+					httpResponse = http.Patch();
+					break;
 			}
 
 			var restResponse = ConvertToRestResponse(httpResponse);

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -294,7 +294,7 @@ namespace RestSharp
 			if(!string.IsNullOrEmpty(BaseUrl))
 				assembled = string.Format("{0}/{1}", BaseUrl, assembled);
 
-			if (request.Method != Method.POST && request.Method != Method.PUT)
+			if (request.Method != Method.POST && request.Method != Method.PUT && request.Method != Method.PATCH)
 			{
 				// build and attach querystring if this is a get-style request
 				if (request.Parameters.Any(p => p.Type == ParameterType.GetOrPost))


### PR DESCRIPTION
Subject pretty much says it all.

HTTP PATCH: http://tools.ietf.org/html/rfc5789

Verified manually against a small Sinatra service, RestSharp behaved just as well as curl did performing the same PATCH request.

There didn't seem to be a clear cut spot in the integration tests to add tests for this so, I didn't create any tests for this change. If a set of "MethodTests" is something you'd like to see, I could try to add some tests for the different methods. Not sure how much additional value such tests would add.
