### PR TITLE
JsonDeserializer support for IEnumerable

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -82,6 +82,17 @@ namespace RestSharp.Tests
         }
 
         [Test]
+        public void Can_Deserialize_IEnumerable_of_Simple_Types()
+        {
+            const string content = "{\"numbers\":[1,2,3,4,5]}";
+            JsonDeserializer json = new JsonDeserializer { RootElement = "numbers" };
+            var output = json.Deserialize<IEnumerable<int>>(new RestResponse { Content = content });
+
+            Assert.IsNotEmpty(output);
+            Assert.IsTrue(output.Count() == 5);
+        }
+
+        [Test]
         public void Can_Deserialize_Lists_of_Simple_Types()
         {
             string doc = File.ReadAllText(Path.Combine("SampleData", "jsonlists.txt"));

--- a/RestSharp/Deserializers/JsonDeserializer.cs
+++ b/RestSharp/Deserializers/JsonDeserializer.cs
@@ -294,6 +294,13 @@ namespace RestSharp.Deserializers
             {
                 Type genericTypeDef = type.GetGenericTypeDefinition();
 
+                if (genericTypeDef == typeof(IEnumerable<>))
+                {
+                    Type itemType = type.GetGenericArguments()[0];
+                    Type listType = typeof(List<>).MakeGenericType(itemType);
+                    return this.BuildList(listType, value);
+                }
+
                 if (genericTypeDef == typeof(List<>))
                 {
                     return this.BuildList(type, value);


### PR DESCRIPTION
Bug fix for JsonDeserialize to support type of IEnumerable. If the given
property is IEnumerable, create a new list using the same generic
argument.