### PR TITLE
MonoTouch: Issue 293: JsonDeserialzer crashes on generic lists

### DIFF
--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -198,7 +198,7 @@ namespace RestSharp.Deserializers
 		private IList BuildList(Type type, object parent)
 		{
 			var list = (IList)Activator.CreateInstance(type);
-			var listType = type.GetInterfaces().First(x => x.GetGenericTypeDefinition() == typeof(IList<>));
+			var listType = type.GetInterfaces().First(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IList<>));
 			var itemType = listType.GetGenericArguments()[0];
 
 			if (parent is IList) {


### PR DESCRIPTION
Bug records:

https://github.com/restsharp/RestSharp/issues/293

https://bugzilla.xamarin.com/show_bug.cgi?id=6031

In MonoTouch, the changed line of code (without the change) causes an issue, as the list of interfaces CAN include non-generic types, and the ordering is not fixed, so you can get a non-generic type first. Calling GetGenericTypeDefinition on a non-generic crashes things.

If the code checks for it being generic first:

var listType = type.GetInterfaces().First(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IList<>));

then it doesn't fail.
