### PR TITLE
Credentials property moved to Client from Request.

### DIFF
--- a/RestSharp/Authenticators/NtlmAuthenticator.cs
+++ b/RestSharp/Authenticators/NtlmAuthenticator.cs
@@ -60,7 +60,7 @@ namespace RestSharp.Authenticators
 
         public void Authenticate(IRestClient client, IRestRequest request)
         {
-            request.Credentials = this.credentials;
+            client.Credentials = this.credentials;
         }
     }
 }

--- a/RestSharp/IRestClient.cs
+++ b/RestSharp/IRestClient.cs
@@ -72,6 +72,11 @@ namespace RestSharp
         byte[] DownloadData(IRestRequest request);
 #endif
 
+        /// <summary>
+        /// In general you would not need to set this directly. Used by the NtlmAuthenticator. 
+        /// </summary>
+        ICredentials Credentials { get; set; }
+
 #if FRAMEWORK
         /// <summary>
         /// X509CertificateCollection to be sent with request

--- a/RestSharp/IRestRequest.cs
+++ b/RestSharp/IRestRequest.cs
@@ -102,11 +102,6 @@ namespace RestSharp
         string XmlNamespace { get; set; }
 
         /// <summary>
-        /// In general you would not need to set this directly. Used by the NtlmAuthenticator. 
-        /// </summary>
-        ICredentials Credentials { get; set; }
-
-        /// <summary>
         /// Timeout in milliseconds to be used for the request. This timeout value overrides a timeout set on the RestClient.
         /// </summary>
         int Timeout { get; set; }

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -55,6 +55,12 @@ namespace RestSharp
         /// </summary>
         public int? MaxRedirects { get; set; }
 
+        /// <summary>
+        /// In general you would not need to set this directly. Used by the NtlmAuthenticator. 
+        /// </summary>
+        public ICredentials Credentials { get; set; }
+
+
 #if FRAMEWORK
         /// <summary>
         /// X509CertificateCollection to be sent with request
@@ -469,9 +475,9 @@ namespace RestSharp
             http.Pipelined = this.Pipelined;
 #endif
 
-            if (request.Credentials != null)
+            if (this.Credentials != null)
             {
-                http.Credentials = request.Credentials;
+                http.Credentials = this.Credentials;
             }
 
             IEnumerable<HttpHeader> headers = from p in request.Parameters

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -582,11 +582,6 @@ namespace RestSharp
         public string XmlNamespace { get; set; }
 
         /// <summary>
-        /// In general you would not need to set this directly. Used by the NtlmAuthenticator. 
-        /// </summary>
-        public ICredentials Credentials { get; set; }
-
-        /// <summary>
         /// Gets or sets a user-defined state object that contains information about a request and which can be later 
         /// retrieved when the request completes.
         /// </summary>


### PR DESCRIPTION
Like ClientCertificates property should be on Client not Request. Internal Credentials class automatically fetch the credentials by accessed resource URL.