### PR TITLE
Add UnsafeAuthenticatedConnectionSharing flag to RestClient

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -419,6 +419,7 @@ namespace RestSharp
 
 #if !WINDOWS_PHONE && !SILVERLIGHT
             webRequest.PreAuthenticate = this.PreAuthenticate;
+            webRequest.UnsafeAuthenticatedConnectionSharing = this.UnsafeAuthenticatedConnectionSharing;
 #endif
             this.AppendHeaders(webRequest);
             this.AppendCookies(webRequest);

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -251,6 +251,7 @@ namespace RestSharp
 
             webRequest.UseDefaultCredentials = this.UseDefaultCredentials;
             webRequest.PreAuthenticate = this.PreAuthenticate;
+            webRequest.UnsafeAuthenticatedConnectionSharing = this.UnsafeAuthenticatedConnectionSharing;
             webRequest.ServicePoint.Expect100Continue = false;
 
             this.AppendHeaders(webRequest);

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -197,6 +197,15 @@ namespace RestSharp
         /// </summary>
         public bool PreAuthenticate { get; set; }
 
+        /// <summary>
+        /// Flag to reuse same connection in the HttpWebRequest
+        /// </summary>
+        public bool UnsafeAuthenticatedConnectionSharing { get; set; }
+
+        /// <summary>
+        /// Flag to send authorisation header with the HttpWebRequest
+        /// </summary>
+        public bool UseUnsafeConnection { get; set; }
 #if FRAMEWORK
         /// <summary>
         /// Proxy info to be sent with request

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -76,6 +76,8 @@ namespace RestSharp
 
         bool PreAuthenticate { get; set; }
 
+        bool UnsafeAuthenticatedConnectionSharing { get; set; }
+
 #if FRAMEWORK
         RequestCachePolicy CachePolicy { get; set; }
 #endif

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -57,6 +57,8 @@ namespace RestSharp
 
         bool PreAuthenticate { get; set; }
 
+        bool UnsafeAuthenticatedConnectionSharing { get; set; }
+
         IList<Parameter> DefaultParameters { get; }
 
         RestRequestAsyncHandle ExecuteAsync(IRestRequest request, Action<IRestResponse, RestRequestAsyncHandle> callback);

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -116,6 +116,8 @@ namespace RestSharp
 
         public bool PreAuthenticate { get; set; }
 
+        public bool UnsafeAuthenticatedConnectionSharing { get; set; }
+
         /// <summary>
         /// Default constructor that registers default content handlers
         /// </summary>
@@ -411,6 +413,7 @@ namespace RestSharp
 
             http.Url = this.BuildUri(request);
             http.PreAuthenticate = this.PreAuthenticate;
+            http.UnsafeAuthenticatedConnectionSharing = this.UnsafeAuthenticatedConnectionSharing;
 
             string userAgent = this.UserAgent ?? http.UserAgent;
 


### PR DESCRIPTION
Add UnsafeAuthenticatedConnectionSharing flag to RestClient so that we
can set it to the underlying webrequest.
