### PR TITLE
Fixed bug where XmlDeserializer would not deserialize public nested type

### DIFF
--- a/RestSharp.Tests/NamespacedXmlTests.cs
+++ b/RestSharp.Tests/NamespacedXmlTests.cs
@@ -253,7 +253,11 @@ namespace RestSharp.Tests
 								new XElement(ns + "Since", DateTime.Now.Year - i)
 							));
 			}
-			root.Add(friends);
+            root.Add(friends);
+
+            root.Add(new XElement(ns + "FavoriteBand",
+                        new XElement(ns + "Name", "Goldfinger")
+                    ));
 
 			doc.Add(root);
 			return doc.ToString();

--- a/RestSharp.Tests/SampleClasses/misc.cs
+++ b/RestSharp.Tests/SampleClasses/misc.cs
@@ -48,6 +48,11 @@ namespace RestSharp.Tests
 		public Order Order { get; set; }
 
 		public Disposition Disposition { get; set; }
+        public Band FavoriteBand { get; set; }
+        public class Band
+        {
+            public string Name { get; set; }
+        }
 
 	}
 

--- a/RestSharp.Tests/XmlAttributeDeserializerTests.cs
+++ b/RestSharp.Tests/XmlAttributeDeserializerTests.cs
@@ -290,7 +290,18 @@ namespace RestSharp.Tests
 
 			Assert.Equal(date, output.StartDate);
 		}
+        [Fact]
+        public void Can_Deserialize_Nested_Class()
+        {
+            var doc = CreateElementsXml();
+            var response = new RestResponse { Content = doc };
 
+            var d = new XmlAttributeDeserializer();
+            var p = d.Deserialize<PersonForXml>(response);
+
+            Assert.NotNull(p.FavoriteBand);
+            Assert.Equal("Goldfinger",p.FavoriteBand.Name);
+        }
 		[Fact]
 		public void Can_Deserialize_Elements_On_Default_Root()
 		{
@@ -838,6 +849,10 @@ namespace RestSharp.Tests
 							));
 			}
 			root.Add(friends);
+
+            root.Add(new XElement("FavoriteBand",
+                 new XElement("Name", "Goldfinger")
+             ));
 
 			doc.Add(root);
 			return doc.ToString();

--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -96,8 +96,8 @@ namespace RestSharp.Deserializers
 			foreach (var prop in props)
 			{
 				var type = prop.PropertyType;
-
-				if (!type.IsPublic || !prop.CanWrite)
+                var typeIsPublic = type.IsPublic || type.IsNestedPublic;
+				if (!typeIsPublic || !prop.CanWrite)
 					continue;
 
 				var name = prop.Name.AsNamespaced(Namespace);


### PR DESCRIPTION
The RestSharp XmlDeserializer only tries to deserialize types where
Type.IsPublic is true. For nested public classes, Type.IsPublic is
false, but Type.IsNestedPublic is true . Updated deserializer to check
for this condition
