### PR TITLE
Serialize Dictionary<string, int> and Dictionary<string, bool>.

### DIFF
--- a/RestSharp.Tests/SimpleJson.cs
+++ b/RestSharp.Tests/SimpleJson.cs
@@ -1041,6 +1041,16 @@ namespace RestSharp.Tests
                 IDictionary<string, string> dict = (IDictionary<string, string>)value;
                 success = SerializeObject(jsonSerializerStrategy, dict.Keys, dict.Values, builder);
             }
+            else if (value is IDictionary<string, int>)
+            {
+                IDictionary<string, int> dict = (IDictionary<string, int>)value;
+                success = SerializeObject(jsonSerializerStrategy, dict.Keys, dict.Values, builder);
+            }
+            else if (value is IDictionary<string, bool>)
+            {
+                IDictionary<string, bool> dict = (IDictionary<string, bool>)value;
+                success = SerializeObject(jsonSerializerStrategy, dict.Keys, dict.Values, builder);
+            }
             else if (value is IEnumerable)
                 success = SerializeArray(jsonSerializerStrategy, (IEnumerable)value, builder);
             else if (IsNumeric(value))

--- a/RestSharp/SimpleJson.cs
+++ b/RestSharp/SimpleJson.cs
@@ -1041,6 +1041,16 @@ namespace RestSharp
                 IDictionary<string, string> dict = (IDictionary<string, string>)value;
                 success = SerializeObject(jsonSerializerStrategy, dict.Keys, dict.Values, builder);
             }
+            else if (value is IDictionary<string, int>)
+            {
+                IDictionary<string, int> dict = (IDictionary<string, int>)value;
+                success = SerializeObject(jsonSerializerStrategy, dict.Keys, dict.Values, builder);
+            }
+            else if (value is IDictionary<string, bool>)
+            {
+                IDictionary<string, bool> dict = (IDictionary<string, bool>)value;
+                success = SerializeObject(jsonSerializerStrategy, dict.Keys, dict.Values, builder);
+            }
             else if (value is IEnumerable)
                 success = SerializeArray(jsonSerializerStrategy, (IEnumerable)value, builder);
             else if (IsNumeric(value))


### PR DESCRIPTION
Treat these types the same as Dictionary<string, object> and
Dictionary<string, bool>.  This matches the behavior of
System.Web.Script.Serialization.JavaScriptSerializer, and just
generally is less surprising behavior.
