### PR TITLE
Fix for culture related issue on Windows Phone

### DIFF
--- a/RestSharp/Extensions/ReflectionExtensions.cs
+++ b/RestSharp/Extensions/ReflectionExtensions.cs
@@ -74,7 +74,7 @@ namespace RestSharp.Extensions
 
 		public static object ChangeType(this object source, Type newType, CultureInfo culture)
 		{
-#if FRAMEWORK
+#if FRAMEWORK || WINDOWS_PHONE
 			return Convert.ChangeType(source, newType, culture);
 #else
 			return Convert.ChangeType(source, newType, null);


### PR DESCRIPTION
JSON deserialization of values such as
{"latitude":59.9324,"longitude":10.8352}
failed for some cultures, since it used
the current culture instead of the one
set in the JsonDeserializer.

Forum thread:
https://groups.google.com/forum/?fromgroups=#!topic/restsharp/ZXuuPCg2Fkc
