### PR TITLE
Repairs InvalidCastException on method RestClientExtensions.ExecuteDynamic

### DIFF
--- a/RestSharp.Net4/Extensions/RestClientExtensions.cs
+++ b/RestSharp.Net4/Extensions/RestClientExtensions.cs
@@ -9,7 +9,7 @@ namespace RestSharp
 	{
 		public static RestResponse<dynamic> ExecuteDynamic(this IRestClient client, IRestRequest request)
 		{
-			var response = client.Execute(request);
+			var response = client.Execute<dynamic>(request);
 
 			var generic = (RestResponse<dynamic>)response;
 			dynamic content = SimpleJson.DeserializeObject(response.Content);


### PR DESCRIPTION
Hi, method RestClientExtensions.ExecuteDynamic throws InvalidCastException : Unable to cast object of type 'RestSharp.RestResponse' to type 'RestSharp.RestResponse`1[System.Object]'. 
on line 

```
var generic = (RestResponse<dynamic>)response;
```

Using generic Execute method repairs problem

```
var response = client.Execute<dynamic>(request);
```

this PR closes #536
