### PR TITLE
Added Deserialize<T>(string) to all Deserializer classes

### DIFF
--- a/RestSharp/Deserializers/DotNetXmlDeserializer.cs
+++ b/RestSharp/Deserializers/DotNetXmlDeserializer.cs
@@ -30,14 +30,20 @@ namespace RestSharp.Deserializers
 
 		public string RootElement { get; set; }
 
+
 		public T Deserialize<T>(IRestResponse response)
 		{
-			if (string.IsNullOrEmpty(response.Content))
+			return this.Deserialize<T>(response.Content);
+		}
+
+		public T Deserialize<T>(string serializedInput)
+		{
+			if (string.IsNullOrEmpty(serializedInput))
 			{
 				return default(T);
 			}
 
-			using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(response.Content)))
+			using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(serializedInput)))
 			{
 				var serializer = new System.Xml.Serialization.XmlSerializer(typeof(T));
 				return (T)serializer.Deserialize(stream);

--- a/RestSharp/Deserializers/IDeserializer.cs
+++ b/RestSharp/Deserializers/IDeserializer.cs
@@ -19,6 +19,7 @@ namespace RestSharp.Deserializers
 	public interface IDeserializer
 	{
 		T Deserialize<T>(IRestResponse response);
+		T Deserialize<T>(string serializedInput);
 		string RootElement { get; set; }
 		string Namespace { get; set; }
 		string DateFormat { get; set; }

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -21,6 +21,11 @@ namespace RestSharp.Deserializers
 
 		public T Deserialize<T>(IRestResponse response)
 		{
+			return this.Deserialize<T>(response.Content);
+		}
+
+		public T Deserialize<T>(string serializedInput)
+		{
 			var target = Activator.CreateInstance<T>();
 
 			if (target is IList)
@@ -29,23 +34,23 @@ namespace RestSharp.Deserializers
 
 				if (RootElement.HasValue())
 				{
-					var root = FindRoot(response.Content);
+					var root = FindRoot(serializedInput);
 					target = (T)BuildList(objType, root);
 				}
-				else
+				else 
 				{
-					var data = SimpleJson.DeserializeObject(response.Content);
+					var data = SimpleJson.DeserializeObject(serializedInput);
 					target = (T)BuildList(objType, data);
 				}
 			}
 			else if (target is IDictionary)
 			{
-				var root = FindRoot(response.Content);
+				var root = FindRoot(serializedInput);
 				target = (T)BuildDictionary(target.GetType(), root);
 			}
 			else
 			{
-				var root = FindRoot(response.Content);
+				var root = FindRoot(serializedInput);
 				Map(target, (IDictionary<string, object>)root);
 			}
 

--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -42,10 +42,15 @@ namespace RestSharp.Deserializers
 
 		public virtual T Deserialize<T>(IRestResponse response)
 		{
-			if (string.IsNullOrEmpty( response.Content ))
+			return this.Deserialize<T>(response.Content);
+		}
+
+		public virtual T Deserialize<T>(string serializedInput)
+		{
+			if (string.IsNullOrEmpty( serializedInput ))
 				return default(T);
 
-			var doc = XDocument.Parse(response.Content);
+			var doc = XDocument.Parse(serializedInput);
 			var root = doc.Root;
 			if (RootElement.HasValue() && doc.Root != null)
 			{


### PR DESCRIPTION
RestSharp has such a nice Deserializer implementation that I wanted to be able to also deserialize input that hasn't been retrieved through a RestSharp request. This simply adds an overloaded method with a string input; IRestResponse deserializations now just use response.Content as string input for the new method. No other changes have been made. 
