### PR TITLE
Deserializing XML  missing node (nullable property) problem

### DIFF
--- a/RestSharp.Tests/XmlTests.cs
+++ b/RestSharp.Tests/XmlTests.cs
@@ -481,6 +481,7 @@ namespace RestSharp.Tests
 			var response = new RestResponse { Content = doc.ToString() };
 
 			var d = new XmlDeserializer();
+            d.RootElement = "event";
 			var output = d.Deserialize<SampleClasses.Lastfm.Event>(response);
 
 			//Assert.NotEmpty(output.artists);
@@ -554,6 +555,19 @@ namespace RestSharp.Tests
 			Assert.Null(output.StartDate);
 			Assert.Equal(new Guid(GuidString), output.UniqueId);
 		}
+
+	    [Fact]
+	    public void Can_Deserialize_Object_With_Property_Named_The_Same_As_Nested_Objects_Property()
+	    {
+	        var person = CreatePersonXmlWithNoNameWithFriendWhoHasName();
+            var response = new RestResponse { Content = person };
+            
+            var d = new XmlDeserializer();
+            var p = d.Deserialize<PersonForXml>(response);
+
+            Assert.Null(p.Name);
+            Assert.Equal("The Fonz", p.BestFriend.Name);
+	    }
 
 		private static string CreateUnderscoresXml()
 		{
@@ -720,6 +734,23 @@ namespace RestSharp.Tests
 							));
 			}
 			root.Add(friends);
+
+			doc.Add(root);
+			return doc.ToString();
+		}
+
+
+        private static string CreatePersonXmlWithNoNameWithFriendWhoHasName()
+		{
+			var doc = new XDocument();
+			var root = new XElement("Person");
+			root.Add(new XElement("StartDate", new DateTime(2009, 9, 25, 0, 6, 1)));
+			root.Add(new XElement("Age", 28));
+
+			root.Add(new XElement("BestFriend",
+						new XElement("Name", "The Fonz"),
+						new XElement("Since", 1952)
+					));
 
 			doc.Add(root);
 			return doc.ToString();

--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -349,11 +349,9 @@ namespace RestSharp.Deserializers
 			}
 
 			// try looking for element that matches sanitized property name (Order by depth)
-			var element = root.Descendants()
-				.OrderBy(d => d.Ancestors().Count())
-				.FirstOrDefault(d => d.Name.LocalName.RemoveUnderscoresAndDashes() == name.LocalName) 
-				?? root.Descendants()
-				.OrderBy(d => d.Ancestors().Count())
+			var element = root.Elements()
+				.FirstOrDefault(d => d.Name.LocalName.RemoveUnderscoresAndDashes() == name.LocalName)
+                ?? root.Elements()
 				.FirstOrDefault(d => d.Name.LocalName.RemoveUnderscoresAndDashes() == name.LocalName.ToLower());
 
 			if (element != null)


### PR DESCRIPTION
Given the following object:

```
public class PersonForXml
{
    public string Name { get; set; }
    public Friend BestFriend { get; set; }
}
```

When deserializing the following xml:

```
<person>
  <BestFriend>
    <Name>The Fonz</Name>
  </BestFriend>
</person>
```

results in 

```
person.Name == "The Fonz"
```

(It should be null or empty string)

This fixes it... 

_HOWEVER_
It may break other users who have used the deserializer to deserialize to an object from an XML element which is nested within the XML sent to the deserializer, where they haven't set the deserializer.RootElement property (As was the case with the Can_Deserialize_Lastfm_Xml test)!!!

In short, I believe this is a good bug fix, but may cause some folks problems if they have not made use of the Deserializer.RootElement as I think it should be used.
