### PR TITLE
Added a check to not allow duplicated question marks in uris

### DIFF
--- a/RestSharp.Tests/UrlBuilderTests.cs
+++ b/RestSharp.Tests/UrlBuilderTests.cs
@@ -12,6 +12,19 @@ namespace RestSharp.Tests
 	public class UrlBuilderTests
 	{
 		[Fact]
+		public void Should_not_duplicate_question_mark()
+		{
+			var request = new RestRequest();
+			request.AddParameter("param2", "value2");
+			var client = new RestClient("http://example.com/resource?param1=value1");
+
+			var expected = new Uri("http://example.com/resource?param1=value1&param2=value2");
+			var output = client.BuildUri(request);
+
+			Assert.Equal(expected, output);
+		}
+
+		[Fact]
 		public void GET_with_leading_slash()
 		{
 			var request = new RestRequest("/resource");

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -285,7 +285,8 @@ namespace RestSharp
 			if (parameters != null && parameters.Any())
 			{
 				var data = EncodeParameters(parameters);
-				assembled = string.Format("{0}?{1}", assembled, data);
+				var separator = assembled.Contains("?") ? "&" : "?";
+				assembled = string.Format("{0}{1}{2}", assembled, separator, data);
 			}
 
 			return new Uri(assembled);


### PR DESCRIPTION
URLs that are initially set up to have a query string, and later parameters are added to the request, build an URI with two question (?) marks. The library should handle those situations. 

Maybe this is agains the REST spec or even agains RestSharp premisses, but nevertheless it seems to be to be a fairly fualusible situation of everyday developer, specially those using RestSharp as a general HTTP library. 
