### PR TITLE
Fixed reference to incorrectly named object

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -797,7 +797,7 @@ namespace RestSharp.Tests
 
 		private string CreateJsonWithEmptyValues()
 		{
-			var doc = new JObject();
+			var doc = new JsonObject();
 			doc["Id"] = "";
 			doc["StartDate"] = "";
 			doc["UniqueId"] = "";


### PR DESCRIPTION
Getting a build error on a fresh clone of the master branch. Looks like a reference exists to non-existent "JObject". All other similar functions on this page reference JsonObject
