### PR TITLE
Don't strip trailing slash when adding query parameters as per RFC1738 a...

### DIFF
--- a/RestSharp.Tests/UrlBuilderTests.cs
+++ b/RestSharp.Tests/UrlBuilderTests.cs
@@ -49,6 +49,21 @@ namespace RestSharp.Tests
 		}
 
 		[Fact]
+		public void GET_wth_trailing_slash_and_query_parameters()
+		{
+			var request = new RestRequest("/resource/");
+			var client = new RestClient("http://example.com");
+			request.AddParameter( "foo", "bar" );
+
+			var expected = new Uri("http://example.com/resource/?foo=bar");
+			var output = client.BuildUri(request);
+
+			var response = client.Execute( request );
+
+			Assert.Equal(expected, output);
+		}
+
+		[Fact]
 		public void POST_with_leading_slash_and_baseurl_trailing_slash()
 		{
 			var request = new RestRequest("/resource", Method.POST);

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -264,11 +264,6 @@ namespace RestSharp
 				// build and attach querystring if this is a get-style request
 				if (request.Parameters.Any(p => p.Type == ParameterType.GetOrPost))
 				{
-					if (assembled.EndsWith("/"))
-					{
-						assembled = assembled.Substring(0, assembled.Length - 1);
-					}
-
 					var data = EncodeParameters(request);
 					assembled = string.Format("{0}?{1}", assembled, data);
 				}


### PR DESCRIPTION
...nd RFC2396

Currently stripping trailing slashes when adding query parameters so that http://api.com/collection/ with parameter foo=bar becomes http://api.com/collection?foo=bar instead of http://api.com/collection/?foo=bar.

This changes that behavior to not strip the trailing slash and includes a test to verify the functionality.
