### PR TITLE
Fix problem with overriding request defaults

### DIFF
--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -34,6 +34,9 @@ namespace RestSharp
 	/// </summary>
 	public partial class RestClient : IRestClient
 	{
+		// silverlight friendly way to get current version
+		static readonly Version version = new AssemblyName(Assembly.GetExecutingAssembly().FullName).Version;
+
 		public IHttpFactory HttpFactory = new SimpleFactory<Http>();
 
 		/// <summary>
@@ -57,12 +60,6 @@ namespace RestSharp
 			AddHandler("text/xml", new XmlDeserializer());
 			AddHandler("*", new XmlDeserializer());
 
-			// silverlight friendly way to get current version
-			var assembly = Assembly.GetExecutingAssembly();
-			AssemblyName assemblyName = new AssemblyName(assembly.FullName);
-			var version = assemblyName.Version;
-
-			UserAgent = "RestSharp " + version.ToString();
 			FollowRedirects = true;
 		}
 
@@ -363,11 +360,9 @@ namespace RestSharp
 			}
 
 			http.Url = BuildUri(request);
-			
-			if(UserAgent.HasValue())
-			{
-				http.UserAgent = UserAgent;
-			}
+
+			var userAgent = UserAgent ?? http.UserAgent;
+			http.UserAgent = userAgent.HasValue() ? userAgent : "RestSharp " + version.ToString();
 
 			var timeout = request.Timeout > 0 ? request.Timeout : Timeout;
 			if (timeout > 0)


### PR DESCRIPTION
Hi all! It's me again. 

The code I replaced was the following line:

```
http.Timeout = request.Timeout == 0 ? Timeout : request.Timeout;
```

Note that if `request.Timeout` and `this.Timeout` are both `0`, this code would set `http.Timeout` to `0`, overriding whatever value it might have been already.

_What? "`http.Timeout` is by default `0` so this is a noop?" you say?_

In the immortal words of Bart Simpson, au contraire, mon frère! You can't know that. RestSharp provides an extensibility point via the `HttpFactory` property of `RestClient` which allows you to substitute your own `IHttpFactory`.

This is how I found the issue because I overrode the `IHttpFactory` so that I could supply some defaults universally - whether I'm using an instance of `RestClient` or `Http` to make the request.

This pull request makes it so you simply don't set the property unless the `Timeout` of the request or the `RestClient` is greater than `0`.
