### PR TITLE
Added RestRequest.AddQueryParameter()

### DIFF
--- a/RestSharp/IRestRequest.cs
+++ b/RestSharp/IRestRequest.cs
@@ -245,6 +245,14 @@ namespace RestSharp
 		/// <returns></returns>
 		IRestRequest AddUrlSegment(string name, string value);
 
+		/// <summary>
+		/// Shortcut to AddParameter(name, value, QueryString) overload
+		/// </summary>
+		/// <param name="name">Name of the parameter to add</param>
+		/// <param name="value">Value of the parameter to add</param>
+		/// <returns></returns>
+		IRestRequest AddQueryParameter(string name, string value);
+
 		Action<IRestResponse> OnBeforeDeserialization { get; set; }
 		void IncreaseNumAttempts();
 	}

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -382,6 +382,17 @@ namespace RestSharp
 		}
 
 		/// <summary>
+		/// Shortcut to AddParameter(name, value, QueryString) overload
+		/// </summary>
+		/// <param name="name">Name of the parameter to add</param>
+		/// <param name="value">Value of the parameter to add</param>
+		/// <returns></returns>
+		public IRestRequest AddQueryParameter (string name, string value)
+		{
+			return AddParameter(name, value, ParameterType.QueryString);
+		}
+
+		/// <summary>
 		/// Container of all HTTP parameters to be passed with the request. 
 		/// See AddParameter() for explanation of the types of parameters that can be passed
 		/// </summary>


### PR DESCRIPTION
Added a shorthand method `AddQueryParameter()` to `RestRequest` and `IRestRequest`, for calling `AddParameter(name, value, ParameterType.QueryString)`
