### PR TITLE
Add ContentLength to the RestClient.AddFile method which takes in a path

### DIFF
--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -116,10 +116,12 @@ namespace RestSharp
 		/// <returns>This request</returns>
 		public IRestRequest AddFile (string name, string path)
 		{
+			var fileInfo = new FileInfo(path);
 			return AddFile(new FileParameter
 			{
 				Name = name,
-				FileName = Path.GetFileName(path),
+				FileName = fileInfo.Name,
+				ContentLength = fileInfo.Length,
 				Writer = s =>
 				{
 					using(var file = new StreamReader(path))


### PR DESCRIPTION
When uploading a file you have the path to, the ContentLength should be known and is safe to set on the FileParameter. I get a System.Net.ProtocolViolationException when trying to upload a file without setting the ContentLength on the FileParameter. The exception message is "Bytes to be written to the stream exceed the Content-Length bytes size specified"

Since the easiest way to accomplish this is to use the FileInfo class, I took the liberty of altering the code in the method which set the FileName to Path.GetFileName(...) to use fileInfo.Name since we will have that information available.

Please let me know if I need to make any changes to get this committed!

-dan
