### PR TITLE
Enable async/task extensions for monodroid and monotouch

### DIFF
--- a/RestSharp.MonoDroid/Extensions/ResponseStatusExtensions.cs
+++ b/RestSharp.MonoDroid/Extensions/ResponseStatusExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Net;
+
+namespace RestSharp.Extensions
+{
+	public static class ResponseStatusExtensions
+	{
+		/// <summary>
+		/// Convert a <see cref="ResponseStatus"/> to a <see cref="WebException"/> instance.
+		/// </summary>
+		/// <param name="responseStatus">The response status.</param>
+		/// <returns></returns>
+		/// <exception cref="System.ArgumentOutOfRangeException">responseStatus</exception>
+		public static WebException ToWebException(this ResponseStatus responseStatus)
+		{
+			switch (responseStatus)
+			{
+				case ResponseStatus.None:
+					return new WebException("The request could not be processed.", WebExceptionStatus.ServerProtocolViolation);
+				case ResponseStatus.Error:
+					return new WebException("An error occured while processing the request.", WebExceptionStatus.ServerProtocolViolation);
+				case ResponseStatus.TimedOut:
+					return new WebException("The request timed-out.", WebExceptionStatus.Timeout);
+				case ResponseStatus.Aborted:
+					return new WebException("The request was aborted.", WebExceptionStatus.Timeout);
+				default:
+					throw new ArgumentOutOfRangeException("responseStatus");
+			}
+		}
+	}
+}

--- a/RestSharp.MonoDroid/RestSharp.MonoDroid.csproj
+++ b/RestSharp.MonoDroid/RestSharp.MonoDroid.csproj
@@ -254,6 +254,7 @@
     <Compile Include="..\RestSharp\SharedAssemblyInfo.cs">
       <Link>SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Extensions\ResponseStatusExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />

--- a/RestSharp.MonoTouch/Extensions/ResponseStatusExtensions.cs
+++ b/RestSharp.MonoTouch/Extensions/ResponseStatusExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Net;
+
+namespace RestSharp.Extensions
+{
+	public static class ResponseStatusExtensions
+	{
+		/// <summary>
+		/// Convert a <see cref="ResponseStatus"/> to a <see cref="WebException"/> instance.
+		/// </summary>
+		/// <param name="responseStatus">The response status.</param>
+		/// <returns></returns>
+		/// <exception cref="System.ArgumentOutOfRangeException">responseStatus</exception>
+		public static WebException ToWebException(this ResponseStatus responseStatus)
+		{
+			switch (responseStatus)
+			{
+				case ResponseStatus.None:
+					return new WebException("The request could not be processed.", WebExceptionStatus.ServerProtocolViolation);
+				case ResponseStatus.Error:
+					return new WebException("An error occured while processing the request.", WebExceptionStatus.ServerProtocolViolation);
+				case ResponseStatus.TimedOut:
+					return new WebException("The request timed-out.", WebExceptionStatus.Timeout);
+				case ResponseStatus.Aborted:
+					return new WebException("The request was aborted.", WebExceptionStatus.Timeout);
+				default:
+					throw new ArgumentOutOfRangeException("responseStatus");
+			}
+		}
+	}
+}

--- a/RestSharp.MonoTouch/RestSharp.MonoTouch.csproj
+++ b/RestSharp.MonoTouch/RestSharp.MonoTouch.csproj
@@ -303,6 +303,7 @@
     <Compile Include="..\RestSharp\SharedAssemblyInfo.cs">
       <Link>SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Extensions\ResponseStatusExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
 </Project>

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -18,7 +18,7 @@ using System;
 using System.Net;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
-#if NET4
+#if NET4 || MONODROID || MONOTOUCH
 using System.Threading;
 using System.Threading.Tasks;
 #endif
@@ -123,7 +123,7 @@ namespace RestSharp
 		IRestResponse<T> ExecuteAsPost<T>(IRestRequest request, string httpMethod) where T : new();
 #endif
 
-#if NET4
+#if NET4 || MONODROID || MONOTOUCH
 		/// <summary>
 		/// Executes the request and callback asynchronously, authenticating if needed
 		/// </summary>

--- a/RestSharp/RestClient.Async.cs
+++ b/RestSharp/RestClient.Async.cs
@@ -18,7 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-#if NET4
+#if NET4 || MONODROID || MONOTOUCH
 using System.Threading.Tasks;
 #endif
 using System.Text;
@@ -158,7 +158,7 @@ namespace RestSharp
 			callback(restResponse, asyncHandle);
 		}
 
-#if NET4
+#if NET4 || MONODROID || MONOTOUCH
 		/// <summary>
 		/// Executes a GET-style request asynchronously, authenticating if needed
 		/// </summary>


### PR DESCRIPTION
The async/task support is now stable (and works well) for Xamarin.iOS (monotouch) and Xamarin.Android (monodroid).
