### PR TITLE
Fix to issue in #466 and others. ExecuteTaskAsync should not throw exceptions

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -368,7 +368,17 @@ namespace RestSharp
 
         private static void ExecuteCallback(HttpResponse response, Action<HttpResponse> callback)
         {
+            PopulateErrorForIncompleteResponse(response);
             callback(response);
+        }
+
+        private static void PopulateErrorForIncompleteResponse(HttpResponse response)
+        {
+            if (response.ResponseStatus != ResponseStatus.Completed && response.ErrorException == null)
+            {
+                response.ErrorException = response.ResponseStatus.ToWebException();
+                response.ErrorMessage = response.ErrorException.Message;
+            }
         }
 
         partial void AddAsyncHeaderActions()

--- a/RestSharp/RestClient.Async.cs
+++ b/RestSharp/RestClient.Async.cs
@@ -275,14 +275,7 @@ namespace RestSharp
                         {
                             taskCompletionSource.TrySetCanceled();
                         }
-                        else if (response.ErrorException != null)
-                        {
-                            taskCompletionSource.TrySetException(response.ErrorException);
-                        }
-                        else if (response.ResponseStatus != ResponseStatus.Completed)
-                        {
-                            taskCompletionSource.TrySetException(response.ResponseStatus.ToWebException());
-                        }
+                        //Don't run TrySetException, since we should set Error properties and swallow exceptions to be consistent with sync methods
                         else
                         {
                             taskCompletionSource.TrySetResult(response);
@@ -384,14 +377,7 @@ namespace RestSharp
                         {
                             taskCompletionSource.TrySetCanceled();
                         }
-                        else if (response.ErrorException != null)
-                        {
-                            taskCompletionSource.TrySetException(response.ErrorException);
-                        }
-                        else if (response.ResponseStatus != ResponseStatus.Completed)
-                        {
-                            taskCompletionSource.TrySetException(response.ResponseStatus.ToWebException());
-                        }
+                        //Don't run TrySetException, since we should set Error properties and swallow exceptions to be consistent with sync methods
                         else
                         {
                             taskCompletionSource.TrySetResult(response);


### PR DESCRIPTION
This issue seems to plague a lot of people.

Execute (sync) and ExecuteAsync handle exceptions by swallowing them and setting the Error properties on the response object. This change makes ExecuteTaskAsync also swallow its errors by NOT invoking  taskCompletionSource.TrySetException(response.ErrorException) in RestClient.Async.cs.

The change in Http.Async.cs was simply to populate the ErrorException with a ResponseStatus.ToWebException() if empty, making it even more consistent with Execute (sync).

Most of the code changes were changes to tests that expected ExecuteTaskAsync to throw exceptions.
