### PR TITLE
Add AddHandler, RemoveHandler, DownloadData and ClearHandlers methods to IRestClient inteface. Add MaxRedirects and FollowRedirects properties to IRestClient interface.

### DIFF
--- a/RestSharp.Tests/InterfaceImplementationTests.cs
+++ b/RestSharp.Tests/InterfaceImplementationTests.cs
@@ -1,0 +1,35 @@
+﻿namespace RestSharp.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Xunit;
+
+    public class InterfaceImplementationTests
+    {
+        [Fact]
+        public void IRestSharp_Has_All_RestSharp_Signatures()
+        {
+            // Arrange
+            var restClientImplementationType = typeof(RestClient);
+            var restClientInterfaceType = typeof(IRestClient);
+            var bindingFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+
+            // Act
+            IEnumerable<string> compareResult = CompareTypes(restClientImplementationType, restClientInterfaceType, bindingFlags);
+            compareResult.ToList().ForEach(x => Console.WriteLine("Method {0} exists in {1} but not in {2}", x, restClientImplementationType.FullName, restClientInterfaceType.FullName));
+
+            // Assert
+            Assert.Equal(0, compareResult.Count());
+        }
+
+        private static IEnumerable<string> CompareTypes(Type type1, Type type2, BindingFlags bindingFlags)
+        {
+            MethodInfo[] typeTMethodInfo = type1.GetMethods(bindingFlags);
+            MethodInfo[] typeXMethodInfo = type2.GetMethods(bindingFlags);
+
+            return typeTMethodInfo.Select(x => x.Name).Except(typeXMethodInfo.Select(x => x.Name));
+        }
+    }
+}

--- a/RestSharp.Tests/RestSharp.Tests.csproj
+++ b/RestSharp.Tests/RestSharp.Tests.csproj
@@ -81,6 +81,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="InterfaceImplementationTests.cs" />
     <Compile Include="OAuthTests.cs" />
     <Compile Include="SampleClasses\EmployeeTracker.cs" />
     <Compile Include="SampleClasses\EnumTest.cs" />

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -19,6 +19,7 @@ using System.Net;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using RestSharp.Deserializers;
 
 #if NET4 || MONODROID || MONOTOUCH || WP8
 using System.Threading;
@@ -104,6 +105,10 @@ namespace RestSharp
         /// <param name="callback">Callback function to be executed upon completion</param>
         /// <param name="httpMethod">The HTTP method to execute</param>
         RestRequestAsyncHandle ExecuteAsyncPost<T>(IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback, string httpMethod);
+
+        void AddHandler(string contentType, IDeserializer deserializer);
+
+        void RemoveHandler(string contentType);
 
 #if FRAMEWORK
         IRestResponse ExecuteAsGet(IRestRequest request, string httpMethod);

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -33,6 +33,8 @@ namespace RestSharp
 #if !PocketPC
         CookieContainer CookieContainer { get; set; }
 #endif
+        int? MaxRedirects { get; set; }
+
         string UserAgent { get; set; }
 
         int Timeout { get; set; }
@@ -59,6 +61,8 @@ namespace RestSharp
         IRestResponse Execute(IRestRequest request);
 
         IRestResponse<T> Execute<T>(IRestRequest request) where T : new();
+
+        byte[] DownloadData(IRestRequest request);
 #endif
 
 #if FRAMEWORK
@@ -69,6 +73,8 @@ namespace RestSharp
 
         IWebProxy Proxy { get; set; }
 #endif
+
+        bool FollowRedirects { get; set; }
 
         Uri BuildUri(IRestRequest request);
 
@@ -109,6 +115,8 @@ namespace RestSharp
         void AddHandler(string contentType, IDeserializer deserializer);
 
         void RemoveHandler(string contentType);
+
+        void ClearHandlers();
 
 #if FRAMEWORK
         IRestResponse ExecuteAsGet(IRestRequest request, string httpMethod);


### PR DESCRIPTION
I use the `IRestClient` interface for unit tests, etc.

The interface is currently missing:
Methods `AddHandler`, `RemoveHandler`, `DownloadData`, and `ClearHandlers`.
Properties `MaxRedirects`, and `FollowRedirects`.

I added a unit test to check the differences between the `RestClient` class and the `IRestClient` interface.

This would be a nice addition.

Let me know what you think or if something is missing.