### PR TITLE
Fix for issue #368

### DIFF
--- a/RestSharp/RestClient.Async.cs
+++ b/RestSharp/RestClient.Async.cs
@@ -73,10 +73,6 @@ namespace RestSharp
 			var http = HttpFactory.Create();
 			AuthenticateIfNeeded(this, request);
 
-			// add Accept header based on registered deserializers
-			var accepts = string.Join(", ", AcceptTypes.ToArray());
-			this.AddDefaultParameter("Accept", accepts, ParameterType.HttpHeader);
-
 			ConfigureHttp(request, http);
 
 			var asyncHandle = new RestRequestAsyncHandle();

--- a/RestSharp/RestClient.Sync.cs
+++ b/RestSharp/RestClient.Sync.cs
@@ -62,10 +62,6 @@ namespace RestSharp
 		{
 			AuthenticateIfNeeded(this, request);
 
-			// add Accept header based on registered deserializers
-			var accepts = string.Join(", ", AcceptTypes.ToArray());
-			this.AddDefaultParameter("Accept", accepts, ParameterType.HttpHeader);
-
 			IRestResponse response = new RestResponse();
 			try
 			{
@@ -88,7 +84,6 @@ namespace RestSharp
 
 			return response;
 		}
-
 
 		private static HttpResponse DoExecuteAsGet(IHttp http, string method)
 		{

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -90,6 +90,10 @@ namespace RestSharp
 			if (contentType != "*")
 			{
 				AcceptTypes.Add(contentType);
+				// add Accept header based on registered deserializers
+				var accepts = string.Join(", ", AcceptTypes.ToArray());
+				this.RemoveDefaultParameter("Accept");
+				this.AddDefaultParameter("Accept", accepts, ParameterType.HttpHeader);
 			}
 		}
 
@@ -101,6 +105,7 @@ namespace RestSharp
 		{
 			ContentHandlers.Remove(contentType);
 			AcceptTypes.Remove(contentType);
+			this.RemoveDefaultParameter("Accept");
 		}
 
 		/// <summary>
@@ -110,6 +115,7 @@ namespace RestSharp
 		{
 			ContentHandlers.Clear();
 			AcceptTypes.Clear();
+			this.RemoveDefaultParameter("Accept");
 		}
 
 		/// <summary>

--- a/RestSharp/RestClientExtensions.cs
+++ b/RestSharp/RestClientExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace RestSharp
 {
@@ -212,6 +213,21 @@ namespace RestSharp
 
 			restClient.DefaultParameters.Add(p);
 		}
+
+        /// <summary>
+        /// Removes a parameter from the default parameters that are used on every request made with this client instance
+        /// </summary>
+        /// <param name="restClient">The IRestClient instance</param>
+        /// <param name="name">The name of the parameter that needs to be removed</param>
+        /// <returns></returns>
+        public static void RemoveDefaultParameter(this IRestClient restClient, string name)
+        {
+            var parameter = restClient.DefaultParameters.SingleOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+            if (parameter != null)
+            {
+                restClient.DefaultParameters.Remove(parameter);
+            }
+        }
 
 		/// <summary>
 		/// Adds a HTTP parameter (QueryString for GET, DELETE, OPTIONS and HEAD; Encoded form for POST and PUT)


### PR DESCRIPTION
When executing Async requests on multiple threads with 1 restclient, there is sometimes an exception.

Accept header isn't added on each execute anymore, but only when added or removed.
