### PR TITLE
Added HTTP ProtocolVersion

### DIFF
--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -404,11 +404,9 @@ namespace RestSharp
 #if FRAMEWORK
                 response.ContentEncoding = webResponse.ContentEncoding;
                 response.Server = webResponse.Server;
-#endif
-
-#if !SILVERLIGHT
                 response.ProtocolVersion = webResponse.ProtocolVersion;
 #endif
+
                 response.ContentType = webResponse.ContentType;
                 response.ContentLength = webResponse.ContentLength;
 

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -405,6 +405,10 @@ namespace RestSharp
                 response.ContentEncoding = webResponse.ContentEncoding;
                 response.Server = webResponse.Server;
 #endif
+
+#if !SILVERLIGHT
+                response.ProtocolVersion = webResponse.ProtocolVersion;
+#endif
                 response.ContentType = webResponse.ContentType;
                 response.ContentLength = webResponse.ContentLength;
 

--- a/RestSharp/HttpResponse.cs
+++ b/RestSharp/HttpResponse.cs
@@ -113,5 +113,12 @@ namespace RestSharp
         /// Exception thrown when error is encountered.
         /// </summary>
         public Exception ErrorException { get; set; }
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// The HTTP protocol version (1.0, 1.1, 2.0, etc.) 
+        /// </summary>
+        public Version ProtocolVersion { get; set; }
+#endif
     }
 }

--- a/RestSharp/HttpResponse.cs
+++ b/RestSharp/HttpResponse.cs
@@ -114,7 +114,7 @@ namespace RestSharp
         /// </summary>
         public Exception ErrorException { get; set; }
 
-#if !SILVERLIGHT
+#if FRAMEWORK
         /// <summary>
         /// The HTTP protocol version (1.0, 1.1, 2.0, etc.) 
         /// </summary>

--- a/RestSharp/IHttpResponse.cs
+++ b/RestSharp/IHttpResponse.cs
@@ -80,7 +80,7 @@ namespace RestSharp
         /// </summary>
         Exception ErrorException { get; set; }
 
-#if !SILVERLIGHT
+#if FRAMEWORK
         /// <summary>
         /// The HTTP protocol version (1.0, 1.1, 2.0, etc.) 
         /// </summary>

--- a/RestSharp/IHttpResponse.cs
+++ b/RestSharp/IHttpResponse.cs
@@ -79,5 +79,12 @@ namespace RestSharp
         /// Exception thrown when error is encountered.
         /// </summary>
         Exception ErrorException { get; set; }
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// The HTTP protocol version (1.0, 1.1, 2.0, etc.) 
+        /// </summary>
+        Version ProtocolVersion { get; set; }
+#endif
     }
 }

--- a/RestSharp/IRestResponse.cs
+++ b/RestSharp/IRestResponse.cs
@@ -90,7 +90,7 @@ namespace RestSharp
         /// HTTP protocol errors are handled by RestSharp and will not appear here.</remarks>
         Exception ErrorException { get; set; }
 
-#if !SILVERLIGHT
+#if FRAMEWORK
         /// <summary>
         /// The HTTP protocol version (1.0, 1.1, 2.0, etc.) 
         /// </summary>

--- a/RestSharp/IRestResponse.cs
+++ b/RestSharp/IRestResponse.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Security.Cryptography.X509Certificates;
 
 namespace RestSharp
 {
@@ -89,6 +90,13 @@ namespace RestSharp
         /// <remarks>Will contain only network transport or framework exceptions thrown during the request.
         /// HTTP protocol errors are handled by RestSharp and will not appear here.</remarks>
         Exception ErrorException { get; set; }
+
+#if !SILVERLIGHT
+        /// <summary>
+        /// The HTTP protocol version (1.0, 1.1, 2.0, etc.) 
+        /// </summary>
+        Version ProtocolVersion { get; set; }
+#endif
     }
 
     /// <summary>

--- a/RestSharp/IRestResponse.cs
+++ b/RestSharp/IRestResponse.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Security.Cryptography.X509Certificates;
 
 namespace RestSharp
 {

--- a/RestSharp/RestResponse.cs
+++ b/RestSharp/RestResponse.cs
@@ -126,6 +126,12 @@ namespace RestSharp
         /// </summary>
         public Exception ErrorException { get; set; }
 
+#if !SILVERLIGHT
+        /// <summary>
+        /// The HTTP protocol version (1.0, 1.1, 2.0, etc.) 
+        /// </summary>
+        public Version ProtocolVersion { get; set; }
+#endif
 
         /// <summary>
         /// Assists with debugging responses by displaying in the debugger output

--- a/RestSharp/RestResponse.cs
+++ b/RestSharp/RestResponse.cs
@@ -126,7 +126,7 @@ namespace RestSharp
         /// </summary>
         public Exception ErrorException { get; set; }
 
-#if !SILVERLIGHT
+#if FRAMEWORK
         /// <summary>
         /// The HTTP protocol version (1.0, 1.1, 2.0, etc.) 
         /// </summary>


### PR DESCRIPTION
This just exposes the underlying property on the HttpWebResponse. This is excluded for SILVERLIGHT builds as that property is not available (https://msdn.microsoft.com/en-us/library/ww5755y6%28v=vs.95%29.aspx).

Closes #790 