### PR TITLE
Fix attribute being deserialized as parent element when named Value

### DIFF
--- a/RestSharp.Tests/SampleClasses/misc.cs
+++ b/RestSharp.Tests/SampleClasses/misc.cs
@@ -79,6 +79,18 @@ namespace RestSharp.Tests.SampleClasses
         }
     }
 
+    public class ValueCollectionForXml
+    {
+        public string Value { get; set; }
+        public List<ValueForXml> Values { get; set; }
+    }
+
+    public class ValueForXml
+    {
+        public DateTime Timestamp { get; set; }
+        public string Value { get; set; }
+    }
+
     public class IncomingInvoice
     {
         public int ConceptId { get; set; }

--- a/RestSharp.Tests/XmlDeserializerTests.cs
+++ b/RestSharp.Tests/XmlDeserializerTests.cs
@@ -659,6 +659,67 @@ namespace RestSharp.Tests
             Assert.AreEqual(nullableDateTimeOffsetWithValue, payload.NullableDateTimeOffsetWithValue);
         }
 
+        [Test]
+        public void Can_Deserialize_ElementNamedValue()
+        {
+            XDocument doc = new XDocument();
+            XElement root = new XElement("ValueCollection");
+
+            string valueName = "First moon landing events";
+            root.Add(new XElement("Value", valueName));
+
+            var xmlCollection = new XElement("Values");
+
+            var first = new XElement("Value");
+            first.Add(new XAttribute("Timestamp", new DateTime(1969, 7, 20, 20, 18, 00, DateTimeKind.Utc)));
+            xmlCollection.Add(first);
+
+            var second = new XElement("Value");
+            second.Add(new XAttribute("Timestamp", new DateTime(1969, 7, 21, 2, 56, 15, DateTimeKind.Utc)));
+            xmlCollection.Add(second);
+
+            root.Add(xmlCollection);
+            doc.Add(root);
+
+            RestResponse response = new RestResponse { Content = doc.ToString() };
+            XmlDeserializer d = new XmlDeserializer();
+            ValueCollectionForXml valueCollection = d.Deserialize<ValueCollectionForXml>(response);
+
+            Assert.AreEqual(valueName, valueCollection.Value);
+            Assert.AreEqual(2, valueCollection.Values.Count);
+            Assert.AreEqual(new DateTime(1969, 7, 20, 20, 18, 00, DateTimeKind.Utc), valueCollection.Values.First().Timestamp.ToUniversalTime());
+        }
+
+        [Test]
+        public void Can_Deserialize_AttributeNamedValue()
+        {
+            XDocument doc = new XDocument();
+            XElement root = new XElement("ValueCollection");
+
+            var xmlCollection = new XElement("Values");
+
+            var first = new XElement("Value");
+            first.Add(new XAttribute("Timestamp", new DateTime(1969, 7, 20, 20, 18, 00, DateTimeKind.Utc)));
+            first.Add(new XAttribute("Value", "Eagle landed"));
+            
+            xmlCollection.Add(first);
+
+            var second = new XElement("Value");
+            second.Add(new XAttribute("Timestamp", new DateTime(1969, 7, 21, 2, 56, 15, DateTimeKind.Utc)));
+            second.Add(new XAttribute("Value", "First step"));
+            xmlCollection.Add(second);
+
+            root.Add(xmlCollection);
+            doc.Add(root);
+
+            RestResponse response = new RestResponse { Content = doc.ToString() };
+            XmlDeserializer d = new XmlDeserializer();
+            ValueCollectionForXml valueCollection = d.Deserialize<ValueCollectionForXml>(response);
+
+            Assert.AreEqual(2, valueCollection.Values.Count);
+            Assert.AreEqual("Eagle landed", valueCollection.Values.First().Value);
+        }
+
         private static string CreateUnderscoresXml()
         {
             XDocument doc = new XDocument();

--- a/RestSharp/Deserializers/XmlDeserializer.cs
+++ b/RestSharp/Deserializers/XmlDeserializer.cs
@@ -522,7 +522,8 @@ namespace RestSharp.Deserializers
                 return root.Element(camelName);
             }
 
-            if (name == "Value".AsNamespaced(name.NamespaceName))
+            if (name == "Value".AsNamespaced(name.NamespaceName) &&
+                (!root.HasAttributes || root.Attributes().All(x => x.Name != name)))
             {
                 return root;
             }


### PR DESCRIPTION
When a class has a property named Value corresponding to an XML attribute inside an element, which is not the root element, then deserialization is failing only for that property.