### PR TITLE
Use InvariantCulture for XmlSerializer

### DIFF
--- a/RestSharp/Serializers/XmlSerializer.cs
+++ b/RestSharp/Serializers/XmlSerializer.cs
@@ -179,8 +179,50 @@ namespace RestSharp.Serializers
 			{
 				output = ((bool)obj).ToString(CultureInfo.InvariantCulture).ToLower();
 			}
+			if (IsNumeric(obj))
+			{
+				return SerializeNumber(obj);
+			}
 
 			return output.ToString();
+		}
+
+		static string SerializeNumber(object number)
+		{
+			if (number is long)
+				return ((long)number).ToString(CultureInfo.InvariantCulture);
+			else if (number is ulong)
+				return ((ulong)number).ToString(CultureInfo.InvariantCulture);
+			else if (number is int)
+				return ((int)number).ToString(CultureInfo.InvariantCulture);
+			else if (number is uint)
+				return ((uint)number).ToString(CultureInfo.InvariantCulture);
+			else if (number is decimal)
+				return ((decimal)number).ToString(CultureInfo.InvariantCulture);
+			else if (number is float)
+				return ((float)number).ToString(CultureInfo.InvariantCulture);
+			else
+				return (Convert.ToDouble(number, CultureInfo.InvariantCulture).ToString("r", CultureInfo.InvariantCulture));
+		}
+
+		/// <summary>
+		/// Determines if a given object is numeric in any way
+		/// (can be integer, double, null, etc).
+		/// </summary>
+		static bool IsNumeric(object value)
+		{
+			if (value is sbyte) return true;
+			if (value is byte) return true;
+			if (value is short) return true;
+			if (value is ushort) return true;
+			if (value is int) return true;
+			if (value is uint) return true;
+			if (value is long) return true;
+			if (value is ulong) return true;
+			if (value is float) return true;
+			if (value is double) return true;
+			if (value is decimal) return true;
+			return false;
 		}
 
 		/// <summary>


### PR DESCRIPTION
There is a mismatch between Json and Xml serialization, with regards to CultureInfo. The SimpleJson serializer, takes care of serializing with CultureInfo.InvariantCulture:

https://github.com/restsharp/RestSharp/blob/master/RestSharp/SimpleJson.cs#L1112

This pull requests makes the same changes for the XmlSerializer.

This problem occured for me when working with decimals in a culture where comma and not dot was used for decimal separater.
