### PR TITLE
Host header for requests can be specified explicitly

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -372,6 +372,15 @@ namespace RestSharp
 			AppendHeaders(webRequest);
 			AppendCookies(webRequest);
 
+			if (Host != null)
+			{
+#if NET4 || MONODROID || MONOTOUCH
+				webRequest.Host = Host;
+#else
+				throw new NotImplementedException("Explicit Host header is supported from .NET 4");
+#endif
+			}
+
 			webRequest.Method = method;
 
 			// make sure Content-Length header is always sent since default is -1

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -223,6 +223,15 @@ namespace RestSharp
 			AppendHeaders(webRequest);
 			AppendCookies(webRequest);
 
+			if (Host != null)
+			{
+#if NET4 || MONODROID || MONOTOUCH
+				webRequest.Host = Host;
+#else
+				throw new NotImplementedException("Explicit Host header is supported from .NET 4");
+#endif
+			}
+
 			webRequest.Method = method;
 
 			// make sure Content-Length header is always sent since default is -1

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -169,6 +169,11 @@ namespace RestSharp
 		/// URL to call for this request
 		/// </summary>
 		public Uri Url { get; set; }
+		/// <summary>
+		/// Explicit Host header value to use in requests independent from the request URI.
+		/// If null, default host value extracted from URI is used.
+		/// </summary>
+		public string Host { get; set; }
 
 #if FRAMEWORK
 		/// <summary>

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -57,6 +57,7 @@ namespace RestSharp
 		byte[] RequestBodyBytes { get; set; }
 
 		Uri Url { get; set; }
+		string Host { get; set; }
 
 		HttpWebRequest DeleteAsync(Action<HttpResponse> action);
 		HttpWebRequest GetAsync(Action<HttpResponse> action);

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -57,6 +57,10 @@ namespace RestSharp
 		/// <summary>
 		/// 
 		/// </summary>
+		string BaseHost { get; set; }
+		/// <summary>
+		/// 
+		/// </summary>
 		IList<Parameter> DefaultParameters { get; }
 		/// <summary>
 		/// 

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -218,6 +218,12 @@ namespace RestSharp
 			}
 		}
 
+		/// <summary>
+		/// Explicit Host header value to use in requests independent from the request URI.
+		/// If null, default host value extracted from URI is used.
+		/// </summary>
+		public virtual string BaseHost { get; set; }
+
 		private void AuthenticateIfNeeded(RestClient client, IRestRequest request)
 		{
 			if (Authenticator != null)
@@ -319,6 +325,7 @@ namespace RestSharp
 			}
 
 			http.Url = BuildUri(request);
+			http.Host = BaseHost;
 
 			var userAgent = UserAgent ?? http.UserAgent;
 			http.UserAgent = userAgent.HasValue() ? userAgent : "RestSharp/" + version;


### PR DESCRIPTION
Uses HttpWebRequest.Host property (.NET 4). Fixes #462.
