### PR TITLE
Changes related to UserState

### DIFF
--- a/RestSharp/IRestRequest.cs
+++ b/RestSharp/IRestRequest.cs
@@ -224,6 +224,13 @@ namespace RestSharp
 		IRestRequest AddUrlSegment(string name, string value);
 
 		Action<IRestResponse> OnBeforeDeserialization { get; set; }
-		void IncreaseNumAttempts();
+
+	    /// <summary>
+	    /// Gets or sets a user-defined state object that contains information about a request and which can be later 
+	    /// retrieved when the request completes.
+	    /// </summary>
+	    object UserState { get; set; }
+
+	    void IncreaseNumAttempts();
 	}
 }

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -432,18 +432,18 @@ namespace RestSharp
 			handler.Namespace = request.XmlNamespace;
 
 			IRestResponse<T> response = new RestResponse<T>();
-			try
+            try
 			{
 			    response = raw.toAsyncResponse<T>();
 				response.Data = handler.Deserialize<T>(raw);
-				response.Request = request;
 			}
 			catch (Exception ex)
 			{
 				response.ResponseStatus = ResponseStatus.Error;
 				response.ErrorMessage = ex.Message;
 				response.ErrorException = ex;
-			}
+            }
+            response.Request = request;
 
 			return response;
 		}


### PR DESCRIPTION
The request property is now set regardless of whether the deserialization
succeeds or not. It's useful to have access to the user state, to know
which request failed.

Added UserState to IRestRequest interface.
