### PR TITLE
Allow deserialization of very large integers

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -825,6 +825,14 @@ namespace RestSharp.Tests
             Assert.IsNull(dictionary["Null"]);
         }
 
+        [Test]
+        public void Can_Deserialize_Very_Large_Integers()
+        {
+            decimal veryLargeInteger = long.MaxValue + 1M;
+            decimal deserializedValue = new JsonDeserializer().Deserialize<decimal>(new RestResponse { Content = veryLargeInteger.ToString() });
+            Assert.AreEqual(veryLargeInteger, deserializedValue);
+        }
+
         private static string CreateJsonWithUnderscores()
         {
             JsonObject doc = new JsonObject();

--- a/RestSharp/SimpleJson.cs
+++ b/RestSharp/SimpleJson.cs
@@ -903,19 +903,29 @@ namespace RestSharp
             EatWhitespace(json, ref index);
             int lastIndex = GetLastIndexOfNumber(json, index);
             int charLength = (lastIndex - index) + 1;
-            object returnNumber;
-            string str = new string(json, index, charLength);
-            if (str.IndexOf(".", StringComparison.OrdinalIgnoreCase) != -1 || str.IndexOf("e", StringComparison.OrdinalIgnoreCase) != -1)
+            object returnNumber = null;
+            string numberAsString = new string(json, index, charLength);
+            if ((numberAsString.IndexOf(".", StringComparison.OrdinalIgnoreCase) != -1)
+             || (numberAsString.IndexOf("e", StringComparison.OrdinalIgnoreCase) != -1))
             {
                 double number;
-                success = double.TryParse(new string(json, index, charLength), NumberStyles.Any, CultureInfo.InvariantCulture, out number);
+                success = double.TryParse(numberAsString, NumberStyles.Any, CultureInfo.InvariantCulture, out number);
                 returnNumber = number;
             }
             else
             {
-                long number;
-                success = long.TryParse(new string(json, index, charLength), NumberStyles.Any, CultureInfo.InvariantCulture, out number);
-                returnNumber = number;
+                long longNumber;
+                decimal decimalNumber;
+                double doubleNumber;
+
+                if (long.TryParse(numberAsString, NumberStyles.Any, CultureInfo.InvariantCulture, out longNumber))
+                    returnNumber = longNumber;
+                else if (decimal.TryParse(numberAsString, NumberStyles.Any, CultureInfo.InvariantCulture, out decimalNumber))
+                    returnNumber = decimalNumber;
+                else if (double.TryParse(numberAsString, NumberStyles.Any, CultureInfo.InvariantCulture, out doubleNumber))
+                    returnNumber = doubleNumber;
+
+                success = (returnNumber != null);
             }
             index = lastIndex + 1;
             return returnNumber;


### PR DESCRIPTION
While I was working on PR #873, I was reading through the SimpleJson code and discovered that the way in which it parses integers might reject some syntactically-valid JSON documents. In particular, JSON allows for very large integer values to be specified (values large enough that a 64-bit integer cannot represent them) with no punctuation or exponentiation. These values would, in typical implementations, need to be represented as floating-point values (`double`), but because they lack periods and `e` signifiers, the SimpleJson code will only attempt to parse them as `long`. This means that the (valid) JSON string produced by `(long.MaxValue + 1M).ToString()` cannot be parsed. This PR addresses the issue (using `decimal` and then `double` as fallbacks where `long` fails), and adds a corresponding unit test.