### PR TITLE
JsonDeserializer was not handling nulls in json lists

### DIFF
--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -209,7 +209,11 @@ namespace RestSharp.Deserializers
 				}
 				else if (itemType == typeof(string))
 				{
-					list.Add(element.ToString());
+					//ensure we handle case where element is null
+					if (element == null)
+						list.Add(null);
+					else
+						list.Add(element.ToString());
 				}
 				else
 				{


### PR DESCRIPTION
e.g. this would break it   {"reset": false, "cursor":
"AlMUg1tRnblGB7JuFfBiExzJj0dUGaXo0CDCXaziIncBeJxjqMn8z8DIp8c-
TfcdAwODIBAzAAA1_QPr", "has_more": false, "entries": [["/dropbox.lnk",
null]]}

I have fixed this in JsonDeserializer line 212 but I have not updated any unit tests.
