### PR TITLE
Added ProtocolVersion to RestResponse.

### DIFF
--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -404,6 +404,7 @@ namespace RestSharp
 #if FRAMEWORK
                 response.ContentEncoding = webResponse.ContentEncoding;
                 response.Server = webResponse.Server;
+                response.ProtocolVersion = webResponse.ProtocolVersion;
 #endif
                 response.ContentType = webResponse.ContentType;
                 response.ContentLength = webResponse.ContentLength;

--- a/RestSharp/HttpResponse.cs
+++ b/RestSharp/HttpResponse.cs
@@ -113,5 +113,11 @@ namespace RestSharp
         /// Exception thrown when error is encountered.
         /// </summary>
         public Exception ErrorException { get; set; }
+
+        /// <summary>
+        /// The HTTP protocol version (1.0, 1.1, etc)
+        /// </summary>
+        /// <remarks>Only set when underlying framework supports it.</remarks>
+        public Version ProtocolVersion { get; set; }
     }
 }

--- a/RestSharp/IHttpResponse.cs
+++ b/RestSharp/IHttpResponse.cs
@@ -79,5 +79,11 @@ namespace RestSharp
         /// Exception thrown when error is encountered.
         /// </summary>
         Exception ErrorException { get; set; }
+
+        /// <summary>
+        /// The HTTP protocol version (1.0, 1.1, etc)
+        /// </summary>
+        /// <remarks>Only set when underlying framework supports it.</remarks>
+        Version ProtocolVersion { get; set; }
     }
 }

--- a/RestSharp/IRestResponse.cs
+++ b/RestSharp/IRestResponse.cs
@@ -89,6 +89,12 @@ namespace RestSharp
         /// <remarks>Will contain only network transport or framework exceptions thrown during the request.
         /// HTTP protocol errors are handled by RestSharp and will not appear here.</remarks>
         Exception ErrorException { get; set; }
+
+        /// <summary>
+        /// The HTTP protocol version (1.0, 1.1, etc)
+        /// </summary>
+        /// <remarks>Only set when underlying framework supports it.</remarks>
+        Version ProtocolVersion { get; set; }
     }
 
     /// <summary>

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -565,6 +565,7 @@ namespace RestSharp
                                             RawBytes = httpResponse.RawBytes,
                                             ResponseStatus = httpResponse.ResponseStatus,
                                             ResponseUri = httpResponse.ResponseUri,
+                                            ProtocolVersion = httpResponse.ProtocolVersion,
                                             Server = httpResponse.Server,
                                             StatusCode = httpResponse.StatusCode,
                                             StatusDescription = httpResponse.StatusDescription,

--- a/RestSharp/RestResponse.cs
+++ b/RestSharp/RestResponse.cs
@@ -126,6 +126,11 @@ namespace RestSharp
         /// </summary>
         public Exception ErrorException { get; set; }
 
+        /// <summary>
+        /// The HTTP protocol version (1.0, 1.1, etc)
+        /// </summary>
+        /// <remarks>Only set when underlying framework supports it.</remarks>
+        public Version ProtocolVersion { get; set; }
 
         /// <summary>
         /// Assists with debugging responses by displaying in the debugger output
@@ -164,6 +169,7 @@ namespace RestSharp
                        RawBytes = response.RawBytes,
                        ResponseStatus = response.ResponseStatus,
                        ResponseUri = response.ResponseUri,
+                       ProtocolVersion = response.ProtocolVersion,
                        Server = response.Server,
                        StatusCode = response.StatusCode,
                        StatusDescription = response.StatusDescription,


### PR DESCRIPTION
It is only set in FRAMEWORK builds, but is available as the default on any platform.

Fixes #790