### PR TITLE
Add RemoteCertificateValidationCallback for .NET 4.5 and Above via RestClient

### DIFF
--- a/RestSharp.Net45/RestSharp.Net45.Signed.csproj
+++ b/RestSharp.Net45/RestSharp.Net45.Signed.csproj
@@ -22,7 +22,7 @@
     <Optimize>false</Optimize>
     <OutputPath>bin\DebugSigned\</OutputPath>
     <IntermediateOutputPath>obj\DebugSigned\</IntermediateOutputPath>
-    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4, SIGNED</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4, NET45, SIGNED</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\DebugSigned\RestSharp.xml</DocumentationFile>

--- a/RestSharp.Net45/RestSharp.Net45.csproj
+++ b/RestSharp.Net45/RestSharp.Net45.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4, NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\RestSharp.xml</DocumentationFile>

--- a/RestSharp.Net451/RestSharp.Net451.Signed.csproj
+++ b/RestSharp.Net451/RestSharp.Net451.Signed.csproj
@@ -22,7 +22,7 @@
     <Optimize>false</Optimize>
     <OutputPath>bin\DebugSigned\</OutputPath>
     <IntermediateOutputPath>obj\DebugSigned\</IntermediateOutputPath>
-    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4, SIGNED</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4, NET45, SIGNED</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\DebugSigned\RestSharp.xml</DocumentationFile>

--- a/RestSharp.Net451/RestSharp.Net451.csproj
+++ b/RestSharp.Net451/RestSharp.Net451.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4, NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\RestSharp.xml</DocumentationFile>

--- a/RestSharp.Net452/RestSharp.Net452.Signed.csproj
+++ b/RestSharp.Net452/RestSharp.Net452.Signed.csproj
@@ -22,7 +22,7 @@
     <Optimize>false</Optimize>
     <OutputPath>bin\DebugSigned\</OutputPath>
     <IntermediateOutputPath>obj\DebugSigned\</IntermediateOutputPath>
-    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4, SIGNED</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4, NET45, SIGNED</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\DebugSigned\RestSharp.xml</DocumentationFile>

--- a/RestSharp.Net452/RestSharp.Net452.csproj
+++ b/RestSharp.Net452/RestSharp.Net452.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4, NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\RestSharp.xml</DocumentationFile>

--- a/RestSharp.Net46/RestSharp.Net46.Signed.csproj
+++ b/RestSharp.Net46/RestSharp.Net46.Signed.csproj
@@ -22,7 +22,7 @@
     <Optimize>false</Optimize>
     <OutputPath>bin\DebugSigned\</OutputPath>
     <IntermediateOutputPath>obj\DebugSigned\</IntermediateOutputPath>
-    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4, SIGNED</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4, NET45, SIGNED</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\DebugSigned\RestSharp.xml</DocumentationFile>

--- a/RestSharp.Net46/RestSharp.Net46.csproj
+++ b/RestSharp.Net46/RestSharp.Net46.csproj
@@ -21,7 +21,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;FRAMEWORK, NET4, NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\RestSharp.xml</DocumentationFile>

--- a/RestSharp/Http.Async.cs
+++ b/RestSharp/Http.Async.cs
@@ -486,6 +486,9 @@ namespace RestSharp
 #if !SILVERLIGHT
             webRequest.AllowAutoRedirect = this.FollowRedirects;
 #endif
+#if NET45
+            webRequest.ServerCertificateValidationCallback = this.RemoteCertificateValidationCallback;
+#endif
             return webRequest;
         }
 

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -312,6 +312,10 @@ namespace RestSharp
                 webRequest.MaximumAutomaticRedirections = this.MaxRedirects.Value;
             }
 
+#if NET45
+            webRequest.ServerCertificateValidationCallback = this.RemoteCertificateValidationCallback;
+#endif
+
             return webRequest;
         }
     }

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -30,6 +30,7 @@ using RestSharp.Compression.ZLib;
 
 #if FRAMEWORK
 using System.Net.Cache;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 #endif
@@ -207,6 +208,12 @@ namespace RestSharp
         /// Caching policy for requests created with this wrapper.
         /// </summary>
         public RequestCachePolicy CachePolicy { get; set; }
+#endif
+#if NET45
+        /// <summary>
+        /// Callback function for handling the validation of remote certificates.
+        /// </summary>
+        public RemoteCertificateValidationCallback  RemoteCertificateValidationCallback { get; set; }
 #endif
 
         /// <summary>

--- a/RestSharp/IHttp.cs
+++ b/RestSharp/IHttp.cs
@@ -24,6 +24,7 @@ using System.Text;
 
 #if FRAMEWORK
 using System.Net.Cache;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 #endif
 
@@ -129,6 +130,9 @@ namespace RestSharp
         HttpResponse AsGet(string httpMethod);
 
         IWebProxy Proxy { get; set; }
+#endif
+#if NET45
+        RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 #endif
     }
 }

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -31,6 +31,7 @@ using System.Threading.Tasks;
 #if FRAMEWORK
 using System.Net.Cache;
 using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
 #endif
 
 namespace RestSharp
@@ -85,6 +86,14 @@ namespace RestSharp
         bool FollowRedirects { get; set; }
 
         Uri BuildUri(IRestRequest request);
+
+#if NET45
+        /// <summary>
+        /// Callback function for handling the validation of remote certificates. Useful for certificate pinning and
+        /// overriding certificate errors in the scope of a request.
+        /// </summary>
+        RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
+#endif
 
         /// <summary>
         /// Executes a GET-style request and callback asynchronously, authenticating if needed

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -118,6 +118,10 @@ namespace RestSharp
         public bool PreAuthenticate { get; set; }
 
 #if NET45
+        /// <summary>
+        /// Callback function for handling the validation of remote certificates. Useful for certificate pinning and
+        /// overriding certificate errors in the scope of a request.
+        /// </summary>
         public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
 #endif
 
@@ -544,6 +548,9 @@ namespace RestSharp
             }
 #if FRAMEWORK
             this.ConfigureProxy(http);
+#endif
+#if NET45
+            http.RemoteCertificateValidationCallback = this.RemoteCertificateValidationCallback;
 #endif
         }
 

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -30,6 +30,7 @@ using RestSharp.Extensions;
 #if FRAMEWORK
 using System.Net.Cache;
 using System.Security.Cryptography.X509Certificates;
+using System.Net.Security;
 #endif
 
 namespace RestSharp
@@ -115,6 +116,10 @@ namespace RestSharp
         public Encoding Encoding { get; set; }
 
         public bool PreAuthenticate { get; set; }
+
+#if NET45
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; set; }
+#endif
 
         /// <summary>
         /// Default constructor that registers default content handlers


### PR DESCRIPTION
Fixes #620 by adding a ```RemoteCertificateValidationCallback``` on ``IRestClient`` and passing it all the way to the creation of the ```HttpWebRequest``` for custom per-request certificate validation.