### PR TITLE
XmlAttributeDeserializer improvements

### DIFF
--- a/RestSharp/Deserializers/XmlAttributeDeserializer.cs
+++ b/RestSharp/Deserializers/XmlAttributeDeserializer.cs
@@ -19,6 +19,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 using RestSharp.Extensions;
 
@@ -140,13 +141,18 @@ namespace RestSharp.Deserializers
 					}
 				}
 
-				if (type.IsPrimitive)
+				if (type == typeof(bool))
+				{
+					var toConvert = value.ToString().ToLower();
+					prop.SetValue(x, XmlConvert.ToBoolean(toConvert), null);
+				}
+				else if (type.IsPrimitive)
 				{
 					prop.SetValue(x, value.ChangeType(type, Culture), null);
 				}
 				else if (type.IsEnum)
 				{
-					var converted = Enum.Parse(type, value.ToString(), false);
+					var converted = type.FindEnumValue(value.ToString(), Culture);
 					prop.SetValue(x, converted, null);
 				}
 				else if (type == typeof(Uri))

--- a/RestSharp/Extensions/ReflectionExtensions.cs
+++ b/RestSharp/Extensions/ReflectionExtensions.cs
@@ -94,7 +94,7 @@ namespace RestSharp.Extensions
 #if FRAMEWORK
 			return Enum.GetValues(type)
 				.Cast<Enum>()
-				.First(v => v.ToString().GetNameVariants(culture).Contains(value));
+				.First(v => v.ToString().GetNameVariants(culture).Contains(value, StringComparer.Create(culture, true)));
 #else
 			return Enum.Parse(type, value, true);
 #endif


### PR DESCRIPTION
XmlAttributeDeserializer should use same deserialization for bools and enums as XmlDeserializer.
