### PR TITLE
Fixed Json deserialization (null string elements in lists)

### DIFF
--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -209,7 +209,14 @@ namespace RestSharp.Deserializers
 				}
 				else if (itemType == typeof(string))
 				{
-					list.Add(element.ToString());
+					if (element != null)
+					{
+						list.Add(element.ToString());
+					}
+					else
+					{
+						list.Add(element);
+					}
 				}
 				else
 				{


### PR DESCRIPTION
Null strings in lists crashed the deserialization. Now, null strings are
added as null elements to the product of JsonDeserializer.BuildList().
