### PR TITLE
Remember to map ErrorException along with other properties

### DIFF
--- a/RestSharp/Extensions/ResponseExtensions.cs
+++ b/RestSharp/Extensions/ResponseExtensions.cs
@@ -15,6 +15,7 @@ namespace RestSharp.Extensions
 				ContentLength = response.ContentLength,
 				ContentType = response.ContentType,
 				Cookies = response.Cookies,
+				ErrorException = response.ErrorException,
 				ErrorMessage = response.ErrorMessage,
 				Headers = response.Headers,
 				RawBytes = response.RawBytes,


### PR DESCRIPTION
This change is quite simple, When using the generic Execute overload, ErrorException was not set (even though ErrorMessage) was.

The following code gives me the ability to handle any exception occured - for example "Connection refused":

```
        var restClient = new RestClient(url);
        var response = restClient.Execute(new RestRequest());
        // response.ErrorException is set
```

However using the overload of Execute which takes a Dto to deserialize into, works differently:

```
        var restClient = new RestClient(url);
        var response = restClient.Execute<Dto>(new RestRequest());
        // response.ErrorException is not set
```
