### PR TITLE
Restore a JSON lists test that got truncated, and add an additional test...

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -49,6 +49,12 @@ namespace RestSharp.Tests
 		public void Can_Deserialize_Lists_of_Simple_Types()
 		{
 			var doc = File.ReadAllText(Path.Combine("SampleData", "jsonlists.txt"));
+			var json = new JsonDeserializer ();
+
+			var output = json.Deserialize<JsonLists> (new RestResponse { Content = doc });
+
+			Assert.NotEmpty (output.Names);
+			Assert.NotEmpty (output.Numbers);
 		}
 
 		[Fact]
@@ -147,6 +153,23 @@ namespace RestSharp.Tests
 			var json = new JsonDeserializer();
 			var output = json.Deserialize<List<status>>(response);
 			Assert.Equal(4, output.Count);
+		}
+
+		[Fact]
+		public void Can_Deserialize_Various_Enum_Values ()
+		{
+			var data = File.ReadAllText (Path.Combine ("SampleData", "jsonenums.txt"));
+			var response = new RestResponse { Content = data };
+			var json = new JsonDeserializer ();
+			var output = json.Deserialize<JsonEnumsTestStructure>(response);
+
+			Assert.Equal (output.Upper, Disposition.Friendly);
+			Assert.Equal (output.Lower, Disposition.Friendly);
+			Assert.Equal (output.CamelCased, Disposition.SoSo);
+			Assert.Equal (output.Underscores, Disposition.SoSo);
+			Assert.Equal (output.LowerUnderscores, Disposition.SoSo);
+			Assert.Equal (output.Dashes, Disposition.SoSo);
+			Assert.Equal (output.LowerDashes, Disposition.SoSo);
 		}
 
 		[Fact]

--- a/RestSharp.Tests/RestSharp.Tests.csproj
+++ b/RestSharp.Tests/RestSharp.Tests.csproj
@@ -111,6 +111,9 @@
     <Content Include="SampleData\datetimes.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="SampleData\jsonenums.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="SampleData\person.json.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/RestSharp.Tests/SampleClasses/misc.cs
+++ b/RestSharp.Tests/SampleClasses/misc.cs
@@ -153,4 +153,15 @@ namespace RestSharp.Tests
 		public DateTimeOffset? NullableDateTimeOffsetWithNull { get; set; }
 		public DateTimeOffset? NullableDateTimeOffsetWithValue { get; set; }
 	}
+
+	public class JsonEnumsTestStructure
+	{
+		public Disposition Upper { get; set; }
+		public Disposition Lower { get; set; }
+		public Disposition CamelCased { get; set; }
+		public Disposition Underscores { get; set; }
+		public Disposition LowerUnderscores { get; set; }
+		public Disposition Dashes { get; set; }
+		public Disposition LowerDashes { get; set; }
+	}
 }

--- a/RestSharp.Tests/SampleData/jsonenums.txt
+++ b/RestSharp.Tests/SampleData/jsonenums.txt
@@ -1,0 +1,9 @@
+﻿{
+  "upper": "FRIENDLY",
+  "lower": "friendly",
+  "camel_cased": "SoSo",
+  "underscores": "So_So",
+  "lower_underscores": "so_so",
+  "dashes": "So-So",
+  "lower_dashes": "so_so",
+}

--- a/RestSharp/Extensions/StringExtensions.cs
+++ b/RestSharp/Extensions/StringExtensions.cs
@@ -315,32 +315,25 @@ namespace RestSharp.Extensions
 			if (String.IsNullOrEmpty(name))
 				yield break;
 
-			var actualName = name;
-			yield return actualName;
+			yield return name;
 
 			// try camel cased name
-			actualName = name.ToCamelCase(culture);
-			yield return actualName;
+			yield return name.ToCamelCase(culture);
 
 			// try lower cased name
-			actualName = name.ToLower(culture);
-			yield return actualName;
+			yield return name.ToLower(culture);
 
 			// try name with underscores
-			actualName = name.AddUnderscores();
-			yield return actualName;
+			yield return name.AddUnderscores();
 
 			// try name with underscores with lower case
-			actualName = name.AddUnderscores().ToLower(culture);
-			yield return actualName;
+			yield return name.AddUnderscores().ToLower(culture);
 
 			// try name with dashes
-			actualName = name.AddDashes();
-			yield return actualName;
+			yield return name.AddDashes();
 
 			// try name with dashes with lower case
-			actualName = name.AddDashes().ToLower(culture);
-			yield return actualName;
+			yield return name.AddDashes().ToLower(culture);
 		}
 	}
 }


### PR DESCRIPTION
... for JSON enum parsing.

That pretty much sums it up. Had started work on the tests to validate a fix I was about to add for all upper case enum values mapping properly, only to find it had already been fixed in master but not in the version of RestSharp I was using.

Either way, the tests add more coverage!
