### PR TITLE
Added support for PCL - Profile 259

### DIFF
--- a/RestSharp.Portable/Properties/AssemblyInfo.cs
+++ b/RestSharp.Portable/Properties/AssemblyInfo.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RestSharp.Portable")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+#if SIGNED
+[assembly: InternalsVisibleTo("RestSharp.IntegrationTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fda57af14a288d46e3efea89617037585c4de57159cd536ca6dff792ea1d6addc665f2fccb4285413d9d44db5a1be87cb82686db200d16325ed9c42c89cd4824d8cc447f7cee2ac000924c3bceeb1b7fcb5cc1a3901785964d48ce14172001084134f4dcd9973c3776713b595443b1064bb53e2eeb924969244d354e46495e9d"),
+           InternalsVisibleTo("RestSharp.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100fda57af14a288d46e3efea89617037585c4de57159cd536ca6dff792ea1d6addc665f2fccb4285413d9d44db5a1be87cb82686db200d16325ed9c42c89cd4824d8cc447f7cee2ac000924c3bceeb1b7fcb5cc1a3901785964d48ce14172001084134f4dcd9973c3776713b595443b1064bb53e2eeb924969244d354e46495e9d")]
+#else
+[assembly: InternalsVisibleTo("RestSharp.IntegrationTests"),
+		   InternalsVisibleTo("RestSharp.Tests")]
+#endif

--- a/RestSharp.Portable/RestSharp.Portable.csproj
+++ b/RestSharp.Portable/RestSharp.Portable.csproj
@@ -1,0 +1,263 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RestSharp</RootNamespace>
+    <AssemblyName>RestSharp</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;PORTABLE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <DocumentationFile>bin\Debug\RestSharp.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
+    <NoWarn>1591,1584,1572,1574,1658</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;PORTABLE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <DocumentationFile>bin\Release\RestSharp.xml</DocumentationFile>
+    <NoWarn>1591,1573,1658,1584,1574,1572</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\restsharp\authenticators\HttpBasicAuthenticator.cs">
+      <Link>Authenticators\HttpBasicAuthenticator.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\IAuthenticator.cs">
+      <Link>Authenticators\IAuthenticator.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\NtlmAuthenticator.cs">
+      <Link>Authenticators\NtlmAuthenticator.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\OAuth1Authenticator.cs">
+      <Link>Authenticators\OAuth1Authenticator.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\OAuth2Authenticator.cs">
+      <Link>Authenticators\OAuth2Authenticator.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\extensions\CollectionExtensions.cs">
+      <Link>Authenticators\OAuth\Extensions\CollectionExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\extensions\OAuthExtensions.cs">
+      <Link>Authenticators\OAuth\Extensions\OAuthExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\extensions\StringExtensions.cs">
+      <Link>Authenticators\OAuth\Extensions\StringExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\extensions\TimeExtensions.cs">
+      <Link>Authenticators\OAuth\Extensions\TimeExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\HttpPostParameter.cs">
+      <Link>Authenticators\OAuth\HttpPostParameter.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\HttpPostParameterType.cs">
+      <Link>Authenticators\OAuth\HttpPostParameterType.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\OAuthParameterHandling.cs">
+      <Link>Authenticators\OAuth\OAuthParameterHandling.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\OAuthSignatureMethod.cs">
+      <Link>Authenticators\OAuth\OAuthSignatureMethod.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\OAuthSignatureTreatment.cs">
+      <Link>Authenticators\OAuth\OAuthSignatureTreatment.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\OAuthTools.cs">
+      <Link>Authenticators\OAuth\OAuthTools.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\OAuthType.cs">
+      <Link>Authenticators\OAuth\OAuthType.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\OAuthWebQueryInfo.cs">
+      <Link>Authenticators\OAuth\OAuthWebQueryInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\OAuthWorkflow.cs">
+      <Link>Authenticators\OAuth\OAuthWorkflow.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\WebPair.cs">
+      <Link>Authenticators\OAuth\WebPair.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\WebPairCollection.cs">
+      <Link>Authenticators\OAuth\WebPairCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\WebParameter.cs">
+      <Link>Authenticators\OAuth\WebParameter.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\oauth\WebParameterCollection.cs">
+      <Link>Authenticators\OAuth\WebParameterCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\authenticators\SimpleAuthenticator.cs">
+      <Link>Authenticators\SimpleAuthenticator.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\deserializers\DeserializeAsAttribute.cs">
+      <Link>Deserializers\DeserializeAsAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\deserializers\DotNetXmlDeserializer.cs">
+      <Link>Deserializers\DotNetXmlDeserializer.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\deserializers\IDeserializer.cs">
+      <Link>Deserializers\IDeserializer.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\deserializers\JsonDeserializer.cs">
+      <Link>Deserializers\JsonDeserializer.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\deserializers\XmlAttributeDeserializer.cs">
+      <Link>Deserializers\XmlAttributeDeserializer.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\deserializers\XmlDeserializer.cs">
+      <Link>Deserializers\XmlDeserializer.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\Enum.cs">
+      <Link>Enum.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\extensions\MiscExtensions.cs">
+      <Link>Extensions\MiscExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\extensions\ReflectionExtensions.cs">
+      <Link>Extensions\ReflectionExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\extensions\ResponseExtensions.cs">
+      <Link>Extensions\ResponseExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\Extensions\ResponseStatusExtensions.cs">
+      <Link>Extensions\ResponseStatusExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\extensions\StringExtensions.cs">
+      <Link>Extensions\StringExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\extensions\XmlExtensions.cs">
+      <Link>Extensions\XmlExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\FileParameter.cs">
+      <Link>FileParameter.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\Http.Async.cs">
+      <Link>Http.Async.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\Http.cs">
+      <Link>Http.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\HttpCookie.cs">
+      <Link>HttpCookie.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\HttpFile.cs">
+      <Link>HttpFile.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\HttpHeader.cs">
+      <Link>HttpHeader.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\HttpParameter.cs">
+      <Link>HttpParameter.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\HttpResponse.cs">
+      <Link>HttpResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\IHttp.cs">
+      <Link>IHttp.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\IHttpFactory.cs">
+      <Link>IHttpFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\IHttpResponse.cs">
+      <Link>IHttpResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\IRestClient.cs">
+      <Link>IRestClient.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\IRestRequest.cs">
+      <Link>IRestRequest.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\IRestResponse.cs">
+      <Link>IRestResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\Parameter.cs">
+      <Link>Parameter.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\RestClient.Async.cs">
+      <Link>RestClient.Async.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\RestClient.cs">
+      <Link>RestClient.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\RestClientExtensions.cs">
+      <Link>RestClientExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\RestRequest.cs">
+      <Link>RestRequest.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\RestRequestAsyncHandle.cs">
+      <Link>RestRequestAsyncHandle.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\RestResponse.cs">
+      <Link>RestResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\RestResponseCookie.cs">
+      <Link>RestResponseCookie.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\serializers\DotNetXmlSerializer.cs">
+      <Link>Serializers\DotNetXmlSerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\serializers\ISerializer.cs">
+      <Link>Serializers\ISerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\serializers\JsonSerializer.cs">
+      <Link>Serializers\JsonSerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\serializers\SerializeAsAttribute.cs">
+      <Link>Serializers\SerializeAsAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\serializers\XmlSerializer.cs">
+      <Link>Serializers\XmlSerializer.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\SharedAssemblyInfo.cs">
+      <Link>SharedAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\RestSharp\SimpleJson.cs">
+      <Link>SimpleJson.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\validation\Require.cs">
+      <Link>Validation\Require.cs</Link>
+    </Compile>
+    <Compile Include="..\restsharp\validation\Validate.cs">
+      <Link>Validation\Validate.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/RestSharp.sln
+++ b/RestSharp.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet", "NuGet", "{E709A928-A45C-4622-A35C-CCD8EE44CA80}"
 	ProjectSection(SolutionItems) = preProject
@@ -38,6 +38,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RestSharp.Net4", "RestSharp.Net4\RestSharp.Net4.csproj", "{5FF943A5-260F-4042-B4CE-C4977BAD4EBB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RestSharp.Build", "RestSharp.Build\RestSharp.Build.csproj", "{CCC30138-3D68-44D8-AF1A-D22F769EE8DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RestSharp.Portable", "RestSharp.Portable\RestSharp.Portable.csproj", "{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -184,6 +186,24 @@ Global
 		{CCC30138-3D68-44D8-AF1A-D22F769EE8DC}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{CCC30138-3D68-44D8-AF1A-D22F769EE8DC}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{CCC30138-3D68-44D8-AF1A-D22F769EE8DC}.Release|x86.ActiveCfg = Release|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.DebugAppveyor|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.DebugAppveyor|Any CPU.Build.0 = Debug|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.DebugAppveyor|ARM.ActiveCfg = Debug|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.DebugAppveyor|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.DebugAppveyor|Mixed Platforms.Build.0 = Debug|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.DebugAppveyor|x86.ActiveCfg = Debug|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.Release|ARM.ActiveCfg = Release|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{8DBD6F4C-EC41-4EC6-9902-C3D88EABC2DF}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RestSharp/Authenticators/OAuth/Extensions/CollectionExtensions.cs
+++ b/RestSharp/Authenticators/OAuth/Extensions/CollectionExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Text;
+using RestSharp.Extensions;
 
 namespace RestSharp.Authenticators.OAuth.Extensions
 {
@@ -48,8 +49,18 @@ namespace RestSharp.Authenticators.OAuth.Extensions
                 action(item);
             }
         }
+		
+#if PORTABLE
+		public static void ForEach(this string items, Action<char> action)
+		{
+			foreach (char item in items)
+			{
+				action(item);
+			}
+		}
+#endif
 
-#if !WINDOWS_PHONE && !SILVERLIGHT && !PocketPC
+#if !WINDOWS_PHONE && !SILVERLIGHT && !PocketPC && !PORTABLE
 
         public static void AddRange(this IDictionary<string, string> collection, NameValueCollection range)
         {

--- a/RestSharp/Authenticators/OAuth/Extensions/OAuthExtensions.cs
+++ b/RestSharp/Authenticators/OAuth/Extensions/OAuthExtensions.cs
@@ -1,5 +1,7 @@
 using System;
+#if !PORTABLE
 using System.Security.Cryptography;
+#endif
 using System.Text;
 
 namespace RestSharp.Authenticators.OAuth.Extensions
@@ -26,11 +28,13 @@ namespace RestSharp.Authenticators.OAuth.Extensions
             }
         }
 
+#if !PORTABLE
         public static string HashWith(this string input, HashAlgorithm algorithm)
         {
             var data = Encoding.UTF8.GetBytes(input);
             var hash = algorithm.ComputeHash(data);
             return Convert.ToBase64String(hash);
         }
+#endif
     }
 }

--- a/RestSharp/Authenticators/OAuth/Extensions/StringExtensions.cs
+++ b/RestSharp/Authenticators/OAuth/Extensions/StringExtensions.cs
@@ -40,17 +40,6 @@ namespace RestSharp.Authenticators.OAuth.Extensions
             return String.Concat(input, value);
         }
 
-        public static string UrlEncode(this string value)
-        {
-            // [DC] This is more correct than HttpUtility; it escapes spaces as %20, not +
-            return Uri.EscapeDataString(value);
-        }
-
-        public static string UrlDecode(this string value)
-        {
-            return Uri.UnescapeDataString(value);
-        }
-
         public static Uri AsUri(this string value)
         {
             return new Uri(value);
@@ -94,9 +83,16 @@ namespace RestSharp.Authenticators.OAuth.Extensions
                     pair => pair[0], pair => pair[1]
                 );
         }
+		
+#if PORTABLE
+        public static bool Contains(this string value, char character)
+        {
+            return value.IndexOf(character) != -1;
+        }
+#endif
 
         private const RegexOptions Options =
-#if !WINDOWS_PHONE && !SILVERLIGHT && !PocketPC
+#if !WINDOWS_PHONE && !SILVERLIGHT && !PocketPC && !PORTABLE
             RegexOptions.Compiled | RegexOptions.IgnoreCase;
 #else
             RegexOptions.IgnoreCase;

--- a/RestSharp/Authenticators/OAuth/HttpPostParameterType.cs
+++ b/RestSharp/Authenticators/OAuth/HttpPostParameterType.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace RestSharp.Authenticators.OAuth
 {
-#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC
+#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC && !PORTABLE
     [Serializable]
 #endif
     internal enum HttpPostParameterType

--- a/RestSharp/Authenticators/OAuth/OAuthParameterHandling.cs
+++ b/RestSharp/Authenticators/OAuth/OAuthParameterHandling.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace RestSharp.Authenticators.OAuth
 {
-#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC
+#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC && !PORTABLE
     [Serializable]
 #endif
     public enum OAuthParameterHandling

--- a/RestSharp/Authenticators/OAuth/OAuthSignatureMethod.cs
+++ b/RestSharp/Authenticators/OAuth/OAuthSignatureMethod.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace RestSharp.Authenticators.OAuth
 {
-#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC
+#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC && !PORTABLE
     [Serializable]
 #endif
     public enum OAuthSignatureMethod

--- a/RestSharp/Authenticators/OAuth/OAuthSignatureTreatment.cs
+++ b/RestSharp/Authenticators/OAuth/OAuthSignatureTreatment.cs
@@ -2,7 +2,7 @@
 
 namespace RestSharp.Authenticators.OAuth
 {
-#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC
+#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC && !PORTABLE
     [Serializable]
 #endif
     public enum OAuthSignatureTreatment

--- a/RestSharp/Authenticators/OAuth/OAuthTools.cs
+++ b/RestSharp/Authenticators/OAuth/OAuthTools.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Linq;
+#if !PORTABLE
 using System.Security.Cryptography;
+#endif
 using System.Text;
 using RestSharp.Authenticators.OAuth.Extensions;
 
 namespace RestSharp.Authenticators.OAuth
 {
-#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC
+#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC && !PORTABLE
     [Serializable]
 #endif
     internal static class OAuthTools
@@ -20,13 +22,13 @@ namespace RestSharp.Authenticators.OAuth
         private static readonly Random _random;
         private static readonly object _randomLock = new object();
 
-#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC
+#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC && !PORTABLE
         private static readonly RandomNumberGenerator _rng = RandomNumberGenerator.Create();
 #endif
 
         static OAuthTools()
         {
-#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC
+#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC && !PORTABLE
             var bytes = new byte[4];
             _rng.GetNonZeroBytes(bytes);
             _random = new Random(BitConverter.ToInt32(bytes, 0));
@@ -312,7 +314,7 @@ namespace RestSharp.Authenticators.OAuth
 
             switch (signatureMethod)
             {
-#if !PocketPC
+#if !PocketPC && !PORTABLE
                 case OAuthSignatureMethod.HmacSha1:
                     {
                         var crypto = new HMACSHA1();
@@ -333,7 +335,7 @@ namespace RestSharp.Authenticators.OAuth
                     }
 
                 default:
-#if PocketPC
+#if PocketPC || PORTABLE
                     throw new NotImplementedException("Only PlainText is currently supported.");
 #else
                     throw new NotImplementedException("Only HMAC-SHA1 is currently supported.");

--- a/RestSharp/Authenticators/OAuth/OAuthType.cs
+++ b/RestSharp/Authenticators/OAuth/OAuthType.cs
@@ -2,7 +2,7 @@
 
 namespace RestSharp.Authenticators.OAuth
 {
-#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC
+#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC && !PORTABLE
     [Serializable]
 #endif
     public enum OAuthType

--- a/RestSharp/Authenticators/OAuth/OAuthWebQueryInfo.cs
+++ b/RestSharp/Authenticators/OAuth/OAuthWebQueryInfo.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace RestSharp.Authenticators.OAuth
 {
-#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC
+#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC && !PORTABLE
     [Serializable]
 #endif
     public class OAuthWebQueryInfo

--- a/RestSharp/Authenticators/OAuth/OAuthWorkflow.cs
+++ b/RestSharp/Authenticators/OAuth/OAuthWorkflow.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using RestSharp.Authenticators.OAuth.Extensions;
-#if !WINDOWS_PHONE && !SILVERLIGHT && !PocketPC
+#if !WINDOWS_PHONE && !SILVERLIGHT && !PocketPC && !PORTABLE
 using RestSharp.Contrib;
 #endif
 
@@ -223,13 +223,13 @@ namespace RestSharp.Authenticators.OAuth
 
             // Include url parameters in query pool
             var uri = new Uri(url);
-#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC
+#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC && !PORTABLE
             var urlParameters = HttpUtility.ParseQueryString(uri.Query);
 #else
             var urlParameters = uri.Query.ParseQueryString();
 #endif
 
-#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC
+#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC && !PORTABLE
             foreach (var parameter in urlParameters.AllKeys)
 #else
                 foreach (var parameter in urlParameters.Keys)

--- a/RestSharp/Authenticators/OAuth/WebPairCollection.cs
+++ b/RestSharp/Authenticators/OAuth/WebPairCollection.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+#if !PORTABLE
 using System.Collections.Specialized;
+#endif
 using System.Linq;
 
 namespace RestSharp.Authenticators.OAuth
@@ -30,7 +32,7 @@ namespace RestSharp.Authenticators.OAuth
             _parameters = new List<WebPair>(parameters);
         }
 
-#if !WINDOWS_PHONE && !SILVERLIGHT && !PocketPC
+#if !WINDOWS_PHONE && !SILVERLIGHT && !PocketPC && !PORTABLE
         public WebPairCollection(NameValueCollection collection)
             : this()
         {

--- a/RestSharp/Authenticators/OAuth/WebParameter.cs
+++ b/RestSharp/Authenticators/OAuth/WebParameter.cs
@@ -8,7 +8,7 @@ namespace RestSharp.Authenticators.OAuth
 #if !Smartphone && !PocketPC
     [DebuggerDisplay("{Name}:{Value}")]
 #endif
-#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC
+#if !SILVERLIGHT && !WINDOWS_PHONE && !PocketPC && !PORTABLE
     [Serializable]
 #endif
     internal class WebParameter : WebPair

--- a/RestSharp/Authenticators/OAuth/WebParameterCollection.cs
+++ b/RestSharp/Authenticators/OAuth/WebParameterCollection.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+#if !PORTABLE
 using System.Collections.Specialized;
+#endif
 
 namespace RestSharp.Authenticators.OAuth
 {
@@ -8,7 +10,7 @@ namespace RestSharp.Authenticators.OAuth
         public WebParameterCollection(IEnumerable<WebPair> parameters)
             : base(parameters) { }
 
-#if !WINDOWS_PHONE && !SILVERLIGHT && !PocketPC
+#if !WINDOWS_PHONE && !SILVERLIGHT && !PocketPC && !PORTABLE
         public WebParameterCollection(NameValueCollection collection)
             : base(collection) { }
 #endif

--- a/RestSharp/Authenticators/OAuth1Authenticator.cs
+++ b/RestSharp/Authenticators/OAuth1Authenticator.cs
@@ -24,9 +24,10 @@ using RestSharp.Authenticators.OAuth.Extensions;
 using System.Net;
 #elif SILVERLIGHT
 using System.Windows.Browser;
-#else
+#elif !PORTABLE
 using RestSharp.Contrib;
 #endif
+using RestSharp.Extensions;
 
 namespace RestSharp.Authenticators
 {
@@ -270,7 +271,7 @@ namespace RestSharp.Authenticators
                         !parameter.Name.IsNullOrBlank() &&
                         (parameter.Name.StartsWith("oauth_") || parameter.Name.StartsWith("x_auth_"))))
                     {
-                        request.AddParameter(parameter.Name, HttpUtility.UrlDecode(parameter.Value));
+                        request.AddParameter(parameter.Name, parameter.Value.UrlDecode());
                     }
                     break;
 

--- a/RestSharp/Extensions/MiscExtensions.cs
+++ b/RestSharp/Extensions/MiscExtensions.cs
@@ -24,7 +24,7 @@ namespace RestSharp.Extensions
     /// </summary>
     public static class MiscExtensions
     {
-#if !WINDOWS_PHONE && !PocketPC
+#if !WINDOWS_PHONE && !PocketPC && !PORTABLE
         /// <summary>
         /// Save a byte array to a file
         /// </summary>

--- a/RestSharp/Extensions/ResponseStatusExtensions.cs
+++ b/RestSharp/Extensions/ResponseStatusExtensions.cs
@@ -16,18 +16,40 @@ namespace RestSharp.Extensions
             switch (responseStatus)
             {
                 case ResponseStatus.None:
-                    return new WebException("The request could not be processed.",
-                        WebExceptionStatus.ServerProtocolViolation);
+		            return new WebException("The request could not be processed.",
+#if !PORTABLE
+						WebExceptionStatus.ServerProtocolViolation
+#else
+			            WebExceptionStatus.UnknownError
+#endif
+			            );
 
                 case ResponseStatus.Error:
-                    return new WebException("An error occurred while processing the request.",
-                        WebExceptionStatus.ServerProtocolViolation);
+		            return new WebException("An error occurred while processing the request.",
+#if !PORTABLE
+						WebExceptionStatus.ServerProtocolViolation
+#else
+			            WebExceptionStatus.UnknownError
+#endif
+			            );
 
                 case ResponseStatus.TimedOut:
-                    return new WebException("The request timed-out.", WebExceptionStatus.Timeout);
+		            return new WebException("The request timed-out.",
+#if !PORTABLE
+						WebExceptionStatus.Timeout
+#else
+			            WebExceptionStatus.SendFailure
+#endif
+			            );
 
                 case ResponseStatus.Aborted:
-                    return new WebException("The request was aborted.", WebExceptionStatus.Timeout);
+		            return new WebException("The request was aborted.",
+#if !PORTABLE
+						WebExceptionStatus.Timeout
+#else
+			            WebExceptionStatus.RequestCanceled
+#endif
+			            );
 
                 default:
                     throw new ArgumentOutOfRangeException("responseStatus");

--- a/RestSharp/Extensions/StringExtensions.cs
+++ b/RestSharp/Extensions/StringExtensions.cs
@@ -40,7 +40,7 @@ namespace RestSharp.Extensions
 #if !PocketPC
         public static string UrlDecode(this string input)
         {
-            return HttpUtility.UrlDecode(input);
+            return Uri.UnescapeDataString(input);
         }
 #endif
 
@@ -75,12 +75,12 @@ namespace RestSharp.Extensions
 #if !PocketPC
         public static string HtmlDecode(this string input)
         {
-            return HttpUtility.HtmlDecode(input);
+            return Uri.UnescapeDataString(input);
         }
 
         public static string HtmlEncode(this string input)
         {
-            return HttpUtility.HtmlEncode(input);
+            return Uri.EscapeDataString(input);
         }
 #endif
 
@@ -296,9 +296,9 @@ namespace RestSharp.Extensions
                         string restOfWord = word.Substring(1);
 
                         if (restOfWord.IsUpperCase())
-                            restOfWord = restOfWord.ToLower(culture);
+                            restOfWord = culture.TextInfo.ToLower(restOfWord);
 
-                        char firstChar = char.ToUpper(word[0], culture);
+                        char firstChar = culture.TextInfo.ToUpper(word[0]);
 
                         words[i] = String.Concat(firstChar, restOfWord);
                     }
@@ -307,7 +307,7 @@ namespace RestSharp.Extensions
                 return String.Join(joinString, words);
             }
 
-            return String.Concat(words[0].Substring(0, 1).ToUpper(culture), words[0].Substring(1));
+            return String.Concat(culture.TextInfo.ToUpper(words[0].Substring(0, 1)), words[0].Substring(1));
         }
 
         /// <summary>
@@ -416,19 +416,19 @@ namespace RestSharp.Extensions
             yield return name.ToCamelCase(culture);
 
             // try lower cased name
-            yield return name.ToLower(culture);
+            yield return culture.TextInfo.ToLower(name);
 
             // try name with underscores
             yield return name.AddUnderscores();
 
             // try name with underscores with lower case
-            yield return name.AddUnderscores().ToLower(culture);
+            yield return culture.TextInfo.ToLower(name.AddUnderscores());
 
             // try name with dashes
             yield return name.AddDashes();
 
             // try name with dashes with lower case
-            yield return name.AddDashes().ToLower(culture);
+            yield return culture.TextInfo.ToLower(name.AddDashes());
 
             // try name with underscore prefix
             yield return name.AddUnderscorePrefix();
@@ -440,7 +440,7 @@ namespace RestSharp.Extensions
             yield return name.AddSpaces();
 
             // try name with spaces with lower case
-            yield return name.AddSpaces().ToLower(culture);
+            yield return culture.TextInfo.ToLower(name.AddSpaces());
         }
     }
 }

--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -186,7 +186,7 @@ namespace RestSharp
 
             if (HasBody || HasFiles || AlwaysMultipartFormData)
             {
-#if !WINDOWS_PHONE && !PocketPC
+#if !WINDOWS_PHONE && !PocketPC && !PORTABLE
                 webRequest.ContentLength = CalculateContentLength();
 #endif
                 asyncResult = webRequest.BeginGetRequestStream(result => RequestStreamCallback(result, callback), webRequest);
@@ -339,7 +339,7 @@ namespace RestSharp
 
             if (raw != null)
             {
-                raw.Close();
+                ((IDisposable)raw).Dispose();
             }
         }
 
@@ -398,7 +398,7 @@ namespace RestSharp
             webRequest.UseDefaultCredentials = UseDefaultCredentials;
 #endif
 
-#if !WINDOWS_PHONE && !SILVERLIGHT
+#if !WINDOWS_PHONE && !SILVERLIGHT && !PORTABLE
             webRequest.PreAuthenticate = PreAuthenticate;
 #endif
             AppendHeaders(webRequest);
@@ -407,7 +407,7 @@ namespace RestSharp
             webRequest.Method = method;
 
             // make sure Content-Length header is always sent since default is -1
-#if !WINDOWS_PHONE && !PocketPC
+#if !WINDOWS_PHONE && !PocketPC && !PORTABLE
             // WP7 doesn't as of Beta doesn't support a way to set this value either directly
             // or indirectly
             if (!HasFiles && !AlwaysMultipartFormData)
@@ -421,7 +421,7 @@ namespace RestSharp
                 webRequest.Credentials = Credentials;
             }
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !PORTABLE
             if (UserAgent.HasValue())
             {
                 webRequest.UserAgent = UserAgent;
@@ -458,7 +458,7 @@ namespace RestSharp
             }
 #endif
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !PORTABLE
             webRequest.AllowAutoRedirect = FollowRedirects;
 #endif
             return webRequest;

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -19,7 +19,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+#if FRAMEWORK
 using System.Security.Cryptography.X509Certificates;
+#endif
 using System.Text;
 using RestSharp.Extensions;
 
@@ -120,7 +122,7 @@ namespace RestSharp
         /// </summary>
         public IList<HttpFile> Files { get; private set; }
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !PORTABLE
         /// <summary>
         /// Whether or not HTTP 3xx response redirects should be automatically followed
         /// </summary>
@@ -443,7 +445,7 @@ namespace RestSharp
                     response.Headers.Add(new HttpHeader { Name = headerName, Value = headerValue });
                 }
 
-                webResponse.Close();
+                ((IDisposable)webResponse).Dispose();
             }
         }
 

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -18,7 +18,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+#if FRAMEWORK
 using System.Security.Cryptography.X509Certificates;
+#endif
 
 namespace RestSharp
 {
@@ -43,7 +45,7 @@ namespace RestSharp
 
         int ReadWriteTimeout { get; set; }
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !PORTABLE
         bool FollowRedirects { get; set; }
 #endif
 

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -17,8 +17,10 @@
 using System;
 using System.Net;
 using System.Collections.Generic;
+#if FRAMEWORK
 using System.Security.Cryptography.X509Certificates;
-#if NET4 || MONODROID || MONOTOUCH || WP8
+#endif
+#if NET4 || MONODROID || MONOTOUCH || WP8 || PORTABLE
 using System.Threading;
 using System.Threading.Tasks;
 #endif
@@ -151,7 +153,7 @@ namespace RestSharp
         IRestResponse<T> ExecuteAsPost<T>(IRestRequest request, string httpMethod) where T : new();
 #endif
 
-#if NET4 || MONODROID || MONOTOUCH || WP8
+#if NET4 || MONODROID || MONOTOUCH || WP8 || PORTABLE
         /// <summary>
         /// Executes the request and callback asynchronously, authenticating if needed
         /// </summary>

--- a/RestSharp/RestClient.Async.cs
+++ b/RestSharp/RestClient.Async.cs
@@ -16,7 +16,7 @@
 
 using System;
 using System.Threading;
-#if NET4 || MONODROID || MONOTOUCH || WP8
+#if NET4 || MONODROID || MONOTOUCH || WP8 || PORTABLE
 using System.Threading.Tasks;
 #endif
 using System.Net;
@@ -187,7 +187,7 @@ namespace RestSharp
             callback(restResponse, asyncHandle);
         }
 
-#if NET4 || MONODROID || MONOTOUCH || WP8
+#if NET4 || MONODROID || MONOTOUCH || WP8 || PORTABLE
     /// <summary>
     /// Executes a GET-style request asynchronously, authenticating if needed
     /// </summary>

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -19,7 +19,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+#if FRAMEWORK
 using System.Security.Cryptography.X509Certificates;
+#endif
 using RestSharp.Deserializers;
 using RestSharp.Extensions;
 
@@ -33,6 +35,8 @@ namespace RestSharp
         // silverlight friendly way to get current version
 #if PocketPC
         static readonly Version version = Assembly.GetExecutingAssembly().GetName().Version;
+#elif PORTABLE
+		private static readonly Version version = new AssemblyName(typeof(RestClient).GetTypeInfo().Assembly.FullName).Version;
 #else
         private static readonly Version version = new AssemblyName(Assembly.GetExecutingAssembly().FullName).Version;
 #endif
@@ -378,7 +382,7 @@ namespace RestSharp
                 http.ReadWriteTimeout = readWriteTimeout;
             }
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !PORTABLE
             http.FollowRedirects = FollowRedirects;
 #endif
 

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using RestSharp.Extensions;
 using RestSharp.Serializers;
@@ -118,6 +119,7 @@ namespace RestSharp
             //resource.PathAndQuery not supported by Silverlight :(
         }
 
+#if !PORTABLE
         /// <summary>
         /// Adds a file to the Files collection to be included with a POST or PUT request 
         /// (other methods do not support file uploads).
@@ -144,6 +146,7 @@ namespace RestSharp
                 }
             });
         }
+#endif
 
         /// <summary>
         /// Adds the bytes to the Files collection with the specified file name
@@ -316,7 +319,7 @@ namespace RestSharp
                             var elementType = propType.GetElementType();
 
                             if (((Array)val).Length > 0 &&
-                                (elementType.IsPrimitive || elementType.IsValueType || elementType == typeof(string)))
+                                (elementType.GetTypeInfo().IsPrimitive || elementType.GetTypeInfo().IsValueType || elementType == typeof(string)))
                             {
                                 // convert the array to an array of strings
                                 var values =

--- a/RestSharp/Serializers/XmlSerializer.cs
+++ b/RestSharp/Serializers/XmlSerializer.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Xml.Linq;
 using RestSharp.Extensions;
 
@@ -151,7 +152,7 @@ namespace RestSharp.Serializers
                 var nsName = name.AsNamespaced(Namespace);
                 var element = new XElement(nsName);
 
-                if (propType.IsPrimitive || propType.IsValueType || propType == typeof(string))
+                if (propType.GetTypeInfo().IsPrimitive || propType.GetTypeInfo().IsValueType || propType == typeof(string))
                 {
                     if (useAttribute)
                     {
@@ -202,7 +203,7 @@ namespace RestSharp.Serializers
 
             if (obj is bool)
             {
-                output = ((bool)obj).ToString(CultureInfo.InvariantCulture).ToLower();
+                output = ((bool)obj).ToString().ToLowerInvariant();
             }
 
             if (IsNumeric(obj))

--- a/RestSharp/SimpleJson.cs
+++ b/RestSharp/SimpleJson.cs
@@ -46,7 +46,7 @@
 
 // original json parsing code from http://techblog.procurios.nl/k/618/news/view/14605/14863/How-do-I-write-my-own-parser-for-JSON.html
 
-#if NETFX_CORE
+#if NETFX_CORE || PORTABLE
 #define SIMPLE_JSON_TYPEINFO
 #endif
 


### PR DESCRIPTION
This includes all platforms that support .NET 4.5, except Silverlight 5

Most of the code is intact, supporting all the features that were in the iOS, Android, WP and most of NET45.
The only thing that cannot be supported is the cryptography, due to this being removed entirely.

I ran the unit tests on the actual PCL, and all passed. However, this did not test the OAuth integration, which may not work.

My OAuth knowledge is pretty thin, but I am assuming that the bits are not required to be encrypted, but should be for any sane developer. However, this library should work fine for apps that don't require OAuth, and if it is needed, the platform specific one can be swapped in (build against the PCL, but the app uses the platform version). Swapping will work as the API is exactly the same. This is going to be great to be able to use this lib in say Xamarin.Forms, and not require the platform-specific version.

Please let me know if things need changing or whatnot.
