### PR TITLE
Added support for attribute-based serialization for objects containing IList properties

### DIFF
--- a/RestSharp.Tests/SerializerTests.cs
+++ b/RestSharp.Tests/SerializerTests.cs
@@ -157,6 +157,35 @@ namespace RestSharp.Tests
 			Assert.Equal(expected.ToString(), doc.ToString());
 		}
 
+        [Fact]
+        public void Can_serialize_simple_POCO_With_Attribute_Options_Defined_And_Property_Containing_IList_Elements()
+        {
+            var poco = new WackyPerson
+            {
+                Name = "Foo",
+                Age = 50,
+                Price = 19.95m,
+                StartDate = new DateTime(2009, 12, 18, 10, 2, 23),
+                ContactData = new ContactData
+                    {
+                        EmailAddresses = new List<EmailAddress>
+                            {
+                                new EmailAddress
+                                    {
+                                        Address = "test@test.com",
+                                        Location = "Work"
+                                    }
+                            }
+                    }
+            };
+
+            var xml = new XmlSerializer();
+            var doc = xml.Serialize(poco);
+            var expected = GetSimplePocoXDocWackyNamesWithIListProperty();
+
+            Assert.Equal(expected.ToString(), doc.ToString());
+        }
+
 		[Fact]
 		public void Can_serialize_a_list_which_is_the_root_element()
 		{
@@ -238,13 +267,37 @@ namespace RestSharp.Tests
 
 			[SerializeAs(Name = "start_date", Attribute = true)]
 			public DateTime StartDate { get; set; }
+
+            [SerializeAs(Name = "contact-data")]
+            public ContactData ContactData { get; set; } 
 		}
 
 		[SerializeAs(Name = "People")]
 		private class PersonList : List<Person>
 		{
-
+           
 		}
+
+        private class ContactData
+        {
+            public ContactData()
+            {
+                EmailAddresses = new List<EmailAddress>();
+            }
+
+            [SerializeAs(Name = "email-addresses")]
+            public List<EmailAddress> EmailAddresses { get; set; }
+        }
+
+        [SerializeAs(Name = "email-address")]
+        private class EmailAddress
+        {
+            [SerializeAs(Name = "address")]
+            public string Address { get; set; }
+
+            [SerializeAs(Name = "location")]
+            public string Location { get; set; }
+        }
 
 		private XDocument GetSimplePocoXDoc()
 		{
@@ -322,6 +375,26 @@ namespace RestSharp.Tests
 
 			return doc;
 		}
+
+        private XDocument GetSimplePocoXDocWackyNamesWithIListProperty()
+        {
+            var doc = new XDocument();
+            var root = new XElement("Person");
+            root.Add(new XAttribute("WackyName", "Foo"),
+                    new XElement("Age", 50),
+                    new XAttribute("Price", 19.95m),
+                    new XAttribute("start_date", new DateTime(2009, 12, 18, 10, 2, 23).ToString()),
+                    new XElement("contact-data", 
+                        new XElement("email-addresses",
+                            new XElement("email-address",
+                                new XElement("address", "test@test.com"),
+                                new XElement("location", "Work")
+                                ))));
+
+            doc.Add(root);
+
+            return doc;
+        }
 
 		private XDocument GetSortedPropsXDoc() {
 			var doc = new XDocument();

--- a/RestSharp/Serializers/XmlSerializer.cs
+++ b/RestSharp/Serializers/XmlSerializer.cs
@@ -146,8 +146,13 @@ namespace RestSharp.Serializers
 				else if (rawValue is IList) {
 					var itemTypeName = "";
 					foreach (var item in (IList)rawValue) {
-						if (itemTypeName == "") {
-							itemTypeName = item.GetType().Name;
+						if (itemTypeName == "")
+						{
+						    var type = item.GetType();
+                            var setting = type.GetAttribute<SerializeAsAttribute>();
+							itemTypeName = setting != null && setting.Name.HasValue() 
+                                ? setting.Name 
+                                : type.Name;
 						}
 						var instance = new XElement(itemTypeName);
 						Map(instance, item);


### PR DESCRIPTION
Given the following class structure:

``` csharp
public class Person
{
    [SerializeAs(Name = "contact-data")]
    public ContactData ContactData { get;set; }
}

public class ContactData
{
    [SerializeAs(Name = "email-addresses")]
    public List<EmailAddress> EmailAddresses { get; set; }
}

[SerializeAs(Name = "email-address")]
public class EmailAddress
{
    [SerializeAs(Name = "address")]
    public string Address { get;set; }
}
```

RestSharp's XmlSerializer returns the following XML:

``` xml
<person>
    <contact-data>
        <email-addresses>
            <EmailAddress>
                <address>my@email.com</address> 
             </EmailAddress>
        </email-addresses>
    </contact-data>
</person>
```

**Note that the serialization of the "EmailAddress" element ignored the SerializeAs attribute.**

Code attached to fix this issue and correctly serialize class names when included as an IList<> property.
