### PR TITLE
changed Regex suffix to static

### DIFF
--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -201,7 +201,7 @@ namespace RestSharp
         {
             this.ContentHandlers[contentType] = deserializer;
 
-            if (contentType != "*" && !this.structuredSyntaxSuffixWildcardRegex.IsMatch(contentType))
+            if (contentType != "*" && !structuredSyntaxSuffixWildcardRegex.IsMatch(contentType))
             {
                 this.AcceptTypes.Add(contentType);
                 // add Accept header based on registered deserializers
@@ -263,7 +263,7 @@ namespace RestSharp
             }
 
             // https://tools.ietf.org/html/rfc6839#page-4
-            Match structuredSyntaxSuffixMatch = this.structuredSyntaxSuffixRegex.Match(contentType);
+            Match structuredSyntaxSuffixMatch = structuredSyntaxSuffixRegex.Match(contentType);
 
             if (structuredSyntaxSuffixMatch.Success)
             {
@@ -288,9 +288,9 @@ namespace RestSharp
 
         private readonly Regex structuredSyntaxSuffixWildcardRegex = new Regex(@"^\*\+\w+$");
 #else
-        private readonly Regex structuredSyntaxSuffixRegex = new Regex(@"\+\w+$", RegexOptions.Compiled);
+        private static readonly Regex structuredSyntaxSuffixRegex = new Regex(@"\+\w+$", RegexOptions.Compiled);
 
-        private readonly Regex structuredSyntaxSuffixWildcardRegex = new Regex(@"^\*\+\w+$", RegexOptions.Compiled);
+        private static readonly Regex structuredSyntaxSuffixWildcardRegex = new Regex(@"^\*\+\w+$", RegexOptions.Compiled);
 #endif
 
         private void AuthenticateIfNeeded(RestClient client, IRestRequest request)


### PR DESCRIPTION
This is perfomance problem. When we created class RestClient, it is checked AddHandler, but we create new regexp every time. And this is very long operation. If use static, this operation very fast.
Example:
            for (var i = 0; i < 1000; i++)
            {
                var client = new RestSharp.RestClient( new Uri("https://api-maps.yandex.ru/2.1/"));
            }
with static - 0.07s
without static - 5s
msdn is written regex is Thread Safety - https://msdn.microsoft.com/en-us/library/6h453d2h(v=vs.110).aspx