### PR TITLE
Underscore prefix

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -291,6 +291,20 @@ namespace RestSharp.Tests
 		  }
 
 		[Fact]
+		public void Can_Deserialize_Names_With_Underscore_Prefix()
+		{
+			var data = File.ReadAllText(Path.Combine("SampleData", "underscore_prefix.txt"));
+			var response = new RestResponse { Content = data };
+			var json = new JsonDeserializer();
+			json.RootElement = "User";
+
+			var output = json.Deserialize<SOUser>(response);
+
+			Assert.Equal("John Sheehan", output.DisplayName);
+			Assert.Equal(1786, output.Id);
+		}
+
+		[Fact]
 		public void Can_Deserialize_Names_With_Underscores_With_Default_Root()
 		{
 			var doc = CreateJsonWithUnderscores();

--- a/RestSharp.Tests/RestSharp.Tests.csproj
+++ b/RestSharp.Tests/RestSharp.Tests.csproj
@@ -112,6 +112,9 @@
     <Content Include="SampleData\boolean_from_number.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="SampleData\underscore_prefix.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="SampleData\datetimes.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/RestSharp.Tests/SampleData/underscore_prefix.txt
+++ b/RestSharp.Tests/SampleData/underscore_prefix.txt
@@ -1,0 +1,18 @@
+﻿{
+   "User":{
+      "_id":1786,
+      "_displayName":"John Sheehan",
+      "Reputation":18332,
+      "CreationDate":1219071163,
+      "_displayName":"John Sheehan",
+      "EmailHash":"lkdsafadfjsadfkjlsdjflkjdsf",
+      "Age":"28",
+      "LastAccessDate":1269715453,
+      "WebsiteUrl":"http://john-sheehan.com/blog",
+      "Location":"Minnesota",
+      "AboutMe":"<h2><a href=\"http://twitter.com/johnsheehan\" rel=\"nofollow\">Follow me on Twitter</a></h2>\r\n\r\n<h2><a href=\"http://john-sheehan.com/blog\" rel=\"nofollow\">Read my blog</a></h2>\r\n\r\n<h2>Visit <a href=\"http://managedassembly.com\" rel=\"nofollow\">managedassembly.com</a> - A community for .NET developers.</h2>\r\n\r\n<p>I am the founder of <a href=\"http://rimsystems.com\" rel=\"nofollow\">RIM Systems</a>, maker of <a href=\"http://snapleague.com\" rel=\"nofollow\">SnapLeague</a>, a web-based league management system for recreational athletics.</p>",
+      "Views":1639,
+      "UpVotes":1665,
+      "DownVotes":427
+   }
+}

--- a/RestSharp/Extensions/StringExtensions.cs
+++ b/RestSharp/Extensions/StringExtensions.cs
@@ -348,8 +348,8 @@ namespace RestSharp.Extensions
 			// try name with underscore prefix
 			yield return name.AddUnderscorePrefix();
 
-			// try name with underscore prefix with lower case
-			yield return name.AddUnderscorePrefix().ToLower(culture);
+			// try name with underscore prefix, using camel case
+			yield return name.ToCamelCase(culture).AddUnderscorePrefix();
 		}
 	}
 }


### PR DESCRIPTION
This implementation will add support to match a JSON field with an underscore prefix to properties without the underscore. The case in particular I wanted to fix was to map a "_id" field to an "Id" property.

I believe this can also address issue 230: https://github.com/restsharp/RestSharp/issues/230
