### PR TITLE
AddUrlSegment overload

### DIFF
--- a/RestSharp.Tests/RestRequestTests.cs
+++ b/RestSharp.Tests/RestRequestTests.cs
@@ -85,8 +85,8 @@ namespace RestSharp.Tests
 
             var parameter = request.Parameters.FirstOrDefault(x => x.Name.Equals(ParameterName));
             Assert.IsNotNull(parameter);
-            Assert.Equals(expectedValue, parameter.Value.ToString());
-            Assert.Equals(ParameterType.UrlSegment, parameter.Type);
+            Assert.AreEqual(expectedValue, parameter.Value.ToString());
+            Assert.AreEqual(ParameterType.UrlSegment, parameter.Type);
         }
     }
 }

--- a/RestSharp.Tests/RestRequestTests.cs
+++ b/RestSharp.Tests/RestRequestTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using NUnit.Framework;
 
@@ -70,6 +71,22 @@ namespace RestSharp.Tests
             RestRequest request = new RestRequest();
 
             Assert.DoesNotThrow(() => request.AddHeader("Host", value));
+        }
+
+        [Test]
+        [TestCase(1, "1")]
+        [TestCase("1", "1")]
+        [TestCase("entity", "entity")]
+        public void Can_Add_Object_To_UrlSegment(object value, string expectedValue)
+        {
+            const string ParameterName = "Id";
+            RestRequest request = new RestRequest();
+            request.AddUrlSegment(ParameterName, value);
+
+            var parameter = request.Parameters.FirstOrDefault(x => x.Name.Equals(ParameterName));
+            Assert.IsNotNull(parameter);
+            Assert.Equals(expectedValue, parameter.Value.ToString());
+            Assert.Equals(ParameterType.UrlSegment, parameter.Type);
         }
     }
 }

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -494,6 +494,17 @@ namespace RestSharp
         }
 
         /// <summary>
+        /// Shortcut to AddParameter(name, value, UrlSegment) overload
+        /// </summary>
+        /// <param name="name">Name of the segment to add</param>
+        /// <param name="value">Value of the segment to add</param>
+        /// <returns></returns>
+        public IRestRequest AddUrlSegment(string name, object value)
+        {
+            return this.AddParameter(name, value, ParameterType.UrlSegment);
+        }
+
+        /// <summary>
         /// Shortcut to AddParameter(name, value, QueryString) overload
         /// </summary>
         /// <param name="name">Name of the parameter to add</param>


### PR DESCRIPTION
AddUrlSegment overload method to allow pass object as value so that
calling ToString() on value is not needed.

Let say one would like to send request to API endpoint `api/document/{documentId}/details` and there is method:
```c#
public IList<DocumentDetails> GetDetails(int documentId)
{
          var request = new RestRequest("api/document/{documentId}/details");
          request.AddUrlSegment("documentId", documentId.ToString());
          ...
}
```
It would be nice not to have to call ToString() method on documentId. Just like this:
```c#
public IList<DocumentDetails> GetDetails(int documentId)
{
          var request = new RestRequest("api/document/{documentId}/details");
          request.AddUrlSegment("documentId", documentId);
          ...
}
```
In my opinion this is more convenient and also thanks to it code is a little bit more cleaner.