### PR TITLE
Added a string.IsNullOrEmpty check on the parameter name - I was getting...

### DIFF
--- a/RestSharp/Authenticators/HttpBasicAuthenticator.cs
+++ b/RestSharp/Authenticators/HttpBasicAuthenticator.cs
@@ -39,7 +39,7 @@ namespace RestSharp
 			// request.Credentials = new NetworkCredential(_username, _password);
 
 			// only add the Authorization parameter if it hasn't been added by a previous Execute
-			if (!request.Parameters.Any(p => p.Name.Equals("Authorization", StringComparison.InvariantCultureIgnoreCase)))
+			if (!request.Parameters.Any(p => !(string.IsNullOrEmpty(p.Name)) &&   p.Name.Equals("Authorization", StringComparison.InvariantCultureIgnoreCase)))
 			{
 				var token = Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format("{0}:{1}", _username, _password)));
 				var authHeader = string.Format("Basic {0}", token);


### PR DESCRIPTION
... an error because during a POST, I had the XML I was sending as a parameter, with the XML as the value, but no name. I haven't got to grips with why this is, but putting this check stopped the error, and allowed the POST operation to happen without the app crashing, so that's good enough for me at the moment ...
