### PR TITLE
avoid rebuilding the Basic Authentication header for each request

### DIFF
--- a/RestSharp/Authenticators/HttpBasicAuthenticator.cs
+++ b/RestSharp/Authenticators/HttpBasicAuthenticator.cs
@@ -22,13 +22,12 @@ namespace RestSharp
 {
     public class HttpBasicAuthenticator : IAuthenticator
     {
-        private readonly string _username;
-        private readonly string _password;
+        private readonly string _authHeader;
 
         public HttpBasicAuthenticator(string username, string password)
         {
-            _password = password;
-            _username = username;
+            var token = Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format("{0}:{1}", username, password)));
+            _authHeader = string.Format("Basic {0}", token);
         }
 
         public void Authenticate(IRestClient client, IRestRequest request)
@@ -43,10 +42,7 @@ namespace RestSharp
             // only add the Authorization parameter if it hasn't been added by a previous Execute
             if (!request.Parameters.Any(p => p.Name.Equals("Authorization", StringComparison.OrdinalIgnoreCase)))
             {
-                var token = Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format("{0}:{1}", _username, _password)));
-                var authHeader = string.Format("Basic {0}", token);
-
-                request.AddParameter("Authorization", authHeader, ParameterType.HttpHeader);
+                request.AddParameter("Authorization", _authHeader, ParameterType.HttpHeader);
             }
         }
     }


### PR DESCRIPTION
The username and password never change, so there is no need to re-encode them in Base64 for each request. We can juste compute the header value once and reuse it to save time.
