### PR TITLE
Extend NtlmAuthenticator so that it can also impersonate a user

### DIFF
--- a/RestSharp/Authenticators/NtlmAuthenticator.cs
+++ b/RestSharp/Authenticators/NtlmAuthenticator.cs
@@ -14,18 +14,50 @@
 //   limitations under the License. 
 #endregion
 
+using System;
+using System.Net;
+
 #if FRAMEWORK
 
 namespace RestSharp
 {
 	/// <summary>
-	/// Tries to Authenticate with the credentials of the currently logged in user
+	/// Tries to Authenticate with the credentials of the currently logged in user, or impersonate a user
 	/// </summary>
 	public class NtlmAuthenticator : IAuthenticator
 	{
-		public void Authenticate(IRestClient client, IRestRequest request)
+	    private readonly ICredentials credentials;
+
+        /// <summary>
+        /// Authenticate with the credentials of the currently logged in user
+        /// </summary>
+        public NtlmAuthenticator()
+            : this(CredentialCache.DefaultCredentials)
+	    {
+	    }
+
+        /// <summary>
+        /// Authenticate by impersonation
+        /// </summary>
+        /// <param name="username"></param>
+        /// <param name="password"></param>
+	    public NtlmAuthenticator(string username, string password) : this(new NetworkCredential(username, password))
+	    {
+	    }
+
+        /// <summary>
+        /// Authenticate by impersonation, using an existing <c>ICredentials</c> instance
+        /// </summary>
+        /// <param name="credentials"></param>
+	    public NtlmAuthenticator(ICredentials credentials)
+	    {
+	        if (credentials == null) throw new ArgumentNullException("credentials");
+	        this.credentials = credentials;
+	    }
+
+	    public void Authenticate(IRestClient client, IRestRequest request)
 		{
-			request.Credentials = System.Net.CredentialCache.DefaultCredentials;
+			request.Credentials = credentials;
 		}
 	}
 }


### PR DESCRIPTION
Extend NtlmAuthenticator so that it can also impersonate a user, and not just use the currently logged in user.

See discussion here: http://groups.google.com/group/restsharp/browse_thread/thread/c546342911e3387e/0d443a4b55db1614
