### PR TITLE
JsonDeserialize : int to bool

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -314,6 +314,19 @@ namespace RestSharp.Tests
 		}
 
 		[Fact]
+		public void Can_Deserialize_Int_to_Bool()
+		{
+			var doc = new JsonObject();
+			doc["IsCool"] = 1;
+
+			var d = new JsonDeserializer();
+			var response = new RestResponse { Content = doc.ToString() };
+			var p = d.Deserialize<PersonForJson>(response);
+
+			Assert.True(p.IsCool);
+		}
+
+		[Fact]
 		public void Can_Deserialize_With_Default_Root()
 		{
 			var doc = CreateJson();

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -172,11 +172,7 @@ namespace RestSharp.Deserializers
 
 			if (type.IsPrimitive)
 			{
-				// no primitives can contain quotes so we can safely remove them
-				// allows converting a json value like {"index": "1"} to an int
-				var tmpVal = stringValue.Replace("\"", string.Empty);
-
-				return tmpVal.ChangeType(type, Culture);
+				return value.ChangeType(type, Culture);
 			}
 			else if (type.IsEnum)
 			{


### PR DESCRIPTION
Fixes bug where JsonDeserializer could not deserialize an integer to a boolean property.
