### PR TITLE
Fix RestRequest.RequestFormat documentation.

### DIFF
--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -536,8 +536,8 @@ namespace RestSharp
         public string Resource { get; set; }
 
         /// <summary>
-        /// Serializer to use when writing XML request bodies. Used if RequestFormat is Xml.
-        /// By default XmlSerializer is used.
+        /// Determines how to serialize the request body.
+        /// By default Xml is used.
         /// </summary>
         public DataFormat RequestFormat { get; set; }
 


### PR DESCRIPTION
Original documentation appeared to be a copy/paste of RestRequest.XmlSerializer's documentation.