### PR TITLE
improved the fuzzy matching logic

### DIFF
--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -269,6 +269,12 @@ namespace RestSharp.Deserializers
 				elements = root.Descendants().Where(e => e.Name.LocalName.RemoveUnderscoresAndDashes() == name);
 			}
 
+            if (!elements.Any())
+            {
+                var lowerName = name.ToLower().AsNamespaced(Namespace);
+                elements = root.Descendants().Where(e => e.Name.LocalName.RemoveUnderscoresAndDashes() == lowerName);
+            }
+
 			PopulateListFromElements(t, elements, list);
 
 			// get properties too, not just list items


### PR DESCRIPTION
Had an issue trying to parse the following:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<testing_applications type="array">
  <testing_application>
    <average_time_to_process type="integer">213</average_time_to_process>
    <business>false</business>
    <result_type>email</result_type>
    <supports_content_blocking>false</supports_content_blocking>
    <desktop_client>false</desktop_client>
    <status>0</status>
    <default>false</default>
    <platform_name>Web-based</platform_name>
    <platform_long_name>Web-based</platform_long_name>
    <application_code>hotmail</application_code>
    <application_long_name>Live Hotmail</application_long_name>
  </testing_application>
  ...
</testing_applications>
```

Into a List<> of classes like this:

``` c#
    public class TestingApplication
    {
        public string ApplicationLongName { get; set; }
        public string ApplicationCode { get; set; }
        public string PlatformName { get; set; }
        public string ResultType { get; set; }
    }
```

So I improved the logic in HandleListDerivative to match the underscores and ignore case like is done is some other places.
