### PR TITLE
Add support for mapping JSON objects to Dictionary<string, string> when ...

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -485,6 +485,20 @@ namespace RestSharp.Tests
 			Assert.Equal(bd["ThingBlue"], "ThingBlue");
 		}
 
+		[Fact]
+		public void Can_Deserialize_To_Dictionary_String_String_With_Dynamic_Values ()
+		{
+			var doc = CreateDynamicJsonStringDictionary ();
+			var d = new JsonDeserializer ();
+			var response = new RestResponse { Content = doc };
+			var bd = d.Deserialize<Dictionary<string, string>> (response);
+
+			Assert.Equal ("[\"Value1\",\"Value2\"]", bd["Thing1"]);
+			Assert.Equal ("Thing2", bd["Thing2"]);
+			Assert.Equal ("{\"Name\":\"ThingRed\",\"Color\":\"Red\"}", bd["ThingRed"]);
+			Assert.Equal ("{\"Name\":\"ThingBlue\",\"Color\":\"Blue\"}", bd["ThingBlue"]);
+		}
+
 		private string CreateJsonWithUnderscores()
 		{
 			var doc = new JObject();
@@ -654,6 +668,16 @@ namespace RestSharp.Tests
 			doc["ThingRed"] = "ThingRed";
 			doc["ThingBlue"] = "ThingBlue";
 			return doc.ToString();
+		}
+
+		public string CreateDynamicJsonStringDictionary ()
+		{
+			var doc = new JObject ();
+			doc["Thing1"] = new JArray () { "Value1", "Value2" };
+			doc["Thing2"] = "Thing2";
+			doc["ThingRed"] = new JObject (new JProperty ("Name", "ThingRed"), new JProperty ("Color", "Red"));
+			doc["ThingBlue"] = new JObject (new JProperty("Name", "ThingBlue"), new JProperty ("Color", "Blue"));
+			return doc.ToString ();
 		}
 	}
 }

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -246,7 +246,7 @@ namespace RestSharp.Deserializers
 			}
 			else if (type == typeof(string))
 			{
-				instance = (string)element;
+				instance = element.ToString();
 			}
 			else
 			{


### PR DESCRIPTION
...the field values are different for each field, e.g. HAL _embedded object.

The HAL spec (https://github.com/mikekelly/hal-rfc) allows arbitrary "sub-resources" to be embedded in an object's "_embedded" property, e.g.:

```
{
  "_embedded": {
    "http://api.server.com/rel/dogs": [ { "name": "scruffy" }, { "name": "fluffy" } ],
    "http://api.server.com/rel/favorite_dog": { "name": "scruffy" }
  }
}
```

Because we may have arbitrary properties for the "_embedded" field (since the field names are the 'hypermedia relationship types") and the _values_ can be any arbitrary valid JSON object, we really have no choice but to deserialize this to a type like:

```
public class DogOwner {
  public Dictionary<String, String> _embedded { get; set; }
}
```

And then later deserialize a given dictionary _value_ once we know the type based on the relationship type.

This change allows such a functionality by calling `ToString ()` instead of casting to `string` as is done currently,.
