### PR TITLE
Enhance Debug experience w/ RestResponse

### DIFF
--- a/RestSharp/RestResponse.cs
+++ b/RestSharp/RestResponse.cs
@@ -18,12 +18,15 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using RestSharp.Extensions;
+using System.Diagnostics;
 
 namespace RestSharp
 {
+
     /// <summary>
     /// Base class for common properties shared by RestResponse and RestResponse[[T]]
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay()}")]
     public abstract class RestResponseBase
     {
         private string _content;
@@ -133,12 +136,23 @@ namespace RestSharp
         /// The exception thrown during the request, if any
         /// </summary>
         public Exception ErrorException { get; set; }
+
+
+        /// <summary>
+        /// Assists with debugging responses by displaying in the debugger output
+        /// </summary>
+        /// <returns></returns>
+        protected string DebuggerDisplay()
+        {
+            return string.Format("{0}: {1} ({2})", StatusCode, ContentType, ContentLength);
+        }
     }
 
     /// <summary>
     /// Container for data sent back from API including deserialized data
     /// </summary>
     /// <typeparam name="T">Type of data to deserialize to</typeparam>
+    [DebuggerDisplay("{DebuggerDisplay()}")]
     public class RestResponse<T> : RestResponseBase, IRestResponse<T>
     {
         /// <summary>
@@ -171,5 +185,6 @@ namespace RestSharp
     /// <summary>
     /// Container for data sent back from API
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay()}")]
     public class RestResponse : RestResponseBase, IRestResponse { }
 }


### PR DESCRIPTION
One of the biggest pet peeves of RestSharp is the lack of Debugger Visualizations. This pull request is an attempt to show that a simple change can make a huge difference in the debug experience.

##Current
![image](https://cloud.githubusercontent.com/assets/63355/7555057/3cb124ec-f705-11e4-8c05-3be08bed9f61.png)

##With PR
![image](https://cloud.githubusercontent.com/assets/63355/7555065/9428d382-f705-11e4-8ffd-a980ca988786.png)

The big change that I want is to easily see the HTTP Status Code, beyond that I'm open to any and all suggestions and feedback.

Thank you.