### PR TITLE
ServicePointManager to ServicePoint Change

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -443,7 +443,8 @@ namespace RestSharp
             }
 
             webRequest.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip | DecompressionMethods.None;
-            ServicePointManager.Expect100Continue = false;
+
+            webRequest.ServicePoint.Expect100Continue = false;
 
             if (Timeout != 0)
             {

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -254,7 +254,7 @@ namespace RestSharp
 #endif
             webRequest.PreAuthenticate = PreAuthenticate;
 
-            ServicePointManager.Expect100Continue = false;
+            webRequest.ServicePoint.Expect100Continue = false;
 
             AppendHeaders(webRequest);
             AppendCookies(webRequest);


### PR DESCRIPTION
ServicePointManager.Expect100Continue = false;

with

webRequest.ServicePoint.Expect100Continue = false;

The original version sets the default for all *future* ServicePoints, but not the
current ServicePoint. I don't think setting the global default here is a
great idea, and it doesn't even affect the current ServicePoint which has
already been created.

Setting the application global default down inside a library is a bad behavior to me. This could lead to unintended results elsewhere in the application that incorporates RestSharp.

I posted in the Google Group if anyone wants to discuss or would like more explanation.