### PR TITLE
JsonDeserializer Dictionary Key Type

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -157,6 +157,20 @@ namespace RestSharp.Tests
         }
 
         [Fact]
+        public void Can_Deserialize_To_Dictionary_Int_Object()
+        {
+            var doc = File.ReadAllText(Path.Combine("SampleData", "jsondictionary_KeysType.txt"));
+            var json = new JsonDeserializer();
+            var output = json.Deserialize<Dictionary<int, object>>(new RestResponse { Content = doc });
+
+            Assert.Equal(output.Keys.Count, 2);
+
+            var firstKeysVal = output.FirstOrDefault().Value;
+
+            Assert.IsAssignableFrom<System.Collections.IDictionary>(firstKeysVal);
+        }
+
+        [Fact]
         public void Can_Deserialize_Generic_Members()
         {
             var doc = File.ReadAllText(Path.Combine("SampleData", "GenericWithList.txt"));

--- a/RestSharp.Tests/RestSharp.Tests.Signed.csproj
+++ b/RestSharp.Tests/RestSharp.Tests.Signed.csproj
@@ -139,6 +139,9 @@
     <Content Include="SampleData\iso8601datetimes.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="SampleData\jsondictionary_KeysType.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="SampleData\jsondictionary.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/RestSharp.Tests/RestSharp.Tests.csproj
+++ b/RestSharp.Tests/RestSharp.Tests.csproj
@@ -131,6 +131,9 @@
     <Content Include="SampleData\iso8601datetimes.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="SampleData\jsondictionary_KeysType.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="SampleData\jsondictionary.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/RestSharp.Tests/SampleData/jsondictionary_KeysType.txt
+++ b/RestSharp.Tests/SampleData/jsondictionary_KeysType.txt
@@ -1,0 +1,14 @@
+{
+    "1" : 
+    {
+        "John": [{"Type":"BiWeekly","Amount":3000},{"Type":"Bonus","Amount":5000}],
+        "David": [{"Type":"Monthly","Amount":5000},{"Type":"Bonus","Amount":2500}],
+        "Mary": [{"Type":"BiWeekly","Amount":2000}]
+    },    
+    "2" : 
+    {
+        "John": ["Welcome to Restsharp", "Meetings at 4pm", "Meeting Cancled"],
+        "David": ["Project deadline is Monday", "Good work"],
+        "Mary": ["Is there any documentation on Product A", "I'm leaving early today"]
+    }
+}

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -123,7 +123,7 @@ namespace RestSharp.Deserializers
             foreach (var child in (IDictionary<string, object>)parent)
             {
                 var key = keyType != typeof (string) ? 
-                    Convert.ChangeType(child.Key, keyType) : 
+                    Convert.ChangeType(child.Key, keyType, CultureInfo.InvariantCulture) : 
                     child.Key;
 
                 object item;

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -117,11 +117,15 @@ namespace RestSharp.Deserializers
         private IDictionary BuildDictionary(Type type, object parent)
         {
             var dict = (IDictionary)Activator.CreateInstance(type);
+            var keyType = type.GetGenericArguments()[0];
             var valueType = type.GetGenericArguments()[1];
 
             foreach (var child in (IDictionary<string, object>)parent)
             {
-                var key = child.Key;
+                var key = keyType != typeof (string) ? 
+                    Convert.ChangeType(child.Key, keyType) : 
+                    child.Key;
+
                 object item;
 
                 if (valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(List<>))


### PR DESCRIPTION
I use a json data what use integer keys. And currently change my dictionary type as <string, string> for use restsharp deserializer. I think its fix dictionary key type for what dictionary contains.