### PR TITLE
Updated NuSpec to reference JSON.NET 4.0.4

### DIFF
--- a/restsharp.nuspec
+++ b/restsharp.nuspec
@@ -11,7 +11,7 @@
 		<licenseUrl>https://github.com/johnsheehan/RestSharp/blob/master/LICENSE.txt</licenseUrl>
 		<iconUrl>http://dl.dropbox.com/u/1827/restsharp100.png</iconUrl>
 		<dependencies>
-			<dependency id="Newtonsoft.Json" />
+			<dependency id="Newtonsoft.Json" version="4.0.4" />
 		</dependencies>
 		<tags>REST HTTP API JSON XML</tags>
 	</metadata>


### PR DESCRIPTION
JSON.NET was updated to 4.0.5 as the latest version, which causes RestSharp to break.  I tied the NuSpec to the 4.0.4 version that is being used to compile RestSharp to fix issue #187.
