### PR TITLE
ExecuteAsync callback gets run twice on exceptions

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -306,13 +306,6 @@ namespace RestSharp
 					return;
 				}
 			}
-			catch(Exception ex)
-			{
-				response.ErrorMessage = ex.Message;
-				response.ErrorException = ex;
-				response.ResponseStatus = ResponseStatus.Error;
-				ExecuteCallback(response, callback);
-			}
 		}
 
 		private static void ExecuteCallback(HttpResponse response, Action<HttpResponse> callback)


### PR DESCRIPTION
This patch fixes the following issue https://github.com/restsharp/RestSharp/issues/93.

I'm not convinced (from a very brief glance at the code) that there aren't other similar bugs lurking around. The async code could use a tidy up.
