### PR TITLE
Use built-in method for converting byte array to string

### DIFF
--- a/RestSharp/Extensions/MiscExtensions.cs
+++ b/RestSharp/Extensions/MiscExtensions.cs
@@ -143,15 +143,7 @@ namespace RestSharp.Extensions
 				encoding = Encoding.UTF7;
 			}
 #endif
-			using (MemoryStream stream = new MemoryStream())
-			{
-				stream.Write(buffer, 0, buffer.Length);
-				stream.Seek(0, SeekOrigin.Begin);
-				using (StreamReader reader = new StreamReader(stream, encoding))
-				{
-					return reader.ReadToEnd();
-				}
-			}
+			return encoding.GetString(buffer);
 		}
 
 	}


### PR DESCRIPTION
This reduces the memory footprint dramatically.

Consider the following:

```
var buffer = new byte[1024 * 1024 * 100];

var generator = RandomNumberGenerator.Create();
generator.GetBytes(buffer);
```

This will create a byte array of 100 MiB.

Converting this via `Encoding.GetString()` will increase the overall memory footprint to about 300 MiB.
Converting with the current approach, however, will increase the footprint to ~600 MiB.
