### PR TITLE
Added AttemptPostFilesWithoutBuffering flag for large file uploads

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -391,6 +391,12 @@ namespace RestSharp
 			{
 				webRequest.MaximumAutomaticRedirections = MaxRedirects.Value;
 			}
+
+			if (AttemptPostFilesWithoutBuffering)
+			{
+				webRequest.SendChunked = true;
+				webRequest.AllowWriteStreamBuffering = false;
+			}
 #endif
 
 #if !SILVERLIGHT

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -230,6 +230,12 @@ namespace RestSharp
 				webRequest.MaximumAutomaticRedirections = MaxRedirects.Value; 
 			}
 
+			if (AttemptPostFilesWithoutBuffering)
+			{
+				webRequest.SendChunked = true;
+				webRequest.AllowWriteStreamBuffering = false;
+			}
+
 			return webRequest;
 		}
 	}

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -156,6 +156,14 @@ namespace RestSharp
 		/// Proxy info to be sent with request
 		/// </summary>
 		public IWebProxy Proxy { get; set; }
+
+		/// <summary>
+		/// If the framework you are using defaults to buffering the entire 
+		/// file you are uploading in memory before transmitting (.NET 4.0), 
+		/// set this flag to True to attempt to set flags that should make the 
+		/// file get streamed to HTTP directly from disk.  
+		/// </summary>
+		public bool AttemptPostFilesWithoutBuffering { get; set; }
 #endif
 
 		/// <summary>
@@ -172,6 +180,9 @@ namespace RestSharp
 
 			AddSharedHeaderActions();
 			AddSyncHeaderActions();
+#if FRAMEWORK
+			AttemptPostFilesWithoutBuffering = false;
+#endif
 		}
 
 		partial void AddSyncHeaderActions();

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -63,6 +63,7 @@ namespace RestSharp
 		HttpResponse Patch();
 
 		IWebProxy Proxy { get; set; }
+		bool AttemptPostFilesWithoutBuffering { get; set; }
 #endif
 	}
 }

--- a/RestSharp/IRestRequest.cs
+++ b/RestSharp/IRestRequest.cs
@@ -225,5 +225,17 @@ namespace RestSharp
 
 		Action<IRestResponse> OnBeforeDeserialization { get; set; }
 		void IncreaseNumAttempts();
+
+#if FRAMEWORK
+
+		/// <summary>
+		/// If the framework you are using defaults to buffering the entire 
+		/// file you are uploading in memory before transmitting (.NET 4.0), 
+		/// set this flag to True to attempt to set flags that should make the 
+		/// file get streamed to HTTP directly from disk.  
+		/// </summary>
+		bool AttemptPostFilesWithoutBuffering { get; set; }
+
+#endif
 	}
 }

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -441,6 +441,9 @@ namespace RestSharp
 				http.RequestBody = body.Value.ToString();
 				http.RequestContentType = body.Name;
 			}
+#if FRAMEWORK
+			http.AttemptPostFilesWithoutBuffering = request.AttemptPostFilesWithoutBuffering;
+#endif
 		}
 
 		private RestResponse ConvertToRestResponse(IRestRequest request, HttpResponse httpResponse)

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -52,6 +52,9 @@ namespace RestSharp
 			JsonSerializer = new JsonSerializer();
 
 			OnBeforeDeserialization = r => { };
+#if FRAMEWORK
+			AttemptPostFilesWithoutBuffering = false;
+#endif
 		}
 
 		/// <summary>
@@ -464,5 +467,18 @@ namespace RestSharp
 		{
 			get { return _attempts; }
 		}
+
+#if FRAMEWORK
+
+		/// <summary>
+		/// If the framework you are using defaults to buffering the entire 
+		/// file you are uploading in memory before transmitting (.NET 4.0), 
+		/// set this flag to True to set flags that should make the 
+		/// file get streamed to HTTP directly from disk.  
+		/// </summary>
+		public bool AttemptPostFilesWithoutBuffering { get; set; }
+
+#endif
+
 	}
 }


### PR DESCRIPTION
Exposed a new flag in the RestRequest interface called
AttemptPostFilesWithoutBuffering.  This allows the client to try to
upload files WITHOUT buffering the entire file in memory.  This is
important when trying to upload because extremely large files or
simultaneous uploads could easily exhaust system memory.
