### PR TITLE
Add support for Matrix Parameters

### DIFF
--- a/RestSharp.Tests/UrlBuilderTests.cs
+++ b/RestSharp.Tests/UrlBuilderTests.cs
@@ -188,6 +188,67 @@ namespace RestSharp.Tests
         }
 
         [Test]
+        public void GET_with_matrix_containing_tokens()
+        {
+            RestRequest request = new RestRequest("resource", Method.GET);
+
+            request.AddParameter("foo", "bar", ParameterType.Matrix);
+
+            RestClient client = new RestClient("http://example.com");
+            Uri expected = new Uri("http://example.com/resource;foo=bar");
+            Uri output = client.BuildUri(request);
+
+            Assert.AreEqual(expected, output);
+        }
+
+        [Test]
+        public void GET_with_matrix_and_no_value()
+        {
+            RestRequest request = new RestRequest("resource", Method.GET);
+
+            request.AddMatrixParameter("foo", null);
+
+            RestClient client = new RestClient("http://example.com");
+            Uri expected = new Uri("http://example.com/resource;foo");
+            Uri output = client.BuildUri(request);
+
+            Assert.AreEqual(expected, output);
+        }
+
+        [Test]
+        public void GET_with_matrix_and_querstring()
+        {
+            RestRequest request = new RestRequest("resource", Method.GET);
+
+            request.AddParameter("query", "queryValue", ParameterType.QueryString);
+            request.AddParameter("matrix", "matrixValue", ParameterType.Matrix);
+
+            RestClient client = new RestClient("http://example.com");
+            Uri expected = new Uri("http://example.com/resource;matrix=matrixValue?query=queryValue");
+            Uri output = client.BuildUri(request);
+
+            Assert.AreEqual(expected, output);
+        }
+
+        [Test]
+        public void GET_where_matrix_parameters_should_appear_before_querystring()
+        {
+
+            RestRequest request = new RestRequest("resource", Method.GET);
+
+            request.AddQueryParameter("query1", "queryValue1");
+            request.AddMatrixParameter("matrix1", "matrixValue1");
+            request.AddParameter("query2", null, ParameterType.QueryString);
+            request.AddParameter("matrix2", null, ParameterType.Matrix);
+
+            RestClient client = new RestClient("http://example.com");
+            Uri expected = new Uri("http://example.com/resource;matrix1=matrixValue1;matrix2?query1=queryValue1&query2=");
+            Uri output = client.BuildUri(request);
+
+            Assert.AreEqual(expected, output);
+        }
+
+        [Test]
         public void GET_with_multiple_instances_of_same_key()
         {
             RestRequest request = new RestRequest("v1/people/~/network/updates", Method.GET);

--- a/RestSharp/Enum.cs
+++ b/RestSharp/Enum.cs
@@ -26,7 +26,8 @@ namespace RestSharp
         UrlSegment,
         HttpHeader,
         RequestBody,
-        QueryString
+        QueryString,
+        Matrix
     }
 
     /// <summary>

--- a/RestSharp/IRestRequest.cs
+++ b/RestSharp/IRestRequest.cs
@@ -307,6 +307,14 @@ namespace RestSharp
         /// <returns></returns>
         IRestRequest AddQueryParameter(string name, string value);
 
+        /// <summary>
+        /// Shortcut to AddParameter(name, value, Matrix) overload
+        /// </summary>
+        /// <param name="name">Name of the parameter to add</param>
+        /// <param name="value">Value of the parameter to add</param>
+        /// <returns></returns>
+        IRestRequest AddMatrixParameter(string name, string value);
+
         Action<IRestResponse> OnBeforeDeserialization { get; set; }
 
         void IncreaseNumAttempts();

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -337,6 +337,8 @@ namespace RestSharp
                     : string.Format("{0}{1}", this.BaseUrl, assembled);
             }
 
+            assembled = AssembleMatrixParameters(request, assembled);
+
             IEnumerable<Parameter> parameters;
 
             if (request.Method != Method.POST && request.Method != Method.PUT && request.Method != Method.PATCH)
@@ -359,7 +361,7 @@ namespace RestSharp
             }
 
             // build and attach querystring
-            string data = EncodeParameters(parameters);
+            string data = EncodeParameters(parameters, "&");
             string separator = assembled != null && assembled.Contains("?")
                 ? "&"
                 : "?";
@@ -369,17 +371,37 @@ namespace RestSharp
             return new Uri(assembled);
         }
 
-        private static string EncodeParameters(IEnumerable<Parameter> parameters)
+        private static string AssembleMatrixParameters(IRestRequest request, string assembled)
         {
-            return string.Join("&", parameters.Select(EncodeParameter)
+            IEnumerable<Parameter> parameters = request.Parameters
+                .Where(p => p.Type == ParameterType.Matrix)
+                .ToList();
+
+            if (!parameters.Any())
+                return assembled;
+
+            string data = EncodeParameters(parameters, ";");
+
+            return string.Concat(assembled, ";", data);
+        }
+
+        private static string EncodeParameters(IEnumerable<Parameter> parameters, string separator)
+        {
+            return string.Join(separator, parameters.Select(EncodeParameter)
                                               .ToArray());
         }
 
         private static string EncodeParameter(Parameter parameter)
         {
-            return parameter.Value == null
-                ? string.Concat(parameter.Name.UrlEncode(), "=")
-                : string.Concat(parameter.Name.UrlEncode(), "=", parameter.Value.ToString().UrlEncode());
+            if (parameter.Value == null)
+            {
+                if (parameter.Type == ParameterType.Matrix)
+                    return parameter.Name.UrlEncode();
+
+                return string.Concat(parameter.Name.UrlEncode(), "=");
+            }
+
+            return string.Concat(parameter.Name.UrlEncode(), "=", parameter.Value.ToString().UrlEncode());
         }
 
         private void ConfigureHttp(IRestRequest request, IHttp http)

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -339,6 +339,13 @@ namespace RestSharp
 
             assembled = AssembleMatrixParameters(request, assembled);
 
+            assembled = AssembleQueryString(request, assembled);
+
+            return new Uri(assembled);
+        }
+
+        private static string AssembleQueryString(IRestRequest request, string assembled)
+        {
             IEnumerable<Parameter> parameters;
 
             if (request.Method != Method.POST && request.Method != Method.PUT && request.Method != Method.PATCH)
@@ -357,7 +364,7 @@ namespace RestSharp
 
             if (!parameters.Any())
             {
-                return new Uri(assembled);
+                return assembled;
             }
 
             // build and attach querystring
@@ -367,8 +374,7 @@ namespace RestSharp
                 : "?";
 
             assembled = string.Concat(assembled, separator, data);
-
-            return new Uri(assembled);
+            return assembled;
         }
 
         private static string AssembleMatrixParameters(IRestRequest request, string assembled)

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -505,6 +505,17 @@ namespace RestSharp
         }
 
         /// <summary>
+        /// Shortcut to AddParameter(name, value, Matrix) overload
+        /// </summary>
+        /// <param name="name">Name of the parameter to add</param>
+        /// <param name="value">Value of the parameter to add</param>
+        /// <returns></returns>
+        public IRestRequest AddMatrixParameter(string name, string value)
+        {
+            return this.AddParameter(name, value, ParameterType.Matrix);
+        }
+
+        /// <summary>
         /// Container of all HTTP parameters to be passed with the request. 
         /// See AddParameter() for explanation of the types of parameters that can be passed
         /// </summary>


### PR DESCRIPTION
Matrix parameters are another way of defining parameters and can appear anywhere in the path, but before the query string. Matrix parameters are not very common but is supported in the [WADL spec](http://www.w3.org/Submission/wadl/)

Why? Some older intermediaries or proxies don't cache their response with query string parameters and RestSharp does not support it out of the box.

Matrix parameters appear in two forms:
- Non-Boolean parameters are represented as: ';' name '=' value
- Boolean matrix parameters are represented as: ';' name when value is true and are omitted from identifier when value is false
