### PR TITLE
Possibility to change Pipelined property of WebRequest

### DIFF
--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -419,6 +419,7 @@ namespace RestSharp
 
 #if !WINDOWS_PHONE && !SILVERLIGHT
             webRequest.PreAuthenticate = this.PreAuthenticate;
+            webRequest.Pipelined = this.Pipelined;
 #endif
             this.AppendHeaders(webRequest);
             this.AppendCookies(webRequest);
@@ -481,10 +482,12 @@ namespace RestSharp
             {
                 webRequest.MaximumAutomaticRedirections = this.MaxRedirects.Value;
             }
+
 #endif
 
 #if !SILVERLIGHT
             webRequest.AllowAutoRedirect = this.FollowRedirects;
+
 #endif
             return webRequest;
         }

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -129,6 +129,11 @@ namespace RestSharp
         /// Whether or not HTTP 3xx response redirects should be automatically followed
         /// </summary>
         public bool FollowRedirects { get; set; }
+
+        /// <summary>
+        /// Whether or not to use pipelined connections
+        /// </summary>
+        public bool Pipelined { get; set; }
 #endif
 
 #if FRAMEWORK
@@ -141,6 +146,7 @@ namespace RestSharp
         /// Maximum number of automatic redirects to follow if FollowRedirects is true
         /// </summary>
         public int? MaxRedirects { get; set; }
+
 #endif
 
         /// <summary>

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -50,6 +50,8 @@ namespace RestSharp
 
 #if !SILVERLIGHT
         bool FollowRedirects { get; set; }
+
+        bool Pipelined { get; set; }
 #endif
 
 #if FRAMEWORK

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -80,6 +80,8 @@ namespace RestSharp
         IWebProxy Proxy { get; set; }
 
         RequestCachePolicy CachePolicy { get; set; }
+
+        bool Pipelined { get; set; }
 #endif
 
         bool FollowRedirects { get; set; }

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -442,7 +442,6 @@ namespace RestSharp
 #if !SILVERLIGHT
             http.FollowRedirects = this.FollowRedirects;
 
-            http.Pipelined = this.Pipelined;
 #endif
 
 #if FRAMEWORK
@@ -453,6 +452,7 @@ namespace RestSharp
 
             http.MaxRedirects = this.MaxRedirects;
             http.CachePolicy = this.CachePolicy;
+            http.Pipelined = this.Pipelined;
 #endif
 
             if (request.Credentials != null)

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -65,6 +65,8 @@ namespace RestSharp
         /// The cache policy to use for requests initiated by this client instance.
         /// </summary>
         public RequestCachePolicy CachePolicy { get; set; }
+
+        public bool Pipelined { get; set; }
 #endif
 
         /// <summary>
@@ -390,6 +392,7 @@ namespace RestSharp
             http.ResponseWriter = request.ResponseWriter;
             http.CookieContainer = this.CookieContainer;
 
+
             // move RestClient.DefaultParameters into Request.Parameters
             foreach (Parameter p in this.DefaultParameters)
             {
@@ -438,6 +441,8 @@ namespace RestSharp
 
 #if !SILVERLIGHT
             http.FollowRedirects = this.FollowRedirects;
+
+            http.Pipelined = this.Pipelined;
 #endif
 
 #if FRAMEWORK


### PR DESCRIPTION
I came across to a similar problem as in #770. When having multiple requests at the same sometimes responses got mixed up or some responses got lost. Having Pipelined set as false fixed the problem.