### PR TITLE
Update RestRequest.cs

### DIFF
--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -199,6 +199,37 @@ namespace RestSharp
 			return AddFile(new FileParameter { Name = name, Writer = writer, FileName = fileName, ContentType = contentType });
 		}
 
+
+	        /// <summary>
+	        /// Add bytes to the Files collection as if it was a file of specific type
+	        /// </summary>
+	        /// <param name="name">A form parameter name</param>
+	        /// <param name="bytes">The file data</param>
+	        /// <param name="filename">The file name to use for the uploaded file</param>
+	        /// <param name="contentType">Specific content type. Es: application/x-gzip </param>
+	        /// <returns></returns>
+	        public IRestRequest AddBytesAs(string name, byte[] bytes, string filename, string contentType = "application/x-gzip")
+	        {
+	
+	            long length = bytes.Length;
+	            return AddFile(new FileParameter
+	            {
+	                Name = name,
+	                FileName = filename,
+	                ContentLength = length,
+	                ContentType = contentType,
+	                Writer = s =>
+	                {
+	                    using (var file = new StreamReader(new MemoryStream(bytes)))
+	                    {
+	                        file.BaseStream.CopyTo(s);
+	                    }
+	                }
+	            });
+	        }
+
+
+
 		private IRestRequest AddFile (FileParameter file)
 		{
 			Files.Add(file);


### PR DESCRIPTION
Add a new method to add bytes as it was a file of specific content type. This is useful to send a gzipped data on multipart request without the use of temporary file