### PR TITLE
Change RestResponse to IRestResponse in sample code

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@ request.AddHeader("header", "value");
 request.AddFile(path);
 
 // execute the request
-RestResponse response = client.Execute(request);
+IRestResponse response = client.Execute(request);
 var content = response.Content; // raw content as string
 
 // or automatically deserialize result


### PR DESCRIPTION
Running the example as-is throws `DNX,Version=v4.5.1 error CS0266: Cannot implicitly convert type 'RestSharp.IRestResponse' to 'RestSharp.RestResponse'. An explicit conversion exists (are you missing a cast?)` under .NET Core.

Happy to be told I'm wrong :)