### PR TITLE
Added support for non-standard HTTP methods

### DIFF
--- a/RestSharp/Enum.cs
+++ b/RestSharp/Enum.cs
@@ -48,9 +48,7 @@ namespace RestSharp
 		DELETE,
 		HEAD,
 		OPTIONS,
-		PATCH,
-        COPY,
-        MOVE,
+		PATCH
 	}
 
 	/// <summary>

--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -77,15 +77,25 @@ namespace RestSharp
 			return PutPostInternalAsync("PATCH", action);
 		}
 
-	    public HttpWebRequest CopyAsync(Action<HttpResponse> action)
-	    {
-            return PutPostInternalAsync("COPY", action);
-	    }
-
-	    public HttpWebRequest MoveAsync(Action<HttpResponse> action)
-	    {
-            return PutPostInternalAsync("MOVE", action);
+        /// <summary>
+        /// Execute an async POST-style request with the specified HTTP Method.  
+        /// </summary>
+        /// <param name="httpMethod">The HTTP method to execute.</param>
+        /// <returns></returns>
+        public HttpWebRequest AsPostAsync(Action<HttpResponse> action, string httpMethod)
+        {
+            return PutPostInternalAsync(httpMethod.ToUpperInvariant(), action);
         }
+
+        /// <summary>
+        /// Execute an async GET-style request with the specified HTTP Method.  
+        /// </summary>
+        /// <param name="httpMethod">The HTTP method to execute.</param>
+        /// <returns></returns>
+        public HttpWebRequest AsGetAsync(Action<HttpResponse> action, string httpMethod)
+	    {
+            return GetStyleMethodInternalAsync(httpMethod.ToUpperInvariant(), action);
+	    }
 
 	    private HttpWebRequest GetStyleMethodInternalAsync(string method, Action<HttpResponse> callback)
 		{

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -79,22 +79,6 @@ namespace RestSharp
 			return GetStyleMethodInternal("DELETE");
 		}
 
-        /// <summary>
-        /// Execute a COPY request
-        /// </summary>
-        public HttpResponse Copy()
-        {
-            return PostPutInternal("COPY");
-        }
-
-        /// <summary>
-        /// Execute a MOVE request
-        /// </summary>
-        public HttpResponse Move()
-        {
-            return PostPutInternal("MOVE");
-        }
-
 		/// <summary>
 		/// Execute a PATCH request
 		/// </summary>
@@ -103,7 +87,27 @@ namespace RestSharp
 			return PostPutInternal("PATCH");
 		}
 
-		private HttpResponse GetStyleMethodInternal(string method)
+        /// <summary>
+        /// Execute a GET-style request with the specified HTTP Method.  
+        /// </summary>
+        /// <param name="httpMethod">The HTTP method to execute.</param>
+        /// <returns></returns>
+	    public HttpResponse AsGet(string httpMethod)
+	    {
+            return GetStyleMethodInternal(httpMethod.ToUpperInvariant());
+        }
+
+        /// <summary>
+        /// Execute a POST-style request with the specified HTTP Method.  
+        /// </summary>
+        /// <param name="httpMethod">The HTTP method to execute.</param>
+        /// <returns></returns>
+        public HttpResponse AsPost(string httpMethod)
+        {
+            return PostPutInternal(httpMethod.ToUpperInvariant());
+        }
+
+	    private HttpResponse GetStyleMethodInternal(string method)
 		{
 			var webRequest = ConfigureWebRequest(method, Url);
 

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -52,8 +52,8 @@ namespace RestSharp
 		HttpWebRequest PostAsync(Action<HttpResponse> action);
 		HttpWebRequest PutAsync(Action<HttpResponse> action);
         HttpWebRequest PatchAsync(Action<HttpResponse> action);
-        HttpWebRequest CopyAsync(Action<HttpResponse> action);
-        HttpWebRequest MoveAsync(Action<HttpResponse> action);
+        HttpWebRequest AsPostAsync(Action<HttpResponse> action, string httpMethod);
+        HttpWebRequest AsGetAsync(Action<HttpResponse> action, string httpMethod);
 
 #if FRAMEWORK
 		HttpResponse Delete();
@@ -63,8 +63,8 @@ namespace RestSharp
 		HttpResponse Post();
 		HttpResponse Put();
         HttpResponse Patch();
-        HttpResponse Copy();
-        HttpResponse Move();
+        HttpResponse AsPost(string httpMethod);
+        HttpResponse AsGet(string httpMethod);
 
 		IWebProxy Proxy { get; set; }
 #endif

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -77,5 +77,44 @@ namespace RestSharp
 #endif
 
 		Uri BuildUri(IRestRequest request);
+
+	    /// <summary>
+	    /// Executes a GET-style request and callback asynchronously, authenticating if needed
+	    /// </summary>
+	    /// <param name="request">Request to be executed</param>
+	    /// <param name="callback">Callback function to be executed upon completion providing access to the async handle.</param>
+	    /// <param name="httpMethod">The HTTP method to execute</param>
+	    RestRequestAsyncHandle ExecuteAsyncGet(IRestRequest request, Action<IRestResponse, RestRequestAsyncHandle> callback, string httpMethod);
+
+	    /// <summary>
+	    /// Executes a POST-style request and callback asynchronously, authenticating if needed
+	    /// </summary>
+	    /// <param name="request">Request to be executed</param>
+	    /// <param name="callback">Callback function to be executed upon completion providing access to the async handle.</param>
+	    /// <param name="httpMethod">The HTTP method to execute</param>
+	    RestRequestAsyncHandle ExecuteAsyncPost(IRestRequest request, Action<IRestResponse, RestRequestAsyncHandle> callback, string httpMethod);
+
+	    /// <summary>
+	    /// Executes a GET-style request and callback asynchronously, authenticating if needed
+	    /// </summary>
+	    /// <typeparam name="T">Target deserialization type</typeparam>
+	    /// <param name="request">Request to be executed</param>
+	    /// <param name="callback">Callback function to be executed upon completion</param>
+	    /// <param name="httpMethod">The HTTP method to execute</param>
+	    RestRequestAsyncHandle ExecuteAsyncGet<T>(IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback, string httpMethod);
+
+	    /// <summary>
+	    /// Executes a GET-style request and callback asynchronously, authenticating if needed
+	    /// </summary>
+	    /// <typeparam name="T">Target deserialization type</typeparam>
+	    /// <param name="request">Request to be executed</param>
+	    /// <param name="callback">Callback function to be executed upon completion</param>
+	    /// <param name="httpMethod">The HTTP method to execute</param>
+	    RestRequestAsyncHandle ExecuteAsyncPost<T>(IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback, string httpMethod);
+
+	    IRestResponse ExecuteAsGet(IRestRequest request, string httpMethod);
+	    IRestResponse ExecuteAsPost(IRestRequest request, string httpMethod);
+	    IRestResponse<T> ExecuteAsGet<T>(IRestRequest request, string httpMethod) where T : new();
+	    IRestResponse<T> ExecuteAsPost<T>(IRestRequest request, string httpMethod) where T : new();
 	}
 }

--- a/RestSharp/RestClient.Async.cs
+++ b/RestSharp/RestClient.Async.cs
@@ -32,63 +32,81 @@ namespace RestSharp
 		/// <param name="callback">Callback function to be executed upon completion providing access to the async handle.</param>
 		public virtual RestRequestAsyncHandle ExecuteAsync(IRestRequest request, Action<IRestResponse, RestRequestAsyncHandle> callback)
 		{
-			var http = HttpFactory.Create();
-			AuthenticateIfNeeded(this, request);
+	        string method = Enum.GetName(typeof (Method), request.Method);
+            switch (request.Method)
+            {
+                case Method.PATCH:
+                case Method.POST:
+                case Method.PUT:
+                    return ExecuteAsync(request, callback, method, DoAsGetAsync);
 
-			// add Accept header based on registered deserializers
-			var accepts = string.Join(", ", AcceptTypes.ToArray());
-			AddDefaultParameter("Accept", accepts, ParameterType.HttpHeader);
-
-			ConfigureHttp(request, http);
-
-			HttpWebRequest webRequest = null;
-			var asyncHandle = new RestRequestAsyncHandle();
-
-			Action<HttpResponse> response_cb = r => ProcessResponse(request, r, asyncHandle, callback);
-
-			if (UseSynchronizationContext && SynchronizationContext.Current != null) {
-				var ctx = SynchronizationContext.Current;
-				var cb = response_cb;
-
-				response_cb = resp => ctx.Post(s => cb(resp), null);
-			}
-			
-			switch(request.Method)
-			{
-				case Method.GET:
-					webRequest = http.GetAsync(response_cb);
-					break;
-				case Method.POST:
-					webRequest = http.PostAsync(response_cb);
-					break;
-				case Method.PUT:
-					webRequest = http.PutAsync(response_cb);
-					break;
-				case Method.DELETE:
-					webRequest = http.DeleteAsync(response_cb);
-					break;
-				case Method.HEAD:
-					webRequest = http.HeadAsync(response_cb);
-					break;
-				case Method.OPTIONS:
-					webRequest = http.OptionsAsync(response_cb);
-					break;
-				case Method.PATCH:
-					webRequest = http.PatchAsync(response_cb);
-					break;
-                case Method.COPY:
-                    webRequest = http.CopyAsync(response_cb);
-                    break;
-                case Method.MOVE:
-                    webRequest = http.MoveAsync(response_cb);
-                    break;
+                default:
+                    return ExecuteAsync(request, callback, method, DoAsPostAsync);
             }
-			
-			asyncHandle.WebRequest = webRequest;
-			return asyncHandle;
 		}
 
-		private void ProcessResponse(IRestRequest request, HttpResponse httpResponse, RestRequestAsyncHandle asyncHandle, Action<IRestResponse, RestRequestAsyncHandle> callback)
+        /// <summary>
+        /// Executes a GET-style request and callback asynchronously, authenticating if needed
+        /// </summary>
+        /// <param name="request">Request to be executed</param>
+        /// <param name="callback">Callback function to be executed upon completion providing access to the async handle.</param>
+        /// <param name="httpMethod">The HTTP method to execute</param>
+        public virtual RestRequestAsyncHandle ExecuteAsyncGet(IRestRequest request, Action<IRestResponse, RestRequestAsyncHandle> callback, string httpMethod)
+        {
+            return ExecuteAsync(request, callback, httpMethod, DoAsPostAsync);
+        }
+
+        /// <summary>
+        /// Executes a POST-style request and callback asynchronously, authenticating if needed
+        /// </summary>
+        /// <param name="request">Request to be executed</param>
+        /// <param name="callback">Callback function to be executed upon completion providing access to the async handle.</param>
+        /// <param name="httpMethod">The HTTP method to execute</param>
+        public virtual RestRequestAsyncHandle ExecuteAsyncPost(IRestRequest request, Action<IRestResponse, RestRequestAsyncHandle> callback, string httpMethod)
+        {
+            request.Method = Method.POST;  // Required by RestClient.BuildUri... 
+            return ExecuteAsync(request, callback, httpMethod, DoAsGetAsync);
+        }
+
+	    private RestRequestAsyncHandle ExecuteAsync(IRestRequest request, Action<IRestResponse, RestRequestAsyncHandle> callback, string httpMethod, Func<IHttp, Action<HttpResponse>, string, HttpWebRequest> getWebRequest)
+	    {
+	        var http = HttpFactory.Create();
+	        AuthenticateIfNeeded(this, request);
+
+	        // add Accept header based on registered deserializers
+	        var accepts = string.Join(", ", AcceptTypes.ToArray());
+	        AddDefaultParameter("Accept", accepts, ParameterType.HttpHeader);
+
+	        ConfigureHttp(request, http);
+
+	        var asyncHandle = new RestRequestAsyncHandle();
+
+	        Action<HttpResponse> response_cb = r => ProcessResponse(request, r, asyncHandle, callback);
+
+	        if (UseSynchronizationContext && SynchronizationContext.Current != null)
+	        {
+	            var ctx = SynchronizationContext.Current;
+	            var cb = response_cb;
+
+	            response_cb = resp => ctx.Post(s => cb(resp), null);
+	        }
+
+            asyncHandle.WebRequest = getWebRequest(http, response_cb, httpMethod);
+	        return asyncHandle;
+	    }
+
+	    private static HttpWebRequest DoAsGetAsync(IHttp http, Action<HttpResponse> response_cb, string method)
+	    {
+	        return http.AsGetAsync(response_cb, method);
+	    }
+
+	    private static HttpWebRequest DoAsPostAsync(IHttp http, Action<HttpResponse> response_cb, string method)
+	    {
+	        return http.AsPostAsync(response_cb, method);
+	    }
+
+
+	    private void ProcessResponse(IRestRequest request, HttpResponse httpResponse, RestRequestAsyncHandle asyncHandle, Action<IRestResponse, RestRequestAsyncHandle> callback)
 		{
 			var restResponse = ConvertToRestResponse(request, httpResponse);
 			callback(restResponse, asyncHandle);
@@ -102,16 +120,42 @@ namespace RestSharp
 		/// <param name="callback">Callback function to be executed upon completion</param>
 		public virtual RestRequestAsyncHandle ExecuteAsync<T>(IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback)
 		{
-			return ExecuteAsync(request, (response, asyncHandle) =>
-			{
-				IRestResponse<T> restResponse = response as RestResponse<T>;
-				if (response.ResponseStatus != ResponseStatus.Aborted)
-				{
-					restResponse = Deserialize<T>(request, response);
-				}
-
-				callback(restResponse, asyncHandle);
-			});
+			return ExecuteAsync(request, (response, asyncHandle) => DeserializeResponse(request, callback, response, asyncHandle));
 		}
+
+        /// <summary>
+        /// Executes a GET-style request and callback asynchronously, authenticating if needed
+        /// </summary>
+        /// <typeparam name="T">Target deserialization type</typeparam>
+        /// <param name="request">Request to be executed</param>
+        /// <param name="callback">Callback function to be executed upon completion</param>
+        /// <param name="httpMethod">The HTTP method to execute</param>
+        public virtual RestRequestAsyncHandle ExecuteAsyncGet<T>(IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback, string httpMethod)
+        {
+            return ExecuteAsyncGet(request, (response, asyncHandle) => DeserializeResponse(request, callback, response, asyncHandle), httpMethod);
+        }
+
+        /// <summary>
+        /// Executes a POST-style request and callback asynchronously, authenticating if needed
+        /// </summary>
+        /// <typeparam name="T">Target deserialization type</typeparam>
+        /// <param name="request">Request to be executed</param>
+        /// <param name="callback">Callback function to be executed upon completion</param>
+        /// <param name="httpMethod">The HTTP method to execute</param>
+        public virtual RestRequestAsyncHandle ExecuteAsyncPost<T>(IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback, string httpMethod)
+        {
+            return ExecuteAsyncPost(request, (response, asyncHandle) => DeserializeResponse(request, callback, response, asyncHandle), httpMethod);
+        }
+
+	    private void DeserializeResponse<T>(IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback, IRestResponse response, RestRequestAsyncHandle asyncHandle)
+	    {
+	        IRestResponse<T> restResponse = response as RestResponse<T>;
+	        if (response.ResponseStatus != ResponseStatus.Aborted)
+	        {
+	            restResponse = Deserialize<T>(request, response);
+	        }
+
+	        callback(restResponse, asyncHandle);
+	    }
 	}
 }

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -315,9 +315,7 @@ namespace RestSharp
 
             if (request.Method != Method.POST 
                 && request.Method != Method.PUT 
-                && request.Method != Method.PATCH 
-                && request.Method != Method.COPY 
-                && request.Method != Method.MOVE)
+                && request.Method != Method.PATCH)
 			{
 				// build and attach querystring if this is a get-style request
 				if (request.Parameters.Any(p => p.Type == ParameterType.GetOrPost))

--- a/RestSharp/RestClientExtensions.cs
+++ b/RestSharp/RestClientExtensions.cs
@@ -69,18 +69,6 @@ namespace RestSharp
 			return client.ExecuteAsync<T>(request, callback);
 		}
 
-        public static RestRequestAsyncHandle CopyAsync<T>(this IRestClient client, IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback) where T : new()
-        {
-            request.Method = Method.COPY;
-            return client.ExecuteAsync<T>(request, callback);
-        }
-
-        public static RestRequestAsyncHandle MoveAsync<T>(this IRestClient client, IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback) where T : new()
-        {
-            request.Method = Method.MOVE;
-            return client.ExecuteAsync<T>(request, callback);
-        }
-
 		public static RestRequestAsyncHandle GetAsync(this IRestClient client, IRestRequest request, Action<IRestResponse, RestRequestAsyncHandle> callback)
 		{
 			request.Method = Method.GET;
@@ -122,19 +110,6 @@ namespace RestSharp
             request.Method = Method.DELETE;
             return client.ExecuteAsync(request, callback);
         }
-        
-        public static RestRequestAsyncHandle CopyAsync(this IRestClient client, IRestRequest request, Action<IRestResponse, RestRequestAsyncHandle> callback)
-        {
-            request.Method = Method.COPY;
-            return client.ExecuteAsync(request, callback);
-        }
-
-        public static RestRequestAsyncHandle MoveAsync(this IRestClient client, IRestRequest request, Action<IRestResponse, RestRequestAsyncHandle> callback)
-        {
-            request.Method = Method.MOVE;
-            return client.ExecuteAsync(request, callback);
-        }
-
 #if FRAMEWORK
 		public static IRestResponse<T> Get<T>(this IRestClient client, IRestRequest request) where T : new()
 		{
@@ -178,18 +153,6 @@ namespace RestSharp
             return client.Execute<T>(request);
         }
 
-        public static IRestResponse<T> Copy<T>(this IRestClient client, IRestRequest request) where T : new()
-        {
-            request.Method = Method.COPY;
-            return client.Execute<T>(request);
-        }
-
-        public static IRestResponse<T> Move<T>(this IRestClient client, IRestRequest request) where T : new()
-        {
-            request.Method = Method.MOVE;
-            return client.Execute<T>(request);
-        }
-
 		public static IRestResponse Get(this IRestClient client, IRestRequest request)
 		{
 			request.Method = Method.GET;
@@ -229,18 +192,6 @@ namespace RestSharp
         public static IRestResponse Delete(this IRestClient client, IRestRequest request)
         {
             request.Method = Method.DELETE;
-            return client.Execute(request);
-        }
-
-        public static IRestResponse Copy(this IRestClient client, IRestRequest request)
-        {
-            request.Method = Method.COPY;
-            return client.Execute(request);
-        }
-
-        public static IRestResponse Move(this IRestClient client, IRestRequest request)
-        {
-            request.Method = Method.MOVE;
             return client.Execute(request);
         }
 #endif


### PR DESCRIPTION
IHttp now supports non-standard HTTP methods ("COPY", "MOVE", "PROPFIND", etc.) through AsGet{Async} and AsPost{Async}.  These will take the httpMethod argument and apply it to the web request when it is built.  The AsGet/AsPost determines how parameters are applied to the request.  The changes in 29f2f7a and 88543d8 were reverted prior to committing a0f67ed.
