### PR TITLE
Changed string comparisons to use `OrdinalIgnoreCase`

### DIFF
--- a/RestSharp/Authenticators/HttpBasicAuthenticator.cs
+++ b/RestSharp/Authenticators/HttpBasicAuthenticator.cs
@@ -39,7 +39,7 @@ namespace RestSharp
 			// request.Credentials = new NetworkCredential(_username, _password);
 
 			// only add the Authorization parameter if it hasn't been added by a previous Execute
-			if (!request.Parameters.Any(p => p.Name.Equals("Authorization", StringComparison.InvariantCultureIgnoreCase)))
+			if (!request.Parameters.Any(p => p.Name.Equals("Authorization", StringComparison.OrdinalIgnoreCase)))
 			{
 				var token = Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format("{0}:{1}", _username, _password)));
 				var authHeader = string.Format("Basic {0}", token);

--- a/RestSharp/Authenticators/OAuth/Extensions/StringExtensions.cs
+++ b/RestSharp/Authenticators/OAuth/Extensions/StringExtensions.cs
@@ -29,7 +29,7 @@ namespace RestSharp.Authenticators.OAuth.Extensions
 
 		public static bool EqualsIgnoreCase(this string left, string right)
 		{
-			return String.Compare(left, right, StringComparison.InvariantCultureIgnoreCase) == 0;
+			return String.Compare(left, right, StringComparison.OrdinalIgnoreCase) == 0;
 		}
 
 		public static bool EqualsAny(this string input, params string[] args)

--- a/RestSharp/Authenticators/OAuth2Authenticator.cs
+++ b/RestSharp/Authenticators/OAuth2Authenticator.cs
@@ -97,7 +97,7 @@ namespace RestSharp
 		public override void Authenticate(IRestClient client, IRestRequest request)
 		{
 			// only add the Authorization parameter if it hasn't been added.
-			if (!request.Parameters.Any(p => p.Name.Equals("Authorization", StringComparison.InvariantCultureIgnoreCase)))
+			if (!request.Parameters.Any(p => p.Name.Equals("Authorization", StringComparison.OrdinalIgnoreCase)))
 			{
 				request.AddParameter("Authorization", _authorizationValue, ParameterType.HttpHeader);
 			}

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -320,7 +320,7 @@ namespace RestSharp
 				response.ContentType = webResponse.ContentType;
 				response.ContentLength = webResponse.ContentLength;
 #if WINDOWS_PHONE
-                if (string.Equals(webResponse.Headers[HttpRequestHeader.ContentEncoding], "gzip", StringComparison.InvariantCultureIgnoreCase))
+                if (string.Equals(webResponse.Headers[HttpRequestHeader.ContentEncoding], "gzip", StringComparison.OrdinalIgnoreCase))
                     response.RawBytes = new GZipStream(webResponse.GetResponseStream()).ReadAsBytes();
                 else
                     response.RawBytes = webResponse.GetResponseStream().ReadAsBytes();


### PR DESCRIPTION
Not only is ordinal comparisons faster since it does a byte by byte comparison, but for the case of dealing with HTTP headers, it's also the more correct comparsion to do as of .NET 2.0 (see the [MSDN recommendations for string comparisons](http://msdn.microsoft.com/en-us/library/ms973919.aspx)).

As an example, try running these two lines of code:

```
Console.Write(String.Equals("Password", "Paßword", StringComparison.OrdinalIgnoreCase));
Console.Write(String.Equals("Password", "Paßword", StringComparison.InvariantCultureIgnoreCase));
```

Notice the first (ordinal) comparison returns `false` and the second (invariant culture) returns `true`.
