### PR TITLE
Add double quotes in post build event to prevent errors in paths with spaces.

### DIFF
--- a/RestSharp.Build/RestSharp.Build.csproj
+++ b/RestSharp.Build/RestSharp.Build.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y $(TargetPath) $(SolutionDir).nuget\$(TargetFileName)</PostBuildEvent>
+    <PostBuildEvent>copy /Y "$(TargetPath)" "$(SolutionDir).nuget\$(TargetFileName)"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
`RestSharp.Build` project post-build event fails with `Copy` command unless this fix is put in.