### PR TITLE
will it be nice if assembly is CLSCompliant?

### DIFF
--- a/RestSharp/SharedAssemblyInfo.cs
+++ b/RestSharp/SharedAssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -12,7 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © RestSharp Project 2009-2012")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-
+[assembly: CLSCompliant(true)]
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version


### PR DESCRIPTION
Our libraries are marked with `CLSCompliant(true)` and was configured "_Treat warnings as Error_" for _all_. Therefore, when we compile our library which use RestSharp, the compiler throws error as

`Warning as Error: Argument type 'RestSharp.IRestClient' is not CLS-compliant.`

Since RestSharp is already CLSCompliant, will it be nice if it is CLSCompliant? 

Thanks.
