### PR TITLE
Added support for token type in OAuth2Authenticator. fixes #364

### DIFF
--- a/RestSharp/Authenticators/OAuth2Authenticator.cs
+++ b/RestSharp/Authenticators/OAuth2Authenticator.cs
@@ -77,7 +77,7 @@ namespace RestSharp
 	public class OAuth2AuthorizationRequestHeaderAuthenticator : OAuth2Authenticator
 	{
 		/// <summary>
-		/// Stores the Authoriztion header value as "OAuth accessToken". used for performance.
+		/// Stores the Authorization header value as "[tokenType] accessToken". used for performance.
 		/// </summary>
 		private readonly string _authorizationValue;
 
@@ -88,10 +88,24 @@ namespace RestSharp
 		/// The access token.
 		/// </param>
 		public OAuth2AuthorizationRequestHeaderAuthenticator(string accessToken)
+			: this(accessToken, "OAuth")
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="OAuth2AuthorizationRequestHeaderAuthenticator"/> class.
+		/// </summary>
+		/// <param name="accessToken">
+		/// The access token.
+		/// </param>
+		/// <param name="tokenType">
+		/// The token type.
+		/// </param>
+		public OAuth2AuthorizationRequestHeaderAuthenticator(string accessToken, string tokenType)
 			: base(accessToken)
 		{
 			// Conatenate during constructor so that it is only done once. can improve performance.
-			_authorizationValue = "OAuth " + accessToken;
+			_authorizationValue = tokenType + " " + accessToken;
 		}
 
 		public override void Authenticate(IRestClient client, IRestRequest request)


### PR DESCRIPTION
The `OAuth2AuthorizationRequestHeaderAuthenticator` class is based on a relatively old version of the OAuth 2 spec, namely [v10](http://tools.ietf.org/html/draft-ietf-oauth-v2-10#section-5.1.1) whereas the latest version is [v31](http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-7.1). One of the differences between those versions is that the token in the authorization header is now not always prefixed with "OAuth ", but can also be prefixed with other token types such as "Bearer ". The `OAuth2AuthorizationRequestHeaderAuthenticator` class should be updated to support these other token types.

This pull request adds support for specifying the token type. It does this by adding an additional constructor that takes the token type as an additional parameter. This change is backwards-compatible with the previous version.
