### PR TITLE
Removed the "T : new()" constraint from the IDeserializer.Deserialize<T>...

### DIFF
--- a/RestSharp/Deserializers/DotNetXmlDeserializer.cs
+++ b/RestSharp/Deserializers/DotNetXmlDeserializer.cs
@@ -30,7 +30,7 @@ namespace RestSharp.Deserializers
 
 		public string RootElement { get; set; }
 
-		public T Deserialize<T>(IRestResponse response) where T : new()
+		public T Deserialize<T>(IRestResponse response)
 		{
 			if (string.IsNullOrEmpty(response.Content))
 			{

--- a/RestSharp/Deserializers/IDeserializer.cs
+++ b/RestSharp/Deserializers/IDeserializer.cs
@@ -18,7 +18,7 @@ namespace RestSharp.Deserializers
 {
 	public interface IDeserializer
 	{
-		T Deserialize<T>(IRestResponse response) where T : new();
+		T Deserialize<T>(IRestResponse response);
 		string RootElement { get; set; }
 		string Namespace { get; set; }
 		string DateFormat { get; set; }

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -20,9 +20,9 @@ namespace RestSharp.Deserializers
 			Culture = CultureInfo.InvariantCulture;
 		}
 
-		public T Deserialize<T>(IRestResponse response) where T : new()
+		public T Deserialize<T>(IRestResponse response)
 		{
-			var target = new T();
+			var target = Activator.CreateInstance<T>();
 
 			if (target is IList)
 			{

--- a/RestSharp/Deserializers/XmlAttributeDeserializer.cs
+++ b/RestSharp/Deserializers/XmlAttributeDeserializer.cs
@@ -37,7 +37,7 @@ namespace RestSharp.Deserializers
 			Culture = CultureInfo.InvariantCulture;
 		}
 
-		public T Deserialize<T>(IRestResponse response) where T : new()
+		public T Deserialize<T>(IRestResponse response)
 		{
 			if (response.Content == null)
 				return default(T);
@@ -55,7 +55,7 @@ namespace RestSharp.Deserializers
 				RemoveNamespace(doc);
 			}
 
-			var x = new T();
+            var x = Activator.CreateInstance<T>();
 			var objType = x.GetType();
 
 			if (objType.IsSubclassOfRawGeneric(typeof(List<>)))

--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -38,7 +38,7 @@ namespace RestSharp.Deserializers
 			Culture = CultureInfo.InvariantCulture;
 		}
 
-		public T Deserialize<T>(IRestResponse response) where T : new()
+		public T Deserialize<T>(IRestResponse response)
 		{
 			if (string.IsNullOrEmpty( response.Content ))
 				return default(T);
@@ -56,7 +56,7 @@ namespace RestSharp.Deserializers
 				RemoveNamespace(doc);
 			}
 
-			var x = new T();
+			var x = Activator.CreateInstance<T>();
 			var objType = x.GetType();
 
 			if (objType.IsSubclassOfRawGeneric(typeof(List<>)))


### PR DESCRIPTION
The real reason for this change is not forcing someone that creates a custom IDeserializer instance having to use a class with an empty constructor: if it's custom, the developer should handle how he wants the returning class to be created!

So I removed the `new()` and replaced with `Activator.CreateInstance()` instead on the IDeserializer instances.
