### PR TITLE
Expose HttpWebRequest ReadWriteTimeout to client

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -410,11 +410,11 @@ namespace RestSharp
 				webRequest.Timeout = Timeout;
 			}
 
-            if (ReadWriteTimeout != 0)
-            {
-                webRequest.ReadWriteTimeout = ReadWriteTimeout;
-            }
-
+			if (ReadWriteTimeout != 0)
+			{
+				webRequest.ReadWriteTimeout = ReadWriteTimeout;
+			}
+            
 			if (Proxy != null)
 			{
 				webRequest.Proxy = Proxy;

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -248,10 +248,10 @@ namespace RestSharp
 				webRequest.Timeout = Timeout;
 			}
 
-            if (ReadWriteTimeout != 0)
-            {
-                webRequest.ReadWriteTimeout = ReadWriteTimeout;
-            }
+			if (ReadWriteTimeout != 0)
+			{
+				webRequest.ReadWriteTimeout = ReadWriteTimeout;
+			}
 
 			if(Credentials != null)
 			{

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -103,10 +103,10 @@ namespace RestSharp
 		/// Timeout in milliseconds to be used for the request
 		/// </summary>
 		public int Timeout { get; set; }
-        /// <summary>
-        /// The number of milliseconds before the writing or reading times out.
-        /// </summary>
-        public int ReadWriteTimeout { get; set; }
+		/// <summary>
+		/// The number of milliseconds before the writing or reading times out.
+		/// </summary>
+		public int ReadWriteTimeout { get; set; }
 		/// <summary>
 		/// System.Net.ICredentials to be sent with request
 		/// </summary>

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -35,7 +35,7 @@ namespace RestSharp
 
 		string UserAgent { get; set; }
 		int Timeout { get; set; }
-        int ReadWriteTimeout { get; set; }
+		int ReadWriteTimeout { get; set; }
 #if !SILVERLIGHT
 		bool FollowRedirects { get; set; }
 #endif

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -45,10 +45,10 @@ namespace RestSharp
 		/// <summary>
 		/// 
 		/// </summary>
-        int ReadWriteTimeout { get; set; }
-        /// <summary>
-        /// 
-        /// </summary>
+		int ReadWriteTimeout { get; set; }
+		/// <summary>
+		/// 
+		/// </summary>
 		bool UseSynchronizationContext { get; set; }
 		/// <summary>
 		/// 

--- a/RestSharp/IRestRequest.cs
+++ b/RestSharp/IRestRequest.cs
@@ -109,10 +109,10 @@ namespace RestSharp
 		/// </summary>
 		int Timeout { get; set; }
 
-        /// <summary>
-        /// The number of milliseconds before the writing or reading times out.  This timeout value overrides a timeout set on the RestClient.
-        /// </summary>
-        int ReadWriteTimeout { get; set; }
+		/// <summary>
+		/// The number of milliseconds before the writing or reading times out.  This timeout value overrides a timeout set on the RestClient.
+		/// </summary>
+		int ReadWriteTimeout { get; set; }
 
 		/// <summary>
 		/// How many attempts were made to send this Request?

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -184,10 +184,10 @@ namespace RestSharp
 		/// </summary>
 		public int Timeout { get; set; }
 
-        /// <summary>
-        /// The number of milliseconds before the writing or reading times out.
-        /// </summary>
-        public int ReadWriteTimeout { get; set; }
+		/// <summary>
+		/// The number of milliseconds before the writing or reading times out.
+		/// </summary>
+		public int ReadWriteTimeout { get; set; }
 
 		/// <summary>
 		/// Whether to invoke async callbacks using the SynchronizationContext.Current captured when invoked
@@ -334,11 +334,11 @@ namespace RestSharp
 				http.Timeout = timeout;
 			}
 
-            var readWriteTimeout = request.ReadWriteTimeout > 0 ? request.ReadWriteTimeout : ReadWriteTimeout;
-            if (readWriteTimeout > 0)
-            {
-                http.ReadWriteTimeout = readWriteTimeout;
-            }
+			var readWriteTimeout = request.ReadWriteTimeout > 0 ? request.ReadWriteTimeout : ReadWriteTimeout;
+			if (readWriteTimeout > 0)
+			{
+				http.ReadWriteTimeout = readWriteTimeout;
+			}
 
 #if !SILVERLIGHT
 			http.FollowRedirects = FollowRedirects;

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -471,10 +471,10 @@ namespace RestSharp
 		/// </summary>
 		public int Timeout { get; set; }
 
-        /// <summary>
-        /// The number of milliseconds before the writing or reading times out.  This timeout value overrides a timeout set on the RestClient.
-        /// </summary>
-        public int ReadWriteTimeout { get; set; }
+		/// <summary>
+		/// The number of milliseconds before the writing or reading times out.  This timeout value overrides a timeout set on the RestClient.
+		/// </summary>
+		public int ReadWriteTimeout { get; set; }
 
 		private int _attempts;
 


### PR DESCRIPTION
This allows for the client to set ReadWriteTimeout. This property is set to 5 minutes by default...
