### PR TITLE
User set Content-Type was being by the content type of the body

### DIFF
--- a/RestSharp.IntegrationTests/StatusCodeTests.cs
+++ b/RestSharp.IntegrationTests/StatusCodeTests.cs
@@ -56,9 +56,9 @@ namespace RestSharp.IntegrationTests
             {
                 RestClient client = new RestClient(baseUrl);
                 RestRequest request = new RestRequest("error")
-                                      {
-                                          RootElement = "Success"
-                                      };
+                {
+                    RootElement = "Success"
+                };
 
                 request.OnBeforeDeserialization = resp =>
                                                   {
@@ -84,9 +84,9 @@ namespace RestSharp.IntegrationTests
             {
                 RestClient client = new RestClient(baseUrl);
                 RestRequest request = new RestRequest("success")
-                                      {
-                                          RootElement = "Success"
-                                      };
+                {
+                    RootElement = "Success"
+                };
 
                 request.OnBeforeDeserialization = resp =>
                                                   {
@@ -102,10 +102,40 @@ namespace RestSharp.IntegrationTests
                 Assert.AreEqual("Works!", response.Data.Message);
             }
         }
+
+        [Test]
+        public void ContentType_Additional_Information()
+        {
+            Uri baseUrl = new Uri("http://localhost:8888/");
+
+            using (SimpleServer.Create(baseUrl.AbsoluteUri, Handlers.Generic<ResponseHandler>()))
+            {
+                RestClient client = new RestClient(baseUrl);
+                var request = new RestRequest(Method.POST);
+                request.RequestFormat = DataFormat.Json;
+                request.AddBody("bodyadsodajjd");
+                request.AddHeader("X-RequestDigest", "xrequestdigestasdasd");
+                request.AddHeader("Accept", "application/json; odata=verbose");
+                request.AddHeader("Content-Type", "application/json; odata=verbose");
+                request.Resource = "contenttype_odata";
+
+                IRestResponse<Response> response = client.Execute<Response>(request);
+
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
     }
 
     public class ResponseHandler
     {
+
+        private void contenttype_odata(HttpListenerContext context)
+        {
+            bool hasCorrectHeader = context.Request.Headers["Content-Type"] == "application/json; odata=verbose";
+            context.Response.StatusCode = hasCorrectHeader ? 200 : 400;
+        }
+
         private void error(HttpListenerContext context)
         {
             context.Response.StatusCode = 400;

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -329,11 +329,11 @@ namespace RestSharp
             {
 #if FRAMEWORK
                 Cookie cookie = new Cookie
-                                {
-                                    Name = httpCookie.Name,
-                                    Value = httpCookie.Value,
-                                    Domain = webRequest.RequestUri.Host
-                                };
+                {
+                    Name = httpCookie.Name,
+                    Value = httpCookie.Value,
+                    Domain = webRequest.RequestUri.Host
+                };
 
                 webRequest.CookieContainer.Add(cookie);
 #else
@@ -368,18 +368,23 @@ namespace RestSharp
 
         private void PreparePostBody(HttpWebRequest webRequest)
         {
+            bool needsContentType = String.IsNullOrEmpty(webRequest.ContentType);
+
             if (this.HasFiles || this.AlwaysMultipartFormData)
             {
-                webRequest.ContentType = GetMultipartFormContentType();
+                if (needsContentType)
+                    webRequest.ContentType = GetMultipartFormContentType();
             }
             else if (this.HasParameters)
             {
-                webRequest.ContentType = "application/x-www-form-urlencoded";
+                if (needsContentType)
+                    webRequest.ContentType = "application/x-www-form-urlencoded";
                 this.RequestBody = this.EncodeParameters();
             }
             else if (this.HasBody)
             {
-                webRequest.ContentType = this.RequestContentType;
+                if (needsContentType)
+                    webRequest.ContentType = this.RequestContentType;
             }
         }
 
@@ -449,22 +454,22 @@ namespace RestSharp
                     foreach (Cookie cookie in webResponse.Cookies)
                     {
                         response.Cookies.Add(new HttpCookie
-                                             {
-                                                 Comment = cookie.Comment,
-                                                 CommentUri = cookie.CommentUri,
-                                                 Discard = cookie.Discard,
-                                                 Domain = cookie.Domain,
-                                                 Expired = cookie.Expired,
-                                                 Expires = cookie.Expires,
-                                                 HttpOnly = cookie.HttpOnly,
-                                                 Name = cookie.Name,
-                                                 Path = cookie.Path,
-                                                 Port = cookie.Port,
-                                                 Secure = cookie.Secure,
-                                                 TimeStamp = cookie.TimeStamp,
-                                                 Value = cookie.Value,
-                                                 Version = cookie.Version
-                                             });
+                        {
+                            Comment = cookie.Comment,
+                            CommentUri = cookie.CommentUri,
+                            Discard = cookie.Discard,
+                            Domain = cookie.Domain,
+                            Expired = cookie.Expired,
+                            Expires = cookie.Expires,
+                            HttpOnly = cookie.HttpOnly,
+                            Name = cookie.Name,
+                            Path = cookie.Path,
+                            Port = cookie.Port,
+                            Secure = cookie.Secure,
+                            TimeStamp = cookie.TimeStamp,
+                            Value = cookie.Value,
+                            Version = cookie.Version
+                        });
                     }
                 }
 
@@ -473,10 +478,10 @@ namespace RestSharp
                     string headerValue = webResponse.Headers[headerName];
 
                     response.Headers.Add(new HttpHeader
-                                         {
-                                             Name = headerName,
-                                             Value = headerValue
-                                         });
+                    {
+                        Name = headerName,
+                        Value = headerValue
+                    });
                 }
 #if !WINDOWS_UWP
                 webResponse.Close();


### PR DESCRIPTION
Fixes #784 where users were unable to set a custom content type because it was being overwritten by the content type of the body. 
