### PR TITLE
Namespace Cleanup

### DIFF
--- a/RestSharp.IntegrationTests/AuthenticationTests.cs
+++ b/RestSharp.IntegrationTests/AuthenticationTests.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Text;
 using RestSharp.Authenticators;
-using RestSharp.Contrib;
+using RestSharp.Extensions.MonoHttp;
 using RestSharp.IntegrationTests.Helpers;
 using Xunit;
 

--- a/RestSharp.IntegrationTests/oAuth1Tests.cs
+++ b/RestSharp.IntegrationTests/oAuth1Tests.cs
@@ -6,7 +6,7 @@ using System.Net;
 using System.Xml.Serialization;
 using RestSharp.Authenticators;
 using RestSharp.Authenticators.OAuth;
-using RestSharp.Contrib;
+using RestSharp.Extensions.MonoHttp;
 using RestSharp.IntegrationTests.Models;
 using Xunit;
 using System.IO;

--- a/RestSharp.Tests/NamespacedXmlTests.cs
+++ b/RestSharp.Tests/NamespacedXmlTests.cs
@@ -18,11 +18,14 @@ using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
 using RestSharp.Deserializers;
-using RestSharp.Tests.SampleClasses.Lastfm;
+
 using Xunit;
 
 namespace RestSharp.Tests
 {
+    using RestSharp.Tests.SampleClasses;
+    using RestSharp.Tests.SampleClasses.LastFm;
+
     public class NamespacedXmlTests
     {
         private const string GuidString = "AC1FC4BC-087A-4242-B8EE-C53EBE9887A5";

--- a/RestSharp.Tests/RestSharp.Tests.csproj
+++ b/RestSharp.Tests/RestSharp.Tests.csproj
@@ -102,7 +102,7 @@
     <Compile Include="SampleClasses\googleweather.cs" />
     <Compile Include="SampleClasses\JsonLists.cs" />
     <Compile Include="SampleClasses\ListSamples.cs" />
-    <Compile Include="SampleClasses\Lastfm.cs" />
+    <Compile Include="SampleClasses\LastFm\Lastfm.cs" />
     <Compile Include="SampleClasses\misc.cs" />
     <Compile Include="SampleClasses\nullables.cs" />
     <Compile Include="SampleClasses\eventful.cs" />

--- a/RestSharp.Tests/SampleClasses/LastFm/Lastfm.cs
+++ b/RestSharp.Tests/SampleClasses/LastFm/Lastfm.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace RestSharp.Tests.SampleClasses.Lastfm
+﻿namespace RestSharp.Tests.SampleClasses.LastFm
 {
+    using System;
+    using System.Collections.Generic;
+
     public class Event : LastfmBase
     {
         public string id { get; set; }

--- a/RestSharp.Tests/SampleClasses/misc.cs
+++ b/RestSharp.Tests/SampleClasses/misc.cs
@@ -14,12 +14,13 @@
 //   limitations under the License. 
 #endregion
 
-using System;
-using System.Collections.Generic;
-using RestSharp.Serializers;
-
-namespace RestSharp.Tests
+namespace RestSharp.Tests.SampleClasses
 {
+    using System;
+    using System.Collections.Generic;
+
+    using RestSharp.Serializers;
+
     public class PersonForXml
     {
         public string Name { get; set; }
@@ -40,11 +41,11 @@ namespace RestSharp.Tests
 
         protected string Ignore { get; set; }
 
-        public string IgnoreProxy { get { return Ignore; } }
+        public string IgnoreProxy { get { return this.Ignore; } }
 
         protected string ReadOnly { get { return null; } }
 
-        public string ReadOnlyProxy { get { return ReadOnly; } }
+        public string ReadOnlyProxy { get { return this.ReadOnly; } }
 
         public FoeList Foes { get; set; }
 
@@ -102,11 +103,11 @@ namespace RestSharp.Tests
 
         protected string Ignore { get; set; }
 
-        public string IgnoreProxy { get { return Ignore; } }
+        public string IgnoreProxy { get { return this.Ignore; } }
 
         protected string ReadOnly { get { return null; } }
 
-        public string ReadOnlyProxy { get { return ReadOnly; } }
+        public string ReadOnlyProxy { get { return this.ReadOnly; } }
 
         public Dictionary<string, Foe> Foes { get; set; }
 

--- a/RestSharp.Tests/SampleClasses/nullables.cs
+++ b/RestSharp.Tests/SampleClasses/nullables.cs
@@ -1,7 +1,7 @@
-﻿using System;
-
-namespace RestSharp.Tests
+﻿namespace RestSharp.Tests.SampleClasses
 {
+    using System;
+
     public class NullableValues
     {
         public int? Id { get; set; }

--- a/RestSharp.Tests/SerializerTests.cs
+++ b/RestSharp.Tests/SerializerTests.cs
@@ -23,6 +23,8 @@ using Xunit;
 
 namespace RestSharp.Tests
 {
+    using RestSharp.Tests.SampleClasses;
+
     public class SerializerTests
     {
         public SerializerTests()

--- a/RestSharp.Tests/XmlAttributeDeserializerTests.cs
+++ b/RestSharp.Tests/XmlAttributeDeserializerTests.cs
@@ -501,7 +501,7 @@ namespace RestSharp.Tests
             var doc = XDocument.Load(xmlpath);
             var response = new RestResponse { Content = doc.ToString() };
             var d = new XmlAttributeDeserializer();
-            var output = d.Deserialize<SampleClasses.Lastfm.Event>(response);
+            var output = d.Deserialize<SampleClasses.LastFm.Event>(response);
 
             //Assert.NotEmpty(output.artists);
             Assert.Equal("http://www.last.fm/event/328799+Philip+Glass+at+Barbican+Centre+on+12+June+2008", output.url);

--- a/RestSharp.Tests/XmlDeserializerTests.cs
+++ b/RestSharp.Tests/XmlDeserializerTests.cs
@@ -525,7 +525,7 @@ namespace RestSharp.Tests
             var doc = XDocument.Load(xmlpath);
             var response = new RestResponse { Content = doc.ToString() };
             var d = new XmlDeserializer();
-            var output = d.Deserialize<SampleClasses.Lastfm.Event>(response);
+            var output = d.Deserialize<SampleClasses.LastFm.Event>(response);
 
             //Assert.NotEmpty(output.artists);
             Assert.Equal("http://www.last.fm/event/328799+Philip+Glass+at+Barbican+Centre+on+12+June+2008", output.url);

--- a/RestSharp/Authenticators/HttpBasicAuthenticator.cs
+++ b/RestSharp/Authenticators/HttpBasicAuthenticator.cs
@@ -14,12 +14,12 @@
 //   limitations under the License. 
 #endregion
 
-using System;
-using System.Linq;
-using System.Text;
-
-namespace RestSharp
+namespace RestSharp.Authenticators
 {
+    using System;
+    using System.Linq;
+    using System.Text;
+
     public class HttpBasicAuthenticator : IAuthenticator
     {
         private readonly string _authHeader;
@@ -27,7 +27,7 @@ namespace RestSharp
         public HttpBasicAuthenticator(string username, string password)
         {
             var token = Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format("{0}:{1}", username, password)));
-            _authHeader = string.Format("Basic {0}", token);
+            this._authHeader = string.Format("Basic {0}", token);
         }
 
         public void Authenticate(IRestClient client, IRestRequest request)
@@ -42,7 +42,7 @@ namespace RestSharp
             // only add the Authorization parameter if it hasn't been added by a previous Execute
             if (!request.Parameters.Any(p => p.Name.Equals("Authorization", StringComparison.OrdinalIgnoreCase)))
             {
-                request.AddParameter("Authorization", _authHeader, ParameterType.HttpHeader);
+                request.AddParameter("Authorization", this._authHeader, ParameterType.HttpHeader);
             }
         }
     }

--- a/RestSharp/Authenticators/IAuthenticator.cs
+++ b/RestSharp/Authenticators/IAuthenticator.cs
@@ -14,7 +14,7 @@
 //   limitations under the License. 
 #endregion
 
-namespace RestSharp
+namespace RestSharp.Authenticators
 {
     public interface IAuthenticator
     {

--- a/RestSharp/Authenticators/NtlmAuthenticator.cs
+++ b/RestSharp/Authenticators/NtlmAuthenticator.cs
@@ -14,13 +14,14 @@
 //   limitations under the License. 
 #endregion
 
-using System;
-using System.Net;
 
 #if FRAMEWORK
 
-namespace RestSharp
+namespace RestSharp.Authenticators
 {
+    using System;
+    using System.Net;
+
     /// <summary>
     /// Tries to Authenticate with the credentials of the currently logged in user, or impersonate a user
     /// </summary>
@@ -56,7 +57,7 @@ namespace RestSharp
 
         public void Authenticate(IRestClient client, IRestRequest request)
         {
-            request.Credentials = credentials;
+            request.Credentials = this.credentials;
         }
     }
 }

--- a/RestSharp/Authenticators/OAuth/OAuthWorkflow.cs
+++ b/RestSharp/Authenticators/OAuth/OAuthWorkflow.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using RestSharp.Authenticators.OAuth.Extensions;
 #if !WINDOWS_PHONE && !SILVERLIGHT && !PocketPC
-using RestSharp.Contrib;
+using RestSharp.Extensions.MonoHttp;
 #endif
 
 namespace RestSharp.Authenticators.OAuth

--- a/RestSharp/Authenticators/OAuth1Authenticator.cs
+++ b/RestSharp/Authenticators/OAuth1Authenticator.cs
@@ -25,7 +25,7 @@ using System.Net;
 #elif SILVERLIGHT
 using System.Windows.Browser;
 #else
-using RestSharp.Contrib;
+using RestSharp.Extensions.MonoHttp;
 #endif
 
 namespace RestSharp.Authenticators

--- a/RestSharp/Authenticators/OAuth2Authenticator.cs
+++ b/RestSharp/Authenticators/OAuth2Authenticator.cs
@@ -14,11 +14,11 @@
 //   limitations under the License. 
 #endregion
 
-using System;
-using System.Linq;
-
-namespace RestSharp
+namespace RestSharp.Authenticators
 {
+    using System;
+    using System.Linq;
+
     /// <summary>
     /// Base class for OAuth 2 Authenticators.
     /// </summary>
@@ -45,7 +45,7 @@ namespace RestSharp
         /// </param>
         protected OAuth2Authenticator(string accessToken)
         {
-            _accessToken = accessToken;
+            this._accessToken = accessToken;
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace RestSharp
         /// </summary>
         public string AccessToken
         {
-            get { return _accessToken; }
+            get { return this._accessToken; }
         }
 
         public abstract void Authenticate(IRestClient client, IRestRequest request);
@@ -78,7 +78,7 @@ namespace RestSharp
 
         public override void Authenticate(IRestClient client, IRestRequest request)
         {
-            request.AddParameter("oauth_token", AccessToken, ParameterType.GetOrPost);
+            request.AddParameter("oauth_token", this.AccessToken, ParameterType.GetOrPost);
         }
     }
 
@@ -117,7 +117,7 @@ namespace RestSharp
             : base(accessToken)
         {
             // Conatenate during constructor so that it is only done once. can improve performance.
-            _authorizationValue = tokenType + " " + accessToken;
+            this._authorizationValue = tokenType + " " + accessToken;
         }
 
         public override void Authenticate(IRestClient client, IRestRequest request)
@@ -125,7 +125,7 @@ namespace RestSharp
             // only add the Authorization parameter if it hasn't been added.
             if (!request.Parameters.Any(p => p.Name.Equals("Authorization", StringComparison.OrdinalIgnoreCase)))
             {
-                request.AddParameter("Authorization", _authorizationValue, ParameterType.HttpHeader);
+                request.AddParameter("Authorization", this._authorizationValue, ParameterType.HttpHeader);
             }
         }
     }

--- a/RestSharp/Authenticators/SimpleAuthenticator.cs
+++ b/RestSharp/Authenticators/SimpleAuthenticator.cs
@@ -14,7 +14,7 @@
 //   limitations under the License. 
 #endregion
 
-namespace RestSharp
+namespace RestSharp.Authenticators
 {
     public class SimpleAuthenticator : IAuthenticator
     {
@@ -25,16 +25,16 @@ namespace RestSharp
 
         public SimpleAuthenticator(string usernameKey, string username, string passwordKey, string password)
         {
-            _usernameKey = usernameKey;
-            _username = username;
-            _passwordKey = passwordKey;
-            _password = password;
+            this._usernameKey = usernameKey;
+            this._username = username;
+            this._passwordKey = passwordKey;
+            this._password = password;
         }
 
         public void Authenticate(IRestClient client, IRestRequest request)
         {
-            request.AddParameter(_usernameKey, _username);
-            request.AddParameter(_passwordKey, _password);
+            request.AddParameter(this._usernameKey, this._username);
+            request.AddParameter(this._passwordKey, this._password);
         }
     }
 }

--- a/RestSharp/Extensions/MonoHttp/Helpers.cs
+++ b/RestSharp/Extensions/MonoHttp/Helpers.cs
@@ -26,10 +26,11 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-using System.Globalization;
 
-namespace RestSharp.Contrib
+namespace RestSharp.Extensions.MonoHttp
 {
+    using System.Globalization;
+
     class Helpers
     {
         public static readonly CultureInfo InvariantCulture = CultureInfo.InvariantCulture;

--- a/RestSharp/Extensions/MonoHttp/HtmlEncoder.cs
+++ b/RestSharp/Extensions/MonoHttp/HtmlEncoder.cs
@@ -30,16 +30,19 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+
+
 #if NET_4_0
 using System.Web.Configuration;
 #endif
 
-namespace RestSharp.Contrib
+namespace RestSharp.Extensions.MonoHttp
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+
 #if NET_4_0
     public
 #endif

--- a/RestSharp/Extensions/MonoHttp/HttpUtility.cs
+++ b/RestSharp/Extensions/MonoHttp/HttpUtility.cs
@@ -29,15 +29,14 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.IO;
-using System.Text;
-
-namespace RestSharp.Contrib
+namespace RestSharp.Extensions.MonoHttp
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.Specialized;
+    using System.IO;
+    using System.Text;
 
     //#if !MONOTOUCH
     //    // CAS - no InheritanceDemand here as the class is sealed
@@ -49,13 +48,13 @@ namespace RestSharp.Contrib
         {
             public override string ToString()
             {
-                int count = Count;
+                int count = this.Count;
 
                 if (count == 0)
                     return "";
 
                 StringBuilder sb = new StringBuilder();
-                string[] keys = AllKeys;
+                string[] keys = this.AllKeys;
 
                 for (int i = 0; i < count; i++)
                 {

--- a/RestSharp/Extensions/StringExtensions.cs
+++ b/RestSharp/Extensions/StringExtensions.cs
@@ -30,7 +30,7 @@ using System.Windows.Browser;
 #endif
 
 #if FRAMEWORK || MONOTOUCH || MONODROID
-using RestSharp.Contrib;
+using RestSharp.Extensions.MonoHttp;
 #endif
 
 namespace RestSharp.Extensions

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -28,6 +28,8 @@ using System.Threading.Tasks;
 
 namespace RestSharp
 {
+    using RestSharp.Authenticators;
+
     public interface IRestClient
     {
 #if !PocketPC

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -26,6 +26,8 @@ using RestSharp.Extensions;
 
 namespace RestSharp
 {
+    using RestSharp.Authenticators;
+
     /// <summary>
     /// Client to translate RestRequests into Http requests and process response result
     /// </summary>

--- a/RestSharp/SharedAssemblyInfo.cs
+++ b/RestSharp/SharedAssemblyInfo.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Reflection;
 
+using RestSharp;
+
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
@@ -34,12 +36,15 @@ using System.Reflection;
 #endif
 #endif
 
-class SharedAssemblyInfo
+namespace RestSharp
 {
+    class SharedAssemblyInfo
+    {
 #if SIGNED
     public const string Version = "100.0.0";
     public const string FileVersion = "105.0.1";
 #else
-    public const string Version = "105.0.1";
+        public const string Version = "105.0.1";
 #endif
+    }
 }


### PR DESCRIPTION
Cleanup the namespaces for the codebase.

Main changes was changing namespace `RestSharp` to `RestSharp.Authenticators` for all classes in the Authenticators folder.

Also renamed namespace `RestSharp.Contrib` to `RestSharp.Extensions.MonoHttp`.