### PR TITLE
Implemented public Deserialize<T> method on RestClient

### DIFF
--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -64,6 +64,8 @@ namespace RestSharp
 
         RestRequestAsyncHandle ExecuteAsync<T>(IRestRequest request, Action<IRestResponse<T>, RestRequestAsyncHandle> callback);
 
+        IRestResponse<T> Deserialize<T>(IRestResponse response);
+
 #if FRAMEWORK
         IRestResponse Execute(IRestRequest request);
 

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -233,6 +233,11 @@ namespace RestSharp
             this.RemoveDefaultParameter("Accept");
         }
 
+        public IRestResponse<T> Deserialize<T>(IRestResponse response) 
+        {
+            return Deserialize<T>(response.Request, response);
+        }
+
         /// <summary>
         /// Retrieve the handler for the specified MIME content type
         /// </summary>


### PR DESCRIPTION
I created this public method so that callers could choose to deserialize a response into a particular type based on the status code provided in the response.

This should resolve #774 
