### PR TITLE
Update SimpleJson.cs

### DIFF
--- a/RestSharp/SimpleJson.cs
+++ b/RestSharp/SimpleJson.cs
@@ -1348,7 +1348,11 @@ namespace RestSharp
 #endif
                     if (type == typeof(Guid) || (ReflectionUtils.IsNullableType(type) && Nullable.GetUnderlyingType(type) == typeof(Guid)))
                         return new Guid(str);
-                    return str;
+
+					if (type == typeof(string))
+						return str;
+
+					return Convert.ChangeType (str, type);
                 }
                 else
                 {


### PR DESCRIPTION
If the destination type is not string then at least attempt to change the type. Is it kind of weir that the strategy does not take primitive type coversion into account.
