### PR TITLE
Fixes #636 - Header of 'Range' now supports a rangeSpecifier

### DIFF
--- a/RestSharp.Tests/AddRangeTests.cs
+++ b/RestSharp.Tests/AddRangeTests.cs
@@ -1,0 +1,17 @@
+﻿namespace RestSharp.Tests
+{
+    using Xunit;
+
+    public class AddRangeTests
+    {
+        [Fact]
+        public void ShouldParseOutRangeSpecifier()
+        {
+            var restClient = new RestClient("http://localhost");
+            var req = new RestRequest("bob", Method.GET);
+            
+            req.AddHeader("Range", "pages=1-2");
+            var resp = restClient.Execute(req);
+        }
+    }
+}

--- a/RestSharp.Tests/RestSharp.Tests.csproj
+++ b/RestSharp.Tests/RestSharp.Tests.csproj
@@ -81,6 +81,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AddRangeTests.cs" />
     <Compile Include="OAuthTests.cs" />
     <Compile Include="SampleClasses\EmployeeTracker.cs" />
     <Compile Include="SampleClasses\EnumTest.cs" />

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -464,17 +464,18 @@ namespace RestSharp
 #if FRAMEWORK
         private void AddRange(HttpWebRequest r, string range)
         {
-            System.Text.RegularExpressions.Match m = System.Text.RegularExpressions.Regex.Match(range, "=(\\d+)-(\\d+)$");
+            System.Text.RegularExpressions.Match m = System.Text.RegularExpressions.Regex.Match(range, "(\\w+)=(\\d+)-(\\d+)$");
 
             if (!m.Success)
             {
                 return;
             }
 
-            int from = Convert.ToInt32(m.Groups[1].Value);
-            int to = Convert.ToInt32(m.Groups[2].Value);
+            string rangeSpecifier = m.Groups[1].Value;
+            int from = Convert.ToInt32(m.Groups[2].Value);
+            int to = Convert.ToInt32(m.Groups[3].Value);
 
-            r.AddRange(from, to);
+            r.AddRange(rangeSpecifier, from, to);
         }
 #endif
     }


### PR DESCRIPTION
Here's a quick attempt to fix the #636 AddHeader

- [ ] I am not sure how to best test this (I monkey tested it, but that doesn't count)