### PR TITLE
Fixed missing Execute(<T>) in IRestClient

### DIFF
--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -79,13 +79,16 @@ namespace RestSharp
 		/// <param name="request"></param>
 		RestRequestAsyncHandle ExecuteAsync<T>(IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback);
 
+#if FRAMEWORK || PocketPC		
+		IRestResponse Execute(IRestRequest request);
+		IRestResponse<T> Execute<T>(IRestRequest request) where T : new();
+#endif
+
 #if FRAMEWORK
 		/// <summary>
 		/// X509CertificateCollection to be sent with request
 		/// </summary>
 		X509CertificateCollection ClientCertificates { get; set; }
-		IRestResponse Execute(IRestRequest request);
-		IRestResponse<T> Execute<T>(IRestRequest request) where T : new();
 		
 		IWebProxy Proxy { get; set; }
 #endif


### PR DESCRIPTION
In PocketPC, the non-async Execute methods are missing. The "FRAMEWORK || PocketPC" condition is what's inside of RestClient.Sync.cs so I'm just updating to match.
