### PR TITLE
Errors in http layer are not propagated correctly if RawBytes of HttpResponse is null

### DIFF
--- a/RestSharp/Extensions/MiscExtensions.cs
+++ b/RestSharp/Extensions/MiscExtensions.cs
@@ -107,6 +107,8 @@ namespace RestSharp.Extensions
 		/// <returns>The byte as a string.</returns>
 		public static string AsString(this byte[] buffer)
 		{
+            if (buffer == null) return "";
+
 			// Ansi as default
 			Encoding encoding = Encoding.UTF8;
 


### PR DESCRIPTION
If RawBytes of HttpResponse is null (e.g. when a timeout occurs), the RestClient.ConvertToRestResponse method throws when getting HttpResponse.Content. As a consequence, an ArgumentNullException gets set as ErrorException in the RestResponse, instead of the real exception.

This pull request fixes the misleading ArgumentNullException.
