### PR TITLE
BuildUri: Tell which UrlSegment parameter value is null

### DIFF
--- a/RestSharp.Tests/UrlBuilderTests.cs
+++ b/RestSharp.Tests/UrlBuilderTests.cs
@@ -126,6 +126,17 @@ namespace RestSharp.Tests
 		}
 
 		[Fact]
+		public void GET_with_resource_containing_null_token()
+		{
+			var request = new RestRequest("/resource/{foo}", Method.GET);
+			request.AddUrlSegment("foo", null);
+			var client = new RestClient("http://example.com/api/1.0");
+
+			var exception = Assert.Throws<ArgumentException>(() => client.BuildUri(request));
+			Assert.Contains("foo", exception.Message);
+		}
+
+		[Fact]
 		public void POST_with_resource_containing_tokens()
 		{
 			var request = new RestRequest("resource/{foo}", Method.POST);

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -248,6 +248,11 @@ namespace RestSharp
 			var urlParms = request.Parameters.Where(p => p.Type == ParameterType.UrlSegment);
 			foreach (var p in urlParms)
 			{
+				if (p.Value == null)
+				{
+					throw new ArgumentException(string.Format("Cannot build uri when url segment parameter '{0}' value is null.", p.Name), "request");
+				}
+
 				assembled = assembled.Replace("{" + p.Name + "}", p.Value.ToString().UrlEncode());
 			}
 


### PR DESCRIPTION
Currenty a NullReferenceException is thrown. I belive this should be handled better. But I did not want to change the behaviour (i.e. accepting null). So I decided to throw a more descriptive error instead.
