### PR TITLE
Fix invalid cast exception in RestClient.Async.cs

### DIFF
--- a/RestSharp/RestClient.Async.cs
+++ b/RestSharp/RestClient.Async.cs
@@ -98,7 +98,7 @@ namespace RestSharp
 		{
 			return ExecuteAsync(request, (response, asyncHandle) =>
 			{
-				var restResponse = (IRestResponse<T>)response;
+				IRestResponse<T> restResponse = null;
 				if (response.ResponseStatus != ResponseStatus.Aborted)
 				{
 					restResponse = Deserialize<T>(request, response);


### PR DESCRIPTION
Removed attempt to cast IRestResponse to IRestResponse<T>
