### PR TITLE
Add support for fuzzy matching of enum values.

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -195,6 +195,7 @@ namespace RestSharp.Tests
 			Assert.Equal(new Guid(GuidString), p.Guid);
 
 			Assert.Equal(Order.Third, p.Order);
+			Assert.Equal(Disposition.SoSo, p.Disposition);
 
 			Assert.NotNull(p.Friends);
 			Assert.Equal(10, p.Friends.Count);
@@ -523,6 +524,7 @@ namespace RestSharp.Tests
 			doc["Url"] = "http://example.com";
 			doc["UrlPath"] = "/foo/bar";
 			doc["Order"] = "third";
+			doc["Disposition"] = "so_so";
 
 			doc["Guid"] = new Guid(GuidString).ToString();
 			doc["EmptyGuid"] = "";

--- a/RestSharp.Tests/SampleClasses/misc.cs
+++ b/RestSharp.Tests/SampleClasses/misc.cs
@@ -47,6 +47,8 @@ namespace RestSharp.Tests
 
 		public Order Order { get; set; }
 
+		public Disposition Disposition { get; set; }
+
 	}
 
 	public class PersonForJson
@@ -74,12 +76,20 @@ namespace RestSharp.Tests
 
 		public Order Order { get; set; }
 
+		public Disposition Disposition { get; set; }
 	}
 
 	public enum Order { 
 		First,
 		Second,
 		Third
+	}
+
+	public enum Disposition
+	{
+		Friendly,
+		SoSo,
+		SteerVeryClear
 	}
 
 	public class Friend

--- a/RestSharp.Tests/XmlTests.cs
+++ b/RestSharp.Tests/XmlTests.cs
@@ -283,6 +283,7 @@ namespace RestSharp.Tests
 			Assert.Equal(new Uri("/foo/bar", UriKind.RelativeOrAbsolute), p.UrlPath);
 
 			Assert.Equal(Order.Third, p.Order);
+			Assert.Equal(Disposition.SoSo, p.Disposition);
 
 			Assert.NotNull(p.Friends);
 			Assert.Equal(10, p.Friends.Count);
@@ -683,6 +684,7 @@ namespace RestSharp.Tests
 			root.Add(new XElement("Url", "http://example.com"));
 			root.Add(new XElement("UrlPath", "/foo/bar"));
 			root.Add(new XElement("Order", "third"));
+			root.Add(new XElement("Disposition", "so-so"));
 
 			root.Add(new XElement("BestFriend",
 						new XElement("Name", "The Fonz"),

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -91,50 +91,8 @@ namespace RestSharp.Deserializers
 				var type = prop.PropertyType;
 
 				var name = prop.Name;
-				var value = json[name];
-				var actualName = name;
-
-				if (value == null)
-				{
-					// try camel cased name
-					actualName = name.ToCamelCase(Culture);
-					value = json[actualName];
-				}
-
-				if (value == null)
-				{
-					// try lower cased name
-					actualName = name.ToLower(Culture);
-					value = json[actualName];
-				}
-
-				if (value == null)
-				{
-					// try name with underscores
-					actualName = name.AddUnderscores();
-					value = json[actualName];
-				}
-
-				if (value == null)
-				{
-					// try name with underscores with lower case
-					actualName = name.AddUnderscores().ToLower(Culture);
-					value = json[actualName];
-				}
-
-				if (value == null)
-				{
-					// try name with dashes
-					actualName = name.AddDashes();
-					value = json[actualName];
-				}
-
-				if (value == null)
-				{
-					// try name with dashes with lower case
-					actualName = name.AddDashes().ToLower(Culture);
-					value = json[actualName];
-				}
+				var actualName = name.GetNameVariants(Culture).FirstOrDefault(n => json[n] != null);
+				var value = actualName != null ? json[actualName] : null;
 
 				if (value == null || value.Type == JTokenType.Null)
 				{
@@ -156,8 +114,7 @@ namespace RestSharp.Deserializers
 				}
 				else if (type.IsEnum)
 				{
-					string raw = value.AsString();
-					var converted = Enum.Parse(type, raw, true);
+					var converted = type.FindEnumValue(value.AsString(), Culture);
 					prop.SetValue(x, converted, null);
 				}
 				else if (type == typeof(Uri))

--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -144,7 +144,7 @@ namespace RestSharp.Deserializers
 				}
 				else if (type.IsEnum)
 				{
-					var converted = Enum.Parse(type, value.ToString(), true);
+					var converted = type.FindEnumValue(value.ToString(), Culture);
 					prop.SetValue(x, converted, null);
 				}
 				else if (type == typeof(Uri))

--- a/RestSharp/Extensions/ReflectionExtensions.cs
+++ b/RestSharp/Extensions/ReflectionExtensions.cs
@@ -15,6 +15,8 @@
 #endregion
 
 using System;
+using System.Globalization;
+using System.Linq;
 using System.Reflection;
 
 namespace RestSharp.Extensions
@@ -67,6 +69,25 @@ namespace RestSharp.Extensions
 			return Convert.ChangeType(source, newType);
 #else
 			return Convert.ChangeType(source, newType, null);
+#endif
+		}
+
+		/// <summary>
+		/// Find a value from a System.Enum by trying several possible variants
+		/// of the string value of the enum.
+		/// </summary>
+		/// <param name="type">Type of enum</typeparam>
+		/// <param name="value">Value for which to search</param>
+		/// <param name="culture">The culture used to calculate the name variants</param>
+		/// <returns></returns>
+		public static object FindEnumValue(this Type type, string value, CultureInfo culture)
+		{
+#if FRAMEWORK
+			return Enum.GetValues(type)
+				.Cast<Enum>()
+				.First(v => v.ToString().GetNameVariants(culture).Contains(value));
+#else
+			return Enum.Parse(type, value, true);
 #endif
 		}
 	}

--- a/RestSharp/Extensions/StringExtensions.cs
+++ b/RestSharp/Extensions/StringExtensions.cs
@@ -297,6 +297,43 @@ namespace RestSharp.Extensions
 				"$1-$2"), @"[\s]", "-");
 		}
 
+		/// <summary>
+		/// Return possible variants of a name for name matching.
+		/// </summary>
+		/// <param name="name">String to convert</param>
+		/// <param name="culture">The culture to use for conversion</param>
+		/// <returns>IEnumerable&lt;string&gt;</returns>
+		public static IEnumerable<string> GetNameVariants(this string name, CultureInfo culture)
+		{
+			if (String.IsNullOrEmpty(name))
+				yield break;
 
+			var actualName = name;
+			yield return actualName;
+
+			// try camel cased name
+			actualName = name.ToCamelCase(culture);
+			yield return actualName;
+
+			// try lower cased name
+			actualName = name.ToLower(culture);
+			yield return actualName;
+
+			// try name with underscores
+			actualName = name.AddUnderscores();
+			yield return actualName;
+
+			// try name with underscores with lower case
+			actualName = name.AddUnderscores().ToLower(culture);
+			yield return actualName;
+
+			// try name with dashes
+			actualName = name.AddDashes();
+			yield return actualName;
+
+			// try name with dashes with lower case
+			actualName = name.AddDashes().ToLower(culture);
+			yield return actualName;
+		}
 	}
 }


### PR DESCRIPTION
Add support for fuzzy matching of enum values, So things like 'so-so' will match Disposition.SoSo.

Refactored things a bit in the process to move the "get all possible name variations" into a separate extension method. I don't currently have the WP7 dev tools installed, so please test this works as expected with those targets (I believe I added the conditional properly).

Thanks!
