### PR TITLE
DynamicObject Support for .Net4+

### DIFF
--- a/RestSharp/SimpleJson.cs
+++ b/RestSharp/SimpleJson.cs
@@ -46,6 +46,10 @@
 
 // original json parsing code from http://techblog.procurios.nl/k/618/news/view/14605/14863/How-do-I-write-my-own-parser-for-JSON.html
 
+#if NET4
+#define SIMPLE_JSON_DYNAMIC
+#endif
+
 #if NETFX_CORE
 #define SIMPLE_JSON_TYPEINFO
 #endif


### PR DESCRIPTION
Now you can use json.name instead of json["name"]