### PR TITLE
Made Silverlight and Windows Phone clients send Cookies on request

### DIFF
--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -238,19 +238,24 @@ namespace RestSharp
 			webRequest.CookieContainer = this.CookieContainer ?? new CookieContainer();
 			foreach (var httpCookie in Cookies)
 			{
-				var cookie = new Cookie
+#if FRAMEWORK
+                var cookie = new Cookie
 				{
 					Name = httpCookie.Name,
 					Value = httpCookie.Value,
 					Domain = webRequest.RequestUri.Host
 				};
-#if FRAMEWORK
 				webRequest.CookieContainer.Add(cookie);
 #else
+                var cookie = new Cookie
+				{
+					Name = httpCookie.Name,
+					Value = httpCookie.Value
+				};
 				var uri = webRequest.RequestUri;
 				webRequest.CookieContainer.Add(new Uri(string.Format("{0}://{1}", uri.Scheme, uri.Host)), cookie);
 #endif
-			}
+            }
 		}
 
 		private string EncodeParameters()


### PR DESCRIPTION
I used AddCookie() method to add cookies to my RestRequest instance, but using Fiddler I managed to see that no cookies where being sent...

Apparently, this is because of adding the Domain to the System.Net.Cookie instance; if you just don't add the Domain on the Silverlight and Windows Phone version of RestSharp, all works fine, and that is just what I did.
I don't think this is even required because the CookieContainer already has information regarding the host address.
