### PR TITLE
Add support for deserializing content types using "Structured Syntax Suffixes"

### DIFF
--- a/RestSharp.IntegrationTests/RestSharp.IntegrationTests.csproj
+++ b/RestSharp.IntegrationTests/RestSharp.IntegrationTests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="RequestBodyTests.cs" />
     <Compile Include="StatusCodeTests.cs" />
     <Compile Include="RequestHeadTests.cs" />
+    <Compile Include="StructuredSyntaxSuffixTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\Koala.jpg">

--- a/RestSharp.IntegrationTests/StructuredSyntaxSuffixTests.cs
+++ b/RestSharp.IntegrationTests/StructuredSyntaxSuffixTests.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Net;
+using RestSharp.Deserializers;
+using RestSharp.IntegrationTests.Helpers;
+using Xunit;
+
+namespace RestSharp.IntegrationTests
+{
+    public class StructuredSyntaxSuffixTests
+    {
+        private class Person
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+        }
+
+        private const string XmlContent = "<Person><name>Bob</name><age>50</age></Person>";
+        private const string JsonContent = @"{ ""name"":""Bob"", ""age"":50 }";
+
+        void QueryStringBasedContentAndContentTypeHandler(HttpListenerContext obj)
+        {
+            obj.Response.ContentType = obj.Request.QueryString["ct"];
+            obj.Response.OutputStream.WriteStringUtf8(obj.Request.QueryString["c"]);
+            obj.Response.StatusCode = 200;
+        }
+
+        [Fact]
+        public void By_default_content_types_with_JSON_structured_syntax_suffix_should_deserialize_as_JSON()
+        {
+            Uri baseUrl = new Uri("http://localhost:8080/");
+
+            using (SimpleServer.Create(baseUrl.AbsoluteUri, QueryStringBasedContentAndContentTypeHandler))
+            {
+                var client = new RestClient(baseUrl);
+                
+                var request = new RestRequest();
+                request.AddParameter("ct", "application/vnd.somebody.something+json");
+                request.AddParameter("c", JsonContent);
+
+                var response = client.Execute<Person>(request);
+
+                Assert.Equal("Bob", response.Data.Name);
+                Assert.Equal(50, response.Data.Age);
+            }
+        }
+
+        [Fact]
+        public void By_default_content_types_with_XML_structured_syntax_suffix_should_deserialize_as_XML()
+        {
+            Uri baseUrl = new Uri("http://localhost:8080/");
+
+            using (SimpleServer.Create(baseUrl.AbsoluteUri, QueryStringBasedContentAndContentTypeHandler))
+            {
+                var client = new RestClient(baseUrl);
+
+                var request = new RestRequest();
+                request.AddParameter("ct", "application/vnd.somebody.something+xml");
+                request.AddParameter("c", XmlContent);
+
+                var response = client.Execute<Person>(request);
+
+                Assert.Equal("Bob", response.Data.Name);
+                Assert.Equal(50, response.Data.Age);
+            }
+        }
+
+        [Fact]
+        public void Content_type_that_matches_the_structured_syntax_suffix_format_but_was_given_an_explicit_handler_should_use_supplied_deserializer()
+        {
+            Uri baseUrl = new Uri("http://localhost:8080/");
+
+            using (SimpleServer.Create(baseUrl.AbsoluteUri, QueryStringBasedContentAndContentTypeHandler))
+            {
+                var client = new RestClient(baseUrl);
+
+                // In spite of the content type (+xml), treat this specific content type as JSON
+                client.AddHandler("application/vnd.somebody.something+xml", new JsonDeserializer());
+
+                var request = new RestRequest();
+                request.AddParameter("ct", "application/vnd.somebody.something+xml");
+                request.AddParameter("c", JsonContent);
+
+                var response = client.Execute<Person>(request);
+
+                Assert.Equal("Bob", response.Data.Name);
+                Assert.Equal(50, response.Data.Age);
+            }
+        }
+
+        [Fact]
+        public void Should_allow_wildcard_content_types_to_be_defined()
+        {
+            Uri baseUrl = new Uri("http://localhost:8080/");
+
+            using (SimpleServer.Create(baseUrl.AbsoluteUri, QueryStringBasedContentAndContentTypeHandler))
+            {
+                var client = new RestClient(baseUrl);
+
+                // In spite of the content type, handle ALL structured syntax suffixes of "+xml" as JSON
+                client.AddHandler("*+xml", new JsonDeserializer());
+
+                var request = new RestRequest();
+                request.AddParameter("ct", "application/vnd.somebody.something+xml");
+                request.AddParameter("c", JsonContent);
+
+                var response = client.Execute<Person>(request);
+
+                Assert.Equal("Bob", response.Data.Name);
+                Assert.Equal(50, response.Data.Age);
+            }
+        }
+
+        [Fact]
+        public void By_default_application_json_content_type_should_deserialize_as_JSON()
+        {
+            Uri baseUrl = new Uri("http://localhost:8080/");
+
+            using (SimpleServer.Create(baseUrl.AbsoluteUri, QueryStringBasedContentAndContentTypeHandler))
+            {
+                var client = new RestClient(baseUrl);
+
+                var request = new RestRequest();
+                request.AddParameter("ct", "application/json");
+                request.AddParameter("c", JsonContent);
+
+                var response = client.Execute<Person>(request);
+
+                Assert.Equal("Bob", response.Data.Name);
+                Assert.Equal(50, response.Data.Age);
+            }
+        }
+
+        [Fact]
+        public void By_default_text_xml_content_type_should_deserialize_as_XML()
+        {
+            Uri baseUrl = new Uri("http://localhost:8080/");
+
+            using (SimpleServer.Create(baseUrl.AbsoluteUri, QueryStringBasedContentAndContentTypeHandler))
+            {
+                var client = new RestClient(baseUrl);
+
+                var request = new RestRequest();
+                request.AddParameter("ct", "text/xml");
+                request.AddParameter("c", XmlContent);
+
+                var response = client.Execute<Person>(request);
+
+                Assert.Equal("Bob", response.Data.Name);
+                Assert.Equal(50, response.Data.Age);
+            }
+        }
+    }
+}

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -21,6 +21,7 @@ using System.Net;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Text.RegularExpressions;
 using RestSharp.Deserializers;
 using RestSharp.Extensions;
 
@@ -130,6 +131,8 @@ namespace RestSharp
             this.AddHandler("text/x-json", new JsonDeserializer());
             this.AddHandler("text/javascript", new JsonDeserializer());
             this.AddHandler("text/xml", new XmlDeserializer());
+            this.AddHandler("*+json", new JsonDeserializer());
+            this.AddHandler("*+xml", new XmlDeserializer());
             this.AddHandler("*", new XmlDeserializer());
 
             this.FollowRedirects = true;
@@ -175,7 +178,7 @@ namespace RestSharp
         {
             this.ContentHandlers[contentType] = deserializer;
 
-            if (contentType != "*")
+            if (contentType != "*" && !structuredSyntaxSuffixWildcardRegex.IsMatch(contentType))
             {
                 this.AcceptTypes.Add(contentType);
                 // add Accept header based on registered deserializers
@@ -227,19 +230,33 @@ namespace RestSharp
             if (semicolonIndex > -1)
                 contentType = contentType.Substring(0, semicolonIndex);
 
-            IDeserializer handler = null;
-
             if (this.ContentHandlers.ContainsKey(contentType))
+                return this.ContentHandlers[contentType];
+
+            // https://tools.ietf.org/html/rfc6839#page-4
+            Match structuredSyntaxSuffixMatch = structuredSyntaxSuffixRegex.Match(contentType);
+
+            if (structuredSyntaxSuffixMatch.Success)
             {
-                handler = this.ContentHandlers[contentType];
-            }
-            else if (this.ContentHandlers.ContainsKey("*"))
-            {
-                handler = this.ContentHandlers["*"];
+                string structuredSyntaxSuffixWildcard = "*" + structuredSyntaxSuffixMatch.Value;
+
+                if (this.ContentHandlers.ContainsKey(structuredSyntaxSuffixWildcard))
+                    return this.ContentHandlers[structuredSyntaxSuffixWildcard];
             }
 
-            return handler;
+            if (this.ContentHandlers.ContainsKey("*"))
+                return this.ContentHandlers["*"];
+
+            return null;
         }
+
+#if SILVERLIGHT
+        private readonly Regex structuredSyntaxSuffixRegex = new Regex(@"\+\w+$");
+        private readonly Regex structuredSyntaxSuffixWildcardRegex = new Regex(@"^\*\+\w+$");
+#else
+        private readonly Regex structuredSyntaxSuffixRegex = new Regex(@"\+\w+$", RegexOptions.Compiled);
+        private readonly Regex structuredSyntaxSuffixWildcardRegex = new Regex(@"^\*\+\w+$", RegexOptions.Compiled);
+#endif
 
         private void AuthenticateIfNeeded(RestClient client, IRestRequest request)
         {


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc6839#section-3,

> `3.  Initial Structured Syntax Suffix Definitions
>
> 3.1.  The +json Structured Syntax Suffix
>
>   [RFC4627] defines the "application/json" media type.  The suffix
   "+json" MAY be used with any media type whose representation follows
   that established for "application/json".

A similar approach is used for XML (``+xml``).

Essentially, what this means is that a JSON request body could be presented with a content type of ``application/json`` or it could use a content type with a structured syntax suffix of ``+json``.  For example, ``application/vnd.somebody.something+json`` should be treated the same way as ``application/json`` by the ``RestClient``.

This commit adds support for handling content types with structured syntax suffixes on deserialization.  Specifically, it adds default "wildcard" handlers for ``*+xml`` and ``*+json`` (similar to the current support for ``*``) which map (by default) to the ``XmlDeserializer`` and ``JsonDeserializer`` respectively.  The commit includes integration tests demonstrating the safe addition of the expanded behavior.
