### PR TITLE
Remove redundant MSBuildBinPath import

### DIFF
--- a/RestSharp/RestSharp.csproj
+++ b/RestSharp/RestSharp.csproj
@@ -180,7 +180,6 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
`MSBuildBinPath` was replaced with `MSBuildToolsPath` after VS2005. `MSBuildBinPath` was kept around for back-compat, but is no longer needed. The extra import causes unnecessary build warnings.

See http://msdn.microsoft.com/en-us/library/bb397428.aspx for
a full discussion.
