### PR TITLE
Update MonoDroid and MonoTouch projects to work with new Xamarin tools

### DIFF
--- a/RestSharp.MonoDroid/RestSharp.MonoDroid.csproj
+++ b/RestSharp.MonoDroid/RestSharp.MonoDroid.csproj
@@ -256,7 +256,7 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/RestSharp.MonoTouch/RestSharp.MonoTouch.csproj
+++ b/RestSharp.MonoTouch/RestSharp.MonoTouch.csproj
@@ -11,7 +11,6 @@
     <RootNamespace>RestSharp</RootNamespace>
     <MtouchSdkVersion>3.2</MtouchSdkVersion>
     <MtouchMinimumOS>3.0</MtouchMinimumOS>
-    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
     <AssemblyName>RestSharp.MonoTouch</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
@@ -87,7 +86,7 @@
     <Reference Include="monotouch" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
-  <Import Project="$(ProgramFiles)\MSBuild\MonoTouch\Novell.MonoTouch.Common.targets" Condition="'$(windir)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Compile Include="..\RestSharp\Enum.cs">


### PR DESCRIPTION
The Xamarin tools have been updated and the projects no longer work, this fixes them.