### PR TITLE
Allow additional file Content-Disposition data

### DIFF
--- a/RestSharp/FileParameter.cs
+++ b/RestSharp/FileParameter.cs
@@ -68,5 +68,28 @@ namespace RestSharp
         /// Name of the parameter
         /// </summary>
         public string Name { get; set; }
+
+        private string _additionalDisposition;
+
+        /// <summary>
+        /// Additional key/value pairs to append to Content-Disposition (key1: val1; key2: val2; ...)
+        /// </summary>
+        public string AdditionalDisposition
+        {
+            get
+            {
+                return this._additionalDisposition;
+            }
+
+            set
+            {
+                if (value != null && value.Length > 0 && value.TrimStart()[0] != ';')
+                {
+                    value = "; " + value;
+                }
+
+                this._additionalDisposition = value;
+            }
+        }
     }
 }

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -253,8 +253,8 @@ namespace RestSharp
 
         private static string GetMultipartFileHeader(HttpFile file)
         {
-            return string.Format("--{0}{4}Content-Disposition: form-data; name=\"{1}\"; filename=\"{2}\"{4}Content-Type: {3}{4}{4}",
-                FORM_BOUNDARY, file.Name, file.FileName, file.ContentType ?? "application/octet-stream", LINE_BREAK);
+            return string.Format("--{0}{5}Content-Disposition: form-data; name=\"{1}\"; filename=\"{2}\"{4}{5}Content-Type: {3}{5}{5}",
+                FORM_BOUNDARY, file.Name, file.FileName, file.ContentType ?? "application/octet-stream", file.AdditionalDisposition, LINE_BREAK);
         }
 
         private string GetMultipartFormData(HttpParameter param)

--- a/RestSharp/HttpFile.cs
+++ b/RestSharp/HttpFile.cs
@@ -32,5 +32,10 @@ namespace RestSharp
         /// Name of the parameter
         /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Additional key/value pairs to append to Content-Disposition (key1: val1; key2: val2; ...)
+        /// </summary>
+        public string AdditionalDisposition { get; set; }
     }
 }

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -455,7 +455,8 @@ namespace RestSharp
                                    ContentType = file.ContentType,
                                    Writer = file.Writer,
                                    FileName = file.FileName,
-                                   ContentLength = file.ContentLength
+                                   ContentLength = file.ContentLength,
+                                   AdditionalDisposition = file.AdditionalDisposition
                                });
             }
 


### PR DESCRIPTION
Allow passing additional Content-Disposition data for files. I'm trying to use RestSharp for my DocuSign integration project. Some of DocuSign's REST API endpoints require custom values to be added to the Content-Disposition when uploading files.