### PR TITLE
Don't crash on captive networks that intercept SSL

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -192,23 +192,22 @@ namespace RestSharp
 					}
 				}
 			}
-			catch (WebException ex)
-			{
-				if (ex.Status == WebExceptionStatus.RequestCanceled)
-				{
-					var response = new HttpResponse {ResponseStatus = ResponseStatus.TimedOut};
-					ExecuteCallback(response, callback);
-					return;
-				}
-			}
 			catch (Exception ex)
 			{
-				var response = new HttpResponse
+				HttpResponse response;
+				if (ex is WebException && ((WebException)ex).Status == WebExceptionStatus.RequestCanceled)
 				{
-					ErrorMessage = ex.Message,
-					ErrorException = ex,
-					ResponseStatus = ResponseStatus.Error
-				};
+					response = new HttpResponse {ResponseStatus = ResponseStatus.TimedOut};
+				}
+				else
+				{
+					response = new HttpResponse
+					{
+						ErrorMessage = ex.Message,
+						ErrorException = ex,
+						ResponseStatus = ResponseStatus.Error
+					};
+				}
 				ExecuteCallback(response, callback);
 				return;
 			}
@@ -297,20 +296,18 @@ namespace RestSharp
 					ExecuteCallback(response, callback);
 				});
 			}
-			catch(WebException ex)
-			{
-				if(ex.Status == WebExceptionStatus.RequestCanceled)
-				{
-					response.ResponseStatus = ResponseStatus.Aborted;
-					ExecuteCallback(response, callback);
-					return;
-				}
-			}
 			catch(Exception ex)
 			{
-				response.ErrorMessage = ex.Message;
-				response.ErrorException = ex;
-				response.ResponseStatus = ResponseStatus.Error;
+				if(ex is WebException && ((WebException)ex).Status == WebExceptionStatus.RequestCanceled)
+				{
+					response.ResponseStatus = ResponseStatus.Aborted;
+				}
+				else
+				{
+					response.ErrorMessage = ex.Message;
+					response.ErrorException = ex;
+					response.ResponseStatus = ResponseStatus.Error;
+				}
 				ExecuteCallback(response, callback);
 			}
 		}


### PR DESCRIPTION
Some captive WiFi networks intercept SSL traffic using an untrusted
certificate. This causes HttpWebRequest.EndGetRequestStream to throw a
TrustFailure WebException with the following message:

```
The underlying connection was closed: Could not establish trust
relationship for the SSL/TLS secure channel.
```

Http.RequestStreamCallback was ignoring this exception, which caused us
to call HttpWebRequest.BeginGetResponse even though we hadn't written
the request body to the request stream. This caused a
ProtocolViolationException to be thrown and was the cause of the crash.

We now handle all kinds of exceptions (and still special-case
RequestCanceled exceptions). I made a similar change in
Http.ResponseCallback even though I didn't personally run into a bug
there.
