### PR TITLE
Guard against null values

### DIFF
--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -297,7 +297,7 @@ namespace RestSharp
 			http.ResponseWriter = request.ResponseWriter;
 
 			// move RestClient.DefaultParameters into Request.Parameters
-			foreach(var p in DefaultParameters)
+			foreach(var p in DefaultParameters.Where(p => p != null))
 			{
 				if(request.Parameters.Any(p2 => p2.Name == p.Name && p2.Type == p.Type))
 				{

--- a/RestSharp/RestClientExtensions.cs
+++ b/RestSharp/RestClientExtensions.cs
@@ -205,6 +205,8 @@ namespace RestSharp
 		/// <returns></returns>
 		public static void AddDefaultParameter(this IRestClient restClient, Parameter p)
 		{
+			if (p == null) throw new ArgumentNullException("p");
+
 			if (p.Type == ParameterType.RequestBody)
 			{
 				throw new NotSupportedException(
@@ -222,6 +224,8 @@ namespace RestSharp
         /// <returns></returns>
         public static void RemoveDefaultParameter(this IRestClient restClient, string name)
         {
+            if (name == null) throw new ArgumentNullException("name");
+
             var parameter = restClient.DefaultParameters.SingleOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
             if (parameter != null)
             {


### PR DESCRIPTION
Since anyone can directly reference `DefaultParameters` directly, it's possible for a null value to be added (since you can bypass `AddDefaultParameter`. Doing so is almost certainly a programming mistake, but a `NullReferenceException` isn't helpful in this location.

We seem to have run into this somehow in high stress situations in our app and we're most certainly not adding nulls. It might have been due to weird multi-threading issues like those in #368 so I'm not sure if this is still a problem. I figured it doesn't hurt to have defense in depth.
:)
