### PR TITLE
ExecuteAsync was not setting Proxy

### DIFF
--- a/RestSharp/RestClient.Sync.cs
+++ b/RestSharp/RestClient.Sync.cs
@@ -72,7 +72,6 @@ namespace RestSharp
 				var http = HttpFactory.Create();
 
 				ConfigureHttp(request, http);
-				ConfigureProxy(http);
 
 				response = ConvertToRestResponse(request, getResponse(http, httpMethod));
 				response.Request = request;

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -375,6 +375,8 @@ namespace RestSharp
 				http.RequestBody = body.Value.ToString();
 				http.RequestContentType = body.Name;
 			}
+
+			ConfigureProxy(http);
 		}
 
 		private RestResponse ConvertToRestResponse(IRestRequest request, HttpResponse httpResponse)


### PR DESCRIPTION
Added ConfigureProxy(http) to the end of ConfigureHttp(request, http).
Removed call to ConfigureProxy(http) in Execute().
