### PR TITLE
Made BaseUrl property virtual

### DIFF
--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -261,7 +261,7 @@ namespace RestSharp
 		/// <example>
 		/// client.BaseUrl = "http://example.com";
 		/// </example>
-		public string BaseUrl
+		public virtual string BaseUrl
 		{
 			get
 			{


### PR DESCRIPTION
I have a settings object that is the one true source for `BaseUrl`. I'd rather avoid having to observe changes to that object in order to set the `BaseUrl` property on the `RestClient`. Instead, I have a derived `MyRestClient` that sets `BaseUrl` to the value of my settings object. If `BaseUrl` is virtual, I can do this. :)
