### PR TITLE
Fixed ClientCertificate NotImplementedException on mono runtime.

### DIFF
--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -221,7 +221,7 @@ namespace RestSharp
 
 			if(ClientCertificates != null)
 			{
-				webRequest.ClientCertificates = ClientCertificates;
+                webRequest.ClientCertificates.AddRange(ClientCertificates);
 			}
 
 			if(UserAgent.HasValue())


### PR DESCRIPTION
In mono there is no setter for the ClientCertificates property on the WebRequest
class, and therefore it throws a NotSupportedException. However, if the collection
is empty upon access a new instance is added and returned, thus, one can simply
add the current certificates to the request's certificate collection.
