### PR TITLE
Added the ability to control the DateTime format for individual properties.

### DIFF
--- a/RestSharp.Net4/RestSharp.Net4.csproj
+++ b/RestSharp.Net4/RestSharp.Net4.csproj
@@ -113,6 +113,9 @@
     <Compile Include="..\restsharp\authenticators\SimpleAuthenticator.cs">
       <Link>Authenticators\SimpleAuthenticator.cs</Link>
     </Compile>
+    <Compile Include="..\RestSharp\Deserializers\AsDateTimeFormatAttribute.cs">
+      <Link>Deserializers\AsDateTimeFormatAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\restsharp\deserializers\DeserializeAsAttribute.cs">
       <Link>Deserializers\DeserializeAsAttribute.cs</Link>
     </Compile>

--- a/RestSharp.Silverlight/RestSharp.Silverlight.csproj
+++ b/RestSharp.Silverlight/RestSharp.Silverlight.csproj
@@ -132,6 +132,9 @@
     <Compile Include="..\RestSharp\Authenticators\SimpleAuthenticator.cs">
       <Link>Authenticators\SimpleAuthenticator.cs</Link>
     </Compile>
+    <Compile Include="..\RestSharp\Deserializers\AsDateTimeFormatAttribute.cs">
+      <Link>Deserializers\AsDateTimeFormatAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\RestSharp\Deserializers\DeserializeAsAttribute.cs">
       <Link>Deserializers\DeserializeAsAttribute.cs</Link>
     </Compile>

--- a/RestSharp.WindowsPhone/RestSharp.WindowsPhone.csproj
+++ b/RestSharp.WindowsPhone/RestSharp.WindowsPhone.csproj
@@ -151,6 +151,9 @@
     <Compile Include="..\RestSharp\Compression\ZLib\ZLibStream.cs">
       <Link>Compression\ZLib\ZLibStream.cs</Link>
     </Compile>
+    <Compile Include="..\RestSharp\Deserializers\AsDateTimeFormatAttribute.cs">
+      <Link>Deserializers\AsDateTimeFormatAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\RestSharp\Deserializers\DeserializeAsAttribute.cs">
       <Link>Deserializers\DeserializeAsAttribute.cs</Link>
     </Compile>

--- a/RestSharp/Deserializers/AsDateTimeFormatAttribute.cs
+++ b/RestSharp/Deserializers/AsDateTimeFormatAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace RestSharp.Deserializers
+{
+    [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
+    public sealed class AsDateTimeFormatAttribute : Attribute
+    {
+        public string Format { get; set; }
+
+        public AsDateTimeFormatAttribute(string format)
+        {
+            Format = format;
+        }
+    }
+}

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -76,6 +76,12 @@ namespace RestSharp.Deserializers
 				var value = actualName != null ? data[actualName] : null;
 
 				if (value == null) continue;
+                
+				string customDateFormat = DateFormat;
+				var customDateAttribute = prop.GetAttribute<AsDateTimeFormatAttribute>();
+
+				if (customDateAttribute != null && !string.IsNullOrEmpty(customDateAttribute.Format))
+					customDateFormat = customDateAttribute.Format;
 
 				// check for nullable and extract underlying type
 				if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
@@ -83,7 +89,7 @@ namespace RestSharp.Deserializers
 					type = type.GetGenericArguments()[0];
 				}
 
-				prop.SetValue(target, ConvertValue(type, value), null);
+				prop.SetValue(target, ConvertValue(type, value, customDateFormat), null);
 			}
 		}
 
@@ -146,7 +152,7 @@ namespace RestSharp.Deserializers
 			return list;
 		}
 
-		private object ConvertValue(Type type, object value)
+		private object ConvertValue(Type type, object value, string dateTimeFormat = null)
 		{
 			var stringValue = Convert.ToString(value, Culture);
 
@@ -173,9 +179,9 @@ namespace RestSharp.Deserializers
 			else if (type == typeof(DateTime) || type == typeof(DateTimeOffset))
 			{
 				DateTime dt;
-				if (DateFormat.HasValue())
+				if (!string.IsNullOrEmpty(dateTimeFormat))
 				{
-					dt = DateTime.ParseExact(stringValue, DateFormat, Culture);
+					dt = DateTime.ParseExact(stringValue, dateTimeFormat, Culture);
 				}
 				else
 				{

--- a/RestSharp/Deserializers/XmlAttributeDeserializer.cs
+++ b/RestSharp/Deserializers/XmlAttributeDeserializer.cs
@@ -107,6 +107,12 @@ namespace RestSharp.Deserializers
 					isAttribute = options.Attribute;
 				}
 
+				string customDateFormat = DateFormat;
+				var customDateAttribute = prop.GetAttribute<AsDateTimeFormatAttribute>();
+
+				if (customDateAttribute != null && !string.IsNullOrEmpty(customDateAttribute.Format))
+					customDateFormat = customDateAttribute.Format;
+
 				var value = GetValueFromXml(root, name, isAttribute);
 
 				if (value == null)
@@ -166,9 +172,9 @@ namespace RestSharp.Deserializers
 				}
 				else if (type == typeof(DateTime))
 				{
-					if (DateFormat.HasValue())
+					if (!string.IsNullOrEmpty(customDateFormat))
 					{
-						value = DateTime.ParseExact(value.ToString(), DateFormat, Culture);
+						value = DateTime.ParseExact(value.ToString(), customDateFormat, Culture);
 					}
 					else
 					{

--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -101,6 +101,12 @@ namespace RestSharp.Deserializers
 				var name = prop.Name.AsNamespaced(Namespace);
 				var value = GetValueFromXml(root, name);
 
+				string customDateFormat = DateFormat;
+				var customDateAttribute = prop.GetAttribute<AsDateTimeFormatAttribute>();
+
+				if (customDateAttribute != null && !string.IsNullOrEmpty(customDateAttribute.Format))
+					customDateFormat = customDateAttribute.Format;
+
 				if (value == null)
 				{
 					// special case for inline list items
@@ -158,9 +164,9 @@ namespace RestSharp.Deserializers
 				}
 				else if (type == typeof(DateTime))
 				{
-					if (DateFormat.HasValue())
+					if (!string.IsNullOrEmpty(customDateFormat))
 					{
-						value = DateTime.ParseExact(value.ToString(), DateFormat, Culture);
+						value = DateTime.ParseExact(value.ToString(), customDateFormat, Culture);
 					}
 					else
 					{

--- a/RestSharp/RestSharp.csproj
+++ b/RestSharp/RestSharp.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Compression\ZLib\ZLibCodec.cs" />
     <Compile Include="Compression\ZLib\ZLibConstants.cs" />
     <Compile Include="Compression\ZLib\ZLibStream.cs" />
+    <Compile Include="Deserializers\AsDateTimeFormatAttribute.cs" />
     <Compile Include="Deserializers\JsonDeserializer.cs" />
     <Compile Include="Deserializers\DeserializeAsAttribute.cs" />
     <Compile Include="Deserializers\XmlAttributeDeserializer.cs" />


### PR DESCRIPTION
Some APIs are a collection of multiple APIs merged into one. This means that multiple DateTime formats can be used in the API - different ones on different properties in the same class. Using DateTimeFormat on the deserializer will still work, but it will be overwritten by the AsDateTimeFormat attribute on individual properties.
