### PR TITLE
Handle connection failures better

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -266,11 +266,13 @@ namespace RestSharp
 				if(ex.Status == WebExceptionStatus.RequestCanceled)
 				{
 					throw ex;
-				}
-				
+				}			
 				if (ex.Response is HttpWebResponse)
 				{
 					raw = ex.Response as HttpWebResponse;
+				} else
+				{
+					throw ex;
 				}
 			}
 
@@ -304,7 +306,15 @@ namespace RestSharp
 					response.ResponseStatus = ResponseStatus.Aborted;
 					ExecuteCallback(response, callback);
 					return;
+				} else
+				{
+					response.ErrorMessage = ex.Message;
+					response.ErrorException = ex;
+					response.ResponseStatus = ResponseStatus.Error;
+					ExecuteCallback(response, callback);
+					return;
 				}
+
 			}
 			catch(Exception ex)
 			{


### PR DESCRIPTION
Currently it seems that if there is e.g. a connection failure Http.ExtractResponseData chokes with a less than helpful NullReferenceException, This commit seems to fix the issue for me in that now the ErrorMessage and ErrorException refers to connection failure, but as I'm not too familiar with the code base yet please review first to make sure I haven't screwed something else up.
