### PR TITLE
Use a shared CookieContainer instance for all requests from the same RestClient.

### DIFF
--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -99,6 +99,10 @@ namespace RestSharp
 		/// </summary>
 		public ICredentials Credentials { get; set; }
 		/// <summary>
+		/// The System.Net.CookieContainer to be used for the request
+		/// </summary>
+		public CookieContainer CookieContainer { get; set; }
+		/// <summary>
 		/// Collection of files to be sent with request
 		/// </summary>
 		public IList<HttpFile> Files { get; private set; }
@@ -225,7 +229,7 @@ namespace RestSharp
 
 		private void AppendCookies(HttpWebRequest webRequest)
 		{
-			webRequest.CookieContainer = new CookieContainer();
+			webRequest.CookieContainer = this.CookieContainer ?? new CookieContainer();
 			foreach (var httpCookie in Cookies)
 			{
 				var cookie = new Cookie

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -24,6 +24,7 @@ namespace RestSharp
 {
 	public interface IHttp
 	{
+		CookieContainer CookieContainer { get; set; }
 		ICredentials Credentials { get; set; }
 		string UserAgent { get; set; }
 		int Timeout { get; set; }

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -29,6 +29,10 @@ namespace RestSharp
 		/// <summary>
 		/// 
 		/// </summary>
+		CookieContainer CookieContainer { get; set; }
+		/// <summary>
+		/// 
+		/// </summary>
 		string UserAgent { get; set; }
 		/// <summary>
 		/// 

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -41,6 +41,7 @@ namespace RestSharp
 		/// </summary>
 		public RestClient()
 		{
+			CookieContainer = new CookieContainer ();
 			ContentHandlers = new Dictionary<string, IDeserializer>();
 			AcceptTypes = new List<string>();
 			DefaultParameters = new List<Parameter>();
@@ -226,6 +227,11 @@ namespace RestSharp
 		public bool FollowRedirects { get; set; }
 
 		/// <summary>
+		/// The CookieContainer used fo requests made by this client instance
+		/// </summary>
+		public CookieContainer CookieContainer { get; set; }
+
+		/// <summary>
 		/// UserAgent to use for requests made by this client instance
 		/// </summary>
 		public string UserAgent { get; set; }
@@ -327,6 +333,8 @@ namespace RestSharp
 
 		private void ConfigureHttp(IRestRequest request, IHttp http)
 		{
+			http.CookieContainer = CookieContainer;
+
 			// move RestClient.DefaultParameters into Request.Parameters
 			foreach(var p in DefaultParameters)
 			{


### PR DESCRIPTION
Use a shared CookieContainer instance for all requests from the same RestClient. Removes the need for manual cookie management.
