### PR TITLE
Avoid potential NullReferenceException

### DIFF
--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -270,7 +270,7 @@ namespace RestSharp
 			set
 			{
 				_baseUrl = value;
-				if (_baseUrl.EndsWith("/"))
+				if (_baseUrl != null && _baseUrl.EndsWith("/"))
 				{
 					_baseUrl = _baseUrl.Substring(0, _baseUrl.Length - 1);
 				}


### PR DESCRIPTION
If someone sets `BaseUrl` to null, it shouldn't throw a `NullReferenceException`. Either it's an `InvalidOperationException` or it should just set the value to null and not complain.

I took the latter approach.
