### PR TITLE
Add RequestBodyBytes.

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -163,6 +163,9 @@ namespace RestSharp
 
 		private long CalculateContentLength()
 		{
+			if (RequestBodyBytes != null)
+				return RequestBodyBytes.Length;
+
 			if (!HasFiles)
 			{
 				return _defaultEncoding.GetByteCount(RequestBody);
@@ -205,6 +208,10 @@ namespace RestSharp
 					if(HasFiles)
 					{
 						WriteMultipartFormData(requestStream);
+					}
+					else if (RequestBodyBytes != null)
+					{
+						requestStream.Write(RequestBodyBytes, 0, RequestBodyBytes.Length);
 					}
 					else
 					{

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -190,7 +190,7 @@ namespace RestSharp
 			if (!HasBody)
 				return;
 
-			var bytes = _defaultEncoding.GetBytes(RequestBody);
+			var bytes = RequestBodyBytes == null ? _defaultEncoding.GetBytes(RequestBody) : RequestBodyBytes;
 
 			webRequest.ContentLength = bytes.Length;
 

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -75,7 +75,7 @@ namespace RestSharp
 		{
 			get
 			{
-				return !string.IsNullOrEmpty(RequestBody);
+				return RequestBodyBytes != null || !string.IsNullOrEmpty(RequestBody);
 			}
 		}
 
@@ -146,6 +146,10 @@ namespace RestSharp
 		/// Content type of the request body.
 		/// </summary>
 		public string RequestContentType { get; set; }
+		/// <summary>
+		/// An alternative to RequestBody, for when the caller already has the byte array.
+		/// </summary>
+		public byte[] RequestBodyBytes { get; set; }
 		/// <summary>
 		/// URL to call for this request
 		/// </summary>

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -43,6 +43,11 @@ namespace RestSharp
 		string RequestBody { get; set; }
 		string RequestContentType { get; set; }
 
+		/// <summary>
+		/// An alternative to RequestBody, for when the caller already has the byte array.
+		/// </summary>
+		byte[] RequestBodyBytes { get; set; }
+
 		Uri Url { get; set; }
 
 		HttpWebRequest DeleteAsync(Action<HttpResponse> action);

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -372,7 +372,11 @@ namespace RestSharp
 
 			if(body != null)
 			{
-				http.RequestBody = body.Value.ToString();
+				object val = body.Value;
+				if (val is byte[])
+					http.RequestBodyBytes = (byte[])val;
+				else
+					http.RequestBody = body.Value.ToString();
 				http.RequestContentType = body.Name;
 			}
 		}


### PR DESCRIPTION
Implement the ability for the body of a PUT or POST to be specified using
a byte array, rather than a string.  This avoids the roundtrip through
UTF-8 and back again if the caller already has a byte array.
