### PR TITLE
Make Portable.IntegrationTests and Portable.Tests projects loadable in

### DIFF
--- a/RestSharp.Portable.IntegrationTests/RestSharp.Portable.IntegrationTests.csproj
+++ b/RestSharp.Portable.IntegrationTests/RestSharp.Portable.IntegrationTests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/RestSharp.Portable.Tests/RestSharp.Portable.Tests.csproj
+++ b/RestSharp.Portable.Tests/RestSharp.Portable.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>


### PR DESCRIPTION
Xamarin Studio.

When loading the RestSharp.Portable project in Xamarin Studio v4.2 and
above you will get a 'Error while trying to load the project: Unknown
ToolsVersion 12.0'. The fix is trivial, for reference see:

http://forums.xamarin.com/discussion/10460/any-workaround-for-this-error-unknown-toolsversion-12-0
