### PR TITLE
Edited the IRestClient to have the execute functions return IRestResponse

### DIFF
--- a/RestSharp/Deserializers/DotNetXmlDeserializer.cs
+++ b/RestSharp/Deserializers/DotNetXmlDeserializer.cs
@@ -30,7 +30,7 @@ namespace RestSharp.Deserializers
 
 		public string RootElement { get; set; }
 
-		public T Deserialize<T>(RestResponse response) where T : new()
+		public T Deserialize<T>(IRestResponse response) where T : new()
 		{
 			if (string.IsNullOrEmpty(response.Content))
 			{

--- a/RestSharp/Deserializers/IDeserializer.cs
+++ b/RestSharp/Deserializers/IDeserializer.cs
@@ -18,7 +18,7 @@ namespace RestSharp.Deserializers
 {
 	public interface IDeserializer
 	{
-		T Deserialize<T>(RestResponse response) where T : new();
+		T Deserialize<T>(IRestResponse response) where T : new();
 		string RootElement { get; set; }
 		string Namespace { get; set; }
 		string DateFormat { get; set; }

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -37,7 +37,7 @@ namespace RestSharp.Deserializers
 			Culture = CultureInfo.InvariantCulture;
 		}
 
-		public T Deserialize<T>(RestResponse response) where T : new()
+		public T Deserialize<T>(IRestResponse response) where T : new()
 		{
 			var target = new T();
 

--- a/RestSharp/Deserializers/XmlAttributeDeserializer.cs
+++ b/RestSharp/Deserializers/XmlAttributeDeserializer.cs
@@ -37,7 +37,7 @@ namespace RestSharp.Deserializers
 			Culture = CultureInfo.InvariantCulture;
 		}
 
-		public T Deserialize<T>(RestResponse response) where T : new()
+		public T Deserialize<T>(IRestResponse response) where T : new()
 		{
 			if (response.Content == null)
 				return default(T);

--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -38,7 +38,7 @@ namespace RestSharp.Deserializers
 			Culture = CultureInfo.InvariantCulture;
 		}
 
-		public T Deserialize<T>(RestResponse response) where T : new()
+		public T Deserialize<T>(IRestResponse response) where T : new()
 		{
 			if (string.IsNullOrEmpty( response.Content ))
 				return default(T);

--- a/RestSharp/Extensions/ResponseExtensions.cs
+++ b/RestSharp/Extensions/ResponseExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace RestSharp.Extensions
+{
+    public static class ResponseExtensions
+    {
+        public static IRestResponse<T> toAsyncResponse<T>(this IRestResponse response) where T : new()
+        {
+            return new RestResponse<T>
+            {
+                ContentEncoding = response.ContentEncoding,
+                ContentLength = response.ContentLength,
+                ContentType = response.ContentType,
+                Cookies = response.Cookies,
+                ErrorMessage = response.ErrorMessage,
+                Headers = response.Headers,
+                RawBytes = response.RawBytes,
+                ResponseStatus = response.ResponseStatus,
+                ResponseUri = response.ResponseUri,
+                Server = response.Server,
+                StatusCode = response.StatusCode,
+                StatusDescription = response.StatusDescription
+            };
+        }
+    }
+}

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -58,20 +58,20 @@ namespace RestSharp
 		/// 
 		/// </summary>
 		/// <param name="request"></param>
-		RestRequestAsyncHandle ExecuteAsync(IRestRequest request, Action<RestResponse, RestRequestAsyncHandle> callback);
+		RestRequestAsyncHandle ExecuteAsync(IRestRequest request, Action<IRestResponse, RestRequestAsyncHandle> callback);
 		/// <summary>
 		/// 
 		/// </summary>
 		/// <param name="request"></param>
-		RestRequestAsyncHandle ExecuteAsync<T>(IRestRequest request, Action<RestResponse<T>, RestRequestAsyncHandle> callback) where T : new();
+		RestRequestAsyncHandle ExecuteAsync<T>(IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback) where T : new();
 
 #if FRAMEWORK
 		/// <summary>
 		/// X509CertificateCollection to be sent with request
 		/// </summary>
 		X509CertificateCollection ClientCertificates { get; set; }
-		RestResponse Execute(IRestRequest request);
-		RestResponse<T> Execute<T>(IRestRequest request) where T : new();
+		IRestResponse Execute(IRestRequest request);
+		IRestResponse<T> Execute<T>(IRestRequest request) where T : new();
 		
 		IWebProxy Proxy { get; set; }
 #endif

--- a/RestSharp/RestClient.Async.cs
+++ b/RestSharp/RestClient.Async.cs
@@ -30,7 +30,7 @@ namespace RestSharp
 		/// </summary>
 		/// <param name="request">Request to be executed</param>
 		/// <param name="callback">Callback function to be executed upon completion providing access to the async handle.</param>
-		public virtual RestRequestAsyncHandle ExecuteAsync(IRestRequest request, Action<RestResponse, RestRequestAsyncHandle> callback)
+		public virtual RestRequestAsyncHandle ExecuteAsync(IRestRequest request, Action<IRestResponse, RestRequestAsyncHandle> callback)
 		{
 			var http = HttpFactory.Create();
 			AuthenticateIfNeeded(this, request);
@@ -82,7 +82,7 @@ namespace RestSharp
 			return asyncHandle;
 		}
 
-		private void ProcessResponse(HttpResponse httpResponse, RestRequestAsyncHandle asyncHandle, Action<RestResponse, RestRequestAsyncHandle> callback)
+		private void ProcessResponse(HttpResponse httpResponse, RestRequestAsyncHandle asyncHandle, Action<IRestResponse, RestRequestAsyncHandle> callback)
 		{
 			var restResponse = ConvertToRestResponse(httpResponse);
 			callback(restResponse, asyncHandle);
@@ -94,11 +94,11 @@ namespace RestSharp
 		/// <typeparam name="T">Target deserialization type</typeparam>
 		/// <param name="request">Request to be executed</param>
 		/// <param name="callback">Callback function to be executed upon completion</param>
-		public virtual RestRequestAsyncHandle ExecuteAsync<T>(IRestRequest request, Action<RestResponse<T>, RestRequestAsyncHandle> callback) where T : new()
+		public virtual RestRequestAsyncHandle ExecuteAsync<T>(IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback) where T : new()
 		{
 			return ExecuteAsync(request, (response, asyncHandle) =>
 			{
-				var restResponse = (RestResponse<T>)response;
+				var restResponse = (IRestResponse<T>)response;
 				if (response.ResponseStatus != ResponseStatus.Aborted)
 				{
 					restResponse = Deserialize<T>(request, response);

--- a/RestSharp/RestClient.Sync.cs
+++ b/RestSharp/RestClient.Sync.cs
@@ -33,7 +33,7 @@ namespace RestSharp
 		/// </summary>
 		/// <param name="request">Request to be executed</param>
 		/// <returns>RestResponse</returns>
-		public virtual RestResponse Execute(IRestRequest request)
+		public virtual IRestResponse Execute(IRestRequest request)
 		{
 			AuthenticateIfNeeded(this, request);
 
@@ -41,7 +41,7 @@ namespace RestSharp
 			var accepts = string.Join(", ", AcceptTypes.ToArray());
 			AddDefaultParameter("Accept", accepts, ParameterType.HttpHeader);
 
-			var response = new RestResponse();
+			IRestResponse response = new RestResponse();
 			try
 			{
 				response = GetResponse(request);
@@ -65,13 +65,13 @@ namespace RestSharp
 		/// <typeparam name="T">Target deserialization type</typeparam>
 		/// <param name="request">Request to execute</param>
 		/// <returns>RestResponse[[T]] with deserialized data in Data property</returns>
-		public virtual RestResponse<T> Execute<T>(IRestRequest request) where T : new()
+		public virtual IRestResponse<T> Execute<T>(IRestRequest request) where T : new()
 		{
 			var raw = Execute(request);
 			return Deserialize<T>(request, raw);
 		}
 		
-		private RestResponse GetResponse(IRestRequest request)
+		private IRestResponse GetResponse(IRestRequest request)
 		{
 			var http = HttpFactory.Create();
 

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -488,7 +488,7 @@ namespace RestSharp
 			return restResponse;
 		}
 
-		private RestResponse<T> Deserialize<T>(IRestRequest request, RestResponse raw) where T : new()
+		private IRestResponse<T> Deserialize<T>(IRestRequest request, IRestResponse raw) where T : new()
 		{
 			request.OnBeforeDeserialization(raw);
 
@@ -497,10 +497,10 @@ namespace RestSharp
 			handler.DateFormat = request.DateFormat;
 			handler.Namespace = request.XmlNamespace;
 
-			var response = new RestResponse<T>();
+			IRestResponse<T> response = new RestResponse<T>();
 			try
 			{
-				response = (RestResponse<T>)raw;
+			    response = raw.toAsyncResponse<T>();
 				response.Data = handler.Deserialize<T>(raw);
 			}
 			catch (Exception ex)

--- a/RestSharp/RestClientExtensions.cs
+++ b/RestSharp/RestClientExtensions.cs
@@ -10,7 +10,7 @@ namespace RestSharp
         /// <param name="client">The IRestClient this method extends</param>
         /// <param name="request">Request to be executed</param>
         /// <param name="callback">Callback function to be executed upon completion</param>
-        public static RestRequestAsyncHandle ExecuteAsync(this IRestClient client, IRestRequest request, Action<RestResponse> callback)
+        public static RestRequestAsyncHandle ExecuteAsync(this IRestClient client, IRestRequest request, Action<IRestResponse> callback)
         {
             return client.ExecuteAsync(request, (response, handle) => callback(response));
         }
@@ -22,7 +22,7 @@ namespace RestSharp
         /// <typeparam name="T">Target deserialization type</typeparam>
         /// <param name="request">Request to be executed</param>
         /// <param name="callback">Callback function to be executed upon completion providing access to the async handle</param>
-        public static RestRequestAsyncHandle ExecuteAsync<T>(this IRestClient client, IRestRequest request, Action<RestResponse<T>> callback) where T : new()
+        public static RestRequestAsyncHandle ExecuteAsync<T>(this IRestClient client, IRestRequest request, Action<IRestResponse<T>> callback) where T : new()
         {
             return client.ExecuteAsync<T>(request, (response, asyncHandle) => callback(response));
         }

--- a/RestSharp/RestResponse.cs
+++ b/RestSharp/RestResponse.cs
@@ -96,11 +96,11 @@ namespace RestSharp
 		/// <summary>
 		/// Cookies returned by server with the response
 		/// </summary>
-		public IList<RestResponseCookie> Cookies { get; protected set; }
+		public IList<RestResponseCookie> Cookies { get; protected internal set; }
 		/// <summary>
 		/// Headers returned by server with the response
 		/// </summary>
-		public IList<Parameter> Headers { get; protected set; }
+		public IList<Parameter> Headers { get; protected internal set; }
 
 		private ResponseStatus _responseStatus = ResponseStatus.None;
 		/// <summary>
@@ -159,6 +159,7 @@ namespace RestSharp
 				StatusDescription = response.StatusDescription
 			};
 		}
+        
 	}
 
 	/// <summary>

--- a/RestSharp/RestSharp.csproj
+++ b/RestSharp/RestSharp.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Extensions\MonoHttp\Helpers.cs" />
     <Compile Include="Extensions\MonoHttp\HtmlEncoder.cs" />
     <Compile Include="Extensions\MonoHttp\HttpUtility.cs" />
+    <Compile Include="Extensions\ResponseExtensions.cs" />
     <Compile Include="RestClientExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Http.Sync.cs" />


### PR DESCRIPTION
Edited the IRestClient to have the execute functions return IRestResponse instead of the derived type to allow for more natural mocking without having to cast the mock object and added an extension method for
converting a response to a generic reponses

```
modified:   RestSharp/Deserializers/DotNetXmlDeserializer.cs
modified:   RestSharp/Deserializers/IDeserializer.cs
modified:   RestSharp/Deserializers/JsonDeserializer.cs
modified:   RestSharp/Deserializers/XmlAttributeDeserializer.cs
modified:   RestSharp/Deserializers/XmlDeserializer.cs
new file:   RestSharp/Extensions/ResponseExtensions.cs
modified:   RestSharp/IRestClient.cs
modified:   RestSharp/RestClient.Async.cs
modified:   RestSharp/RestClient.Sync.cs
modified:   RestSharp/RestClient.cs
modified:   RestSharp/RestClientExtensions.cs
modified:   RestSharp/RestResponse.cs
modified:   RestSharp/RestSharp.csproj
```
