### PR TITLE
BugFix: RestResponse.Content property might throw an exception.

### DIFF
--- a/RestSharp/RestResponse.cs
+++ b/RestSharp/RestResponse.cs
@@ -62,7 +62,7 @@ namespace RestSharp
 		{
 			get
 			{
-				if (_content == null)
+				if (_content == null && RawBytes != null)
 				{
 					_content = RawBytes.AsString();
 				}


### PR DESCRIPTION
Hi folks,

the RestResponse.Content property was sometimes throwing an exception. This is when it tried to concert the RawBytes to a string .. but if there was no RawBytes data .. well .. :boom: :(

I found this to happen when i tried to goto a bad IP Address like: `new RestClient("https://192.168.0.1/api");`

Cheers :)
