### PR TITLE
XmlAttributeDeserializer crashes if value == ""

### DIFF
--- a/RestSharp/Deserializers/XmlAttributeDeserializer.cs
+++ b/RestSharp/Deserializers/XmlAttributeDeserializer.cs
@@ -109,7 +109,7 @@ namespace RestSharp.Deserializers
 
 				var value = GetValueFromXml(root, name, isAttribute);
 
-				if (value == null)
+				if (value == null || value == string.Empty)
 				{
 					// special case for inline list items
 					if (type.IsGenericType)


### PR DESCRIPTION
Put in a check for value == string.Empty instead of just checking if value == null.
