### PR TITLE
A hacky fix for the decimal parse error which happens for very small numbers like "0.00005557". There might be a better way of doing this.

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -607,6 +607,17 @@ namespace RestSharp.Tests
 			Assert.Equal ("{\"Name\":\"ThingBlue\",\"Color\":\"Blue\"}", bd["ThingBlue"]);
 		}
 
+		[Fact]
+		public void Can_Deserialize_Decimal_With_Four_Zeros_After_Floating_Point()
+		{
+			const string json = "{\"Value\":0.00005557}";
+			var response = new RestResponse() {Content = json};
+			var d = new JsonDeserializer();
+			var result = d.Deserialize<DecimalNumber>(response);
+
+			Assert.Equal(result.Value, .00005557m);
+		}
+
 		private string CreateJsonWithUnderscores()
 		{
 			var doc = new JsonObject();

--- a/RestSharp.Tests/SampleClasses/misc.cs
+++ b/RestSharp.Tests/SampleClasses/misc.cs
@@ -194,4 +194,9 @@ namespace RestSharp.Tests
 		public Disposition LowerDashes { get; set; }
 		public Disposition Integer { get; set; }
 	}
+
+	public class DecimalNumber
+	{
+		public decimal Value { get; set; }
+	}
 }

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -195,8 +195,8 @@ namespace RestSharp.Deserializers
 			else if (type == typeof(Decimal))
 			{
 				if (value is double)
-                    			return (decimal)((double)value);
-                    			
+					return (decimal)((double)value);
+
 				return Decimal.Parse(stringValue, Culture);
 			}
 			else if (type == typeof(Guid))


### PR DESCRIPTION
...bers like "0.00005557"

A simple program which recreates the error:
using System;
using RestSharp;

namespace RestSharpJson
{
    class Program
    {
        static void Main(string[] args)
        {
            var json = "{\"value\":0.00005557}";

```
        var ds = new JsonDeserializer();

        var resp = new RestResponse()
                       {
                           Content = json
                       };

        var result = ds.Deserialize<Number>(resp);
        Console.WriteLine(result.value);
        Console.Read();
    }

    class Number
    {
        public decimal value { get; set; }
    }
}  
```

}

ConvertValue gets value as double already and it needs to convert it to decimal. To do that it transforms it to string. At this step our double value turns into this "5.557E-05". Decimal.Parse is unable to read it.
