### PR TITLE
Fix memory leak around handling of Accepts header.

### DIFF
--- a/RestSharp/RestClient.Async.cs
+++ b/RestSharp/RestClient.Async.cs
@@ -73,10 +73,6 @@ namespace RestSharp
 			var http = HttpFactory.Create();
 			AuthenticateIfNeeded(this, request);
 
-			// add Accept header based on registered deserializers
-			var accepts = string.Join(", ", AcceptTypes.ToArray());
-			this.AddDefaultParameter("Accept", accepts, ParameterType.HttpHeader);
-
 			ConfigureHttp(request, http);
 
 			var asyncHandle = new RestRequestAsyncHandle();

--- a/RestSharp/RestClient.Sync.cs
+++ b/RestSharp/RestClient.Sync.cs
@@ -62,10 +62,6 @@ namespace RestSharp
 		{
 			AuthenticateIfNeeded(this, request);
 
-			// add Accept header based on registered deserializers
-			var accepts = string.Join(", ", AcceptTypes.ToArray());
-			this.AddDefaultParameter("Accept", accepts, ParameterType.HttpHeader);
-
 			IRestResponse response = new RestResponse();
 			try
 			{

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -293,6 +293,13 @@ namespace RestSharp
 				request.AddParameter(p);
 			}
 
+			// Add Accept header based on registered deserializers if none has been set by the caller.
+			if (!request.Parameters.Any(p2 => p2.Name.ToLowerInvariant() == "accept"))
+			{
+				var accepts = string.Join(", ", AcceptTypes.ToArray());
+				request.AddParameter("Accept", accepts, ParameterType.HttpHeader);
+			}
+
 			http.Url = BuildUri(request);
 
 			var userAgent = UserAgent ?? http.UserAgent;


### PR DESCRIPTION
When adding an Accepts header to the request, this shouldn't be put into
DefaultParameters.  Repeated requests through the same RestClient instance
were adding the Accepts header every time, resulting in a large memory
leak because DefaultParameters was growing without bound.

Instead, only add the header for this particular request.
