### PR TITLE
Detection of millisecond-timestamps

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -624,6 +624,17 @@ namespace RestSharp.Tests
         }
 
         [Test]
+        public void Can_Deserialize_Unix_Json_Millisecond_Dates()
+        {
+            string doc = CreateUnixDateMillisecondsJson();
+            JsonDeserializer d = new JsonDeserializer();
+            RestResponse response = new RestResponse { Content = doc };
+            Birthdate bd = d.Deserialize<Birthdate>(response);
+
+            Assert.AreEqual(new DateTime(2011, 6, 30, 8, 15, 46, DateTimeKind.Utc), bd.Value);
+        }
+
+        [Test]
         public void Can_Deserialize_JsonNet_Dates()
         {
             PersonForJson person = GetPayLoad<PersonForJson>("person.json.txt");
@@ -906,6 +917,15 @@ namespace RestSharp.Tests
             JsonObject doc = new JsonObject();
 
             doc["Value"] = 1309421746;
+
+            return doc.ToString();
+        }
+
+        private static string CreateUnixDateMillisecondsJson()
+        {
+            JsonObject doc = new JsonObject();
+
+            doc["Value"] = 1309421746000;
 
             return doc.ToString();
         }

--- a/RestSharp/Extensions/StringExtensions.cs
+++ b/RestSharp/Extensions/StringExtensions.cs
@@ -122,6 +122,8 @@ namespace RestSharp.Extensions
         /// <returns>DateTime</returns>
         public static DateTime ParseJsonDate(this string input, CultureInfo culture)
         {
+            const long maxAllowedTimestamp = 253402300799;
+            
             input = input.Replace("\n", "");
             input = input.Replace("\r", "");
             input = input.RemoveSurroundingQuotes();
@@ -132,10 +134,10 @@ namespace RestSharp.Extensions
             {
                 DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-				if (unix > DateTime.MaxValue.Second)
-					return epoch.AddMilliseconds(unix);
-				else
-					return epoch.AddSeconds(unix);
+                if (unix > maxAllowedTimestamp)
+                    return epoch.AddMilliseconds(unix);
+                else
+                    return epoch.AddSeconds(unix);
             }
 
             if (input.Contains("/Date("))

--- a/RestSharp/Extensions/StringExtensions.cs
+++ b/RestSharp/Extensions/StringExtensions.cs
@@ -132,7 +132,10 @@ namespace RestSharp.Extensions
             {
                 DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-                return epoch.AddSeconds(unix);
+				if (unix > DateTime.MaxValue.Second)
+					return epoch.AddMilliseconds(unix);
+				else
+					return epoch.AddSeconds(unix);
             }
 
             if (input.Contains("/Date("))


### PR DESCRIPTION
ParseJsonDate detects if the given long is outside the allowed range and tries to add it as milliseconds instead of seconds.

This was a problem for me when using Dates generated with Java (Date.getTime()).