### PR TITLE
Fixed System.Net.ProtocolViolationException issue cause of missed the ContentLength property

### DIFF
--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -121,10 +121,13 @@ namespace RestSharp
 		/// <returns>This request</returns>
 		public IRestRequest AddFile (string name, string path)
 		{
+			FileInfo f = new FileInfo (path);
+			long fileLength = f.Length;
 			return AddFile(new FileParameter
 			{
 				Name = name,
 				FileName = Path.GetFileName(path),
+				ContentLength = fileLength,
 				Writer = s =>
 				{
 					using(var file = new StreamReader(path))


### PR DESCRIPTION
When I use RestRequest.AddFile (string name, string path) to add a file entity to upload in Unity3D which has a mono runtime inside, I found upload always failed with this exception:

> System.Net.ProtocolViolationException: The number of bytes to be written is greater than the specified ContentLength.
>   at System.Net.WebConnectionStream.CheckWriteOverflow (Int64 contentLength, Int64 totalWritten, Int64 size) [0x00000] in <filename unknown>:0 
>   at System.Net.WebConnectionStream.BeginWrite (System.Byte[] buffer, Int32 offset, Int32 size, System.AsyncCallback cb, System.Object state) [0x00000] in <filename unknown>:0 
>   at System.Net.WebConnectionStream.Write (System.Byte[] buffer, Int32 offset, Int32 size) [0x00000] in <filename unknown>:0 
>   at RestSharp.Extensions.MiscExtensions.CopyTo (System.IO.Stream input, System.IO.Stream output) [0x0001f] in /Users/helihua/unity_workspace/GowOnline/Assets/Library/RestSharp/Extensions/MiscExtensions.cs:72 
>   at RestSharp.RestRequest+<AddFile>c__AnonStorey5E.<>m__3D (System.IO.Stream s) [0x0000c] in /Users/helihua/unity_workspace/GowOnline/Assets/Library/RestSharp/RestRequest.cs:128 
