### PR TITLE
Adding support for deserializing ISO 8601 durations as TimeSpan in JSON

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -539,6 +539,14 @@ namespace RestSharp.Tests
             Assert.Null(payload.NullableWithoutValue);
             Assert.NotNull(payload.NullableWithValue);
             Assert.Equal(new TimeSpan(21, 30, 7), payload.NullableWithValue.Value);
+            Assert.Equal(new TimeSpan(0, 0, 10), payload.IsoSecond);
+            Assert.Equal(new TimeSpan(0, 3, 23), payload.IsoMinute);
+            Assert.Equal(new TimeSpan(5, 4, 9), payload.IsoHour);
+            Assert.Equal(new TimeSpan(1, 19, 27, 13), payload.IsoDay);
+            // 2 months + 4 days = 64 days
+            Assert.Equal(new TimeSpan(64, 3, 14, 19), payload.IsoMonth);
+            // 1 year = 365 days
+            Assert.Equal(new TimeSpan(365, 9, 27, 48), payload.IsoYear);
         }
 
         [Fact]

--- a/RestSharp.Tests/SampleClasses/misc.cs
+++ b/RestSharp.Tests/SampleClasses/misc.cs
@@ -233,6 +233,18 @@ namespace RestSharp.Tests
         public TimeSpan? NullableWithoutValue { get; set; }
 
         public TimeSpan? NullableWithValue { get; set; }
+
+        public TimeSpan? IsoSecond { get; set; }
+
+        public TimeSpan? IsoMinute { get; set; }
+
+        public TimeSpan? IsoHour { get; set; }
+
+        public TimeSpan? IsoDay { get; set; }
+
+        public TimeSpan? IsoMonth { get; set; }
+
+        public TimeSpan? IsoYear { get; set; }
     }
 
     public class JsonEnumsTestStructure

--- a/RestSharp.Tests/SampleData/timespans.txt
+++ b/RestSharp.Tests/SampleData/timespans.txt
@@ -6,4 +6,10 @@
     "Hour": "21:30:07.0000000",
     "NullableWithoutValue": null,
     "NullableWithValue": "21:30:07.0000000",
+    "IsoSecond": "PT10S",
+    "IsoMinute": "PT3M23S",
+    "IsoHour": "PT5H4M9S",
+    "IsoDay": "P1DT19H27M13S",
+    "IsoMonth": "P2M4DT3H14M19S",
+    "IsoYear": "P1YT9H27M48S"
 }

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -277,7 +277,8 @@ namespace RestSharp.Deserializers
                 {
                     return timeSpan;
                 }
-                // 
+
+                // This should handle ISO 8601 durations
                 return XmlConvert.ToTimeSpan(stringValue);
             }
             else if (type.IsGenericType)

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -7,6 +7,8 @@ using RestSharp.Extensions;
 
 namespace RestSharp.Deserializers
 {
+    using System.Xml;
+
     public class JsonDeserializer : IDeserializer
     {
         public string RootElement { get; set; }
@@ -270,7 +272,13 @@ namespace RestSharp.Deserializers
             }
             else if (type == typeof(TimeSpan))
             {
-                return TimeSpan.Parse(stringValue);
+                TimeSpan timeSpan;
+                if (TimeSpan.TryParse(stringValue, out timeSpan))
+                {
+                    return timeSpan;
+                }
+                // 
+                return XmlConvert.ToTimeSpan(stringValue);
             }
             else if (type.IsGenericType)
             {


### PR DESCRIPTION
It appears that ServiceStack's default serialization for TimeSpan is ISO 8601, which causes an exception during deserialization in RestSharp. XmlConvert handles this format, so we'll attempt normal TimeSpan.Parse and failing that, attempt XmlConvert.