### PR TITLE
Newtonsoft.Json library version in Nuspec file

### DIFF
--- a/restsharp.nuspec
+++ b/restsharp.nuspec
@@ -11,7 +11,7 @@
 		<licenseUrl>https://github.com/restsharp/RestSharp/blob/master/LICENSE.txt</licenseUrl>
 		<iconUrl>http://dl.dropbox.com/u/1827/restsharp100.png</iconUrl>
 		<dependencies>
-			<dependency id="Newtonsoft.Json" />
+			<dependency id="Newtonsoft.Json" version="4.0.8" />
 		</dependencies>
 		<tags>REST HTTP API JSON XML</tags>
 		<releaseNotes>


### PR DESCRIPTION
Nuget package dependency (in nuspec file) should have specified version attribute to used Newtonsoft.Json library.
