### PR TITLE
Fix Accept header for async requests

### DIFF
--- a/RestSharp/RestClient.Async.cs
+++ b/RestSharp/RestClient.Async.cs
@@ -46,11 +46,12 @@ namespace RestSharp
 			var http = HttpFactory.Create();
 			AuthenticateIfNeeded(this, request);
 
-			ConfigureHttp(request, http);
-
 			// add Accept header based on registered deserializers
 			var accepts = string.Join(", ", AcceptTypes.ToArray());
 			AddDefaultParameter("Accept", accepts, ParameterType.HttpHeader);
+
+			ConfigureHttp(request, http);
+
 			HttpWebRequest webRequest = null;
 			var asyncHandle = new RestRequestAsyncHandle();
 


### PR DESCRIPTION
ConfigureHttp must be called after adding accept types as default parameter to RestRequest, otherwise Accept header won't be included into HTTP request. Currently, it makes impossible async requests to APIs that depend on this header.
