### PR TITLE
Change "whitelist" to "includedProperties" to avoid offense in some markets

### DIFF
--- a/RestSharp/IRestRequest.cs
+++ b/RestSharp/IRestRequest.cs
@@ -183,7 +183,7 @@ namespace RestSharp
 		/// <param name="obj">The object with properties to add as parameters</param>
 		/// <param name="includedProperties">The names of the properties to include</param>
 		/// <returns>This request</returns>
-		IRestRequest AddObject (object obj, string[] includedProperties);
+		IRestRequest AddObject (object obj, params string[] includedProperties);
 
 		/// <summary>
 		/// Calls AddParameter() for all public, readable properties of obj

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -260,7 +260,7 @@ namespace RestSharp
 		/// <param name="obj">The object with properties to add as parameters</param>
 		/// <param name="includedProperties">The names of the properties to include</param>
 		/// <returns>This request</returns>
-		public IRestRequest AddObject (object obj, string[] includedProperties)
+		public IRestRequest AddObject (object obj, params string[] includedProperties)
 		{
 			// automatically create parameters from object props
 			var type = obj.GetType();


### PR DESCRIPTION
The term "whitelist" is not allowed by my employer as it may be interpreted as racially offensive. This change will allow my team to continue using RestSharp in our service. 

(RestSharp is "not our code", but the interfaces show up static analysis tools)
