### PR TITLE
Allow deserialization of base types from JSON 

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -12,19 +12,19 @@
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
-//   limitations under the License. 
+//   limitations under the License.
 
-#endregion
+#endregion License
 
+using NUnit.Framework;
+using RestSharp.Deserializers;
+using RestSharp.Tests.SampleClasses;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using NUnit.Framework;
-using RestSharp.Deserializers;
-using RestSharp.Tests.SampleClasses;
 
 namespace RestSharp.Tests
 {
@@ -195,7 +195,7 @@ namespace RestSharp.Tests
             data["Ids"] = new JsonArray { id1, id2 };
 
             JsonDeserializer d = new JsonDeserializer();
-            RestResponse response = new RestResponse { Content = data.ToString()  };
+            RestResponse response = new RestResponse { Content = data.ToString() };
             GuidList p = d.Deserialize<GuidList>(response);
 
             Assert.AreEqual(2, p.Ids.Count);
@@ -778,6 +778,17 @@ namespace RestSharp.Tests
             Assert.IsNotEmpty(output.EmployeesMail);
             Assert.IsNotEmpty(output.EmployeesTime);
             Assert.IsNotEmpty(output.EmployeesPay);
+        }
+
+        [Test]
+        public void Can_Deserialize_Plain_Values()
+        {
+            const string json = "\"c02bdd1e-cce3-4b9c-8473-165e6e93b92a\"";
+            RestResponse response = new RestResponse { Content = json };
+            JsonDeserializer d = new JsonDeserializer();
+            Guid result = d.Deserialize<Guid>(response);
+
+            Assert.AreEqual(result, new Guid("c02bdd1e-cce3-4b9c-8473-165e6e93b92a"));
         }
 
         private static string CreateJsonWithUnderscores()

--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -12,19 +12,19 @@
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
-//   limitations under the License.
+//   limitations under the License. 
 
-#endregion License
+#endregion
 
-using NUnit.Framework;
-using RestSharp.Deserializers;
-using RestSharp.Tests.SampleClasses;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using NUnit.Framework;
+using RestSharp.Deserializers;
+using RestSharp.Tests.SampleClasses;
 
 namespace RestSharp.Tests
 {
@@ -195,7 +195,7 @@ namespace RestSharp.Tests
             data["Ids"] = new JsonArray { id1, id2 };
 
             JsonDeserializer d = new JsonDeserializer();
-            RestResponse response = new RestResponse { Content = data.ToString() };
+            RestResponse response = new RestResponse { Content = data.ToString()  };
             GuidList p = d.Deserialize<GuidList>(response);
 
             Assert.AreEqual(2, p.Ids.Count);

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -1,10 +1,10 @@
-﻿using RestSharp.Extensions;
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using RestSharp.Extensions;
 
 namespace RestSharp.Deserializers
 {
@@ -68,7 +68,7 @@ namespace RestSharp.Deserializers
 
                 if (attributes.Length > 0)
                 {
-                    DeserializeAsAttribute attribute = (DeserializeAsAttribute)attributes[0];
+                    DeserializeAsAttribute attribute = (DeserializeAsAttribute) attributes[0];
                     name = attribute.Name;
                 }
                 else
@@ -96,7 +96,7 @@ namespace RestSharp.Deserializers
                     }
                     else
                     {
-                        currentData = (IDictionary<string, object>)currentData[actualName];
+                        currentData = (IDictionary<string, object>) currentData[actualName];
                     }
                 }
 
@@ -111,11 +111,11 @@ namespace RestSharp.Deserializers
 
         private IDictionary BuildDictionary(Type type, object parent)
         {
-            IDictionary dict = (IDictionary)Activator.CreateInstance(type);
+            IDictionary dict = (IDictionary) Activator.CreateInstance(type);
             Type keyType = type.GetGenericArguments()[0];
             Type valueType = type.GetGenericArguments()[1];
 
-            foreach (KeyValuePair<string, object> child in (IDictionary<string, object>)parent)
+            foreach (KeyValuePair<string, object> child in (IDictionary<string, object>) parent)
             {
                 object key = keyType != typeof(string)
                     ? Convert.ChangeType(child.Key, keyType, CultureInfo.InvariantCulture)
@@ -140,7 +140,7 @@ namespace RestSharp.Deserializers
 
         private IList BuildList(Type type, object parent)
         {
-            IList list = (IList)Activator.CreateInstance(type);
+            IList list = (IList) Activator.CreateInstance(type);
             Type listType = type.GetInterfaces()
                                 .First
                 (x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IList<>));
@@ -148,7 +148,7 @@ namespace RestSharp.Deserializers
 
             if (parent is IList)
             {
-                foreach (object element in (IList)parent)
+                foreach (object element in (IList) parent)
                 {
                     if (itemType.IsPrimitive)
                     {
@@ -251,14 +251,14 @@ namespace RestSharp.Deserializers
 
                 if (type == typeof(DateTimeOffset))
                 {
-                    return (DateTimeOffset)dt;
+                    return (DateTimeOffset) dt;
                 }
             }
             else if (type == typeof(decimal))
             {
                 if (value is double)
                 {
-                    return (decimal)((double)value);
+                    return (decimal) ((double) value);
                 }
 
                 if (stringValue.Contains("e"))
@@ -310,7 +310,7 @@ namespace RestSharp.Deserializers
             }
             else if (type == typeof(JsonObject))
             {
-                // simplify JsonObject into a Dictionary<string, object>
+                // simplify JsonObject into a Dictionary<string, object> 
                 return this.BuildDictionary(typeof(Dictionary<string, object>), value);
             }
             else
@@ -326,7 +326,7 @@ namespace RestSharp.Deserializers
         {
             object instance = Activator.CreateInstance(type);
 
-            this.Map(instance, (IDictionary<string, object>)element);
+            this.Map(instance, (IDictionary<string, object>) element);
 
             return instance;
         }

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -297,19 +297,11 @@ namespace RestSharp.Deserializers
 
                 if (genericTypeDef == typeof(Dictionary<,>))
                 {
-                    Type keyType = type.GetGenericArguments()[0];
+                    return this.BuildDictionary(type, value);
+                }
 
-                    // only supports Dict<string, T>()
-                    if (keyType == typeof(string))
-                    {
-                        return this.BuildDictionary(type, value);
-                    }
-                }
-                else
-                {
-                    // nested property classes
-                    return this.CreateAndMap(type, value);
-                }
+                // nested property classes
+                return this.CreateAndMap(type, value);
             }
             else if (type.IsSubclassOfRawGeneric(typeof(List<>)))
             {


### PR DESCRIPTION
It should fix #635 . I added a unit test for it as well. Now `JsonTests.Can_Deserialize_To_Dictionary_Int_Object` is not passing, but I'm not sure if it a correct test actually, since deserialization of `Dictionary<TKey, TValue>` where `TKey` is not `string` doesn't seem to be supported.