### PR TITLE
Use Encoding to UrlEncode the post parameters 

### DIFF
--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -24,10 +24,6 @@ using System.Net;
 using System.Text;
 using RestSharp.Extensions;
 
-#if WINDOWS_PHONE
-using System.Net;
-#endif
-
 #if SILVERLIGHT
 using System.Windows.Browser;
 #endif

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -23,11 +23,6 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using RestSharp.Extensions;
-
-#if SILVERLIGHT
-using System.Windows.Browser;
-#endif
-
 #if !SILVERLIGHT && !WINDOWS_PHONE
 using RestSharp.Extensions.MonoHttp;
 #endif
@@ -368,7 +363,13 @@ namespace RestSharp
                     querystring.Append("&");
                 }
 
-                querystring.AppendFormat("{0}={1}", p.Name.UrlEncode(), HttpUtility.UrlEncode(p.Value, encoding));
+                querystring.AppendFormat("{0}={1}", p.Name.UrlEncode(), 
+                    #if !SILVERLIGHT && !WINDOWS_PHONE
+                    HttpUtility.UrlEncode(p.Value, encoding)
+                    #else
+                    p.Value.UrlEncode()
+                    #endif
+                );
             }
 
             return querystring.ToString();

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -23,7 +23,18 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using RestSharp.Extensions;
+
+#if WINDOWS_PHONE
+using System.Net;
+#endif
+
+#if SILVERLIGHT
+using System.Windows.Browser;
+#endif
+
+#if !SILVERLIGHT && !WINDOWS_PHONE
 using RestSharp.Extensions.MonoHttp;
+#endif
 
 #if WINDOWS_PHONE
 using RestSharp.Compression.ZLib;

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using RestSharp.Extensions;
+using RestSharp.Extensions.MonoHttp;
 
 #if WINDOWS_PHONE
 using RestSharp.Compression.ZLib;
@@ -360,7 +361,7 @@ namespace RestSharp
                     querystring.Append("&");
                 }
 
-                querystring.AppendFormat("{0}={1}", p.Name.UrlEncode(), p.Value.UrlEncode());
+                querystring.AppendFormat("{0}={1}", p.Name.UrlEncode(), HttpUtility.UrlEncode(p.Value, encoding));
             }
 
             return querystring.ToString();


### PR DESCRIPTION
Use the assigned Encoding to UrlEncode the values of post parameters.

It always fails when post non utf-8 values to a not utf-8 page.