### PR TITLE
query string parameters are encoded correctly using the selected encoding instead of default encoding

### DIFF
--- a/RestSharp.Tests/StringExtensionsTests.cs
+++ b/RestSharp.Tests/StringExtensionsTests.cs
@@ -37,8 +37,8 @@ namespace RestSharp.Tests
         public void UrlEncodeTest()
         {
             const string parameter = "ø";
-            Assert.AreEqual("%F8", parameter.UrlEncode(Encoding.GetEncoding("ISO-8859-1")));
-            Assert.AreEqual("%C3%B8", parameter.UrlEncode());
+            Assert.True(string.Compare("%F8", parameter.UrlEncode(Encoding.GetEncoding("ISO-8859-1")), StringComparison.OrdinalIgnoreCase));
+            Assert.True(string.Compare("%C3%B8", parameter.UrlEncode(), StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/RestSharp.Tests/StringExtensionsTests.cs
+++ b/RestSharp.Tests/StringExtensionsTests.cs
@@ -37,8 +37,8 @@ namespace RestSharp.Tests
         public void UrlEncodeTest()
         {
             const string parameter = "ø";
-            Assert.True(string.Compare("%F8", parameter.UrlEncode(Encoding.GetEncoding("ISO-8859-1")), StringComparison.OrdinalIgnoreCase));
-            Assert.True(string.Compare("%C3%B8", parameter.UrlEncode(), StringComparison.OrdinalIgnoreCase));
+            Assert.True(string.Equals("%F8", parameter.UrlEncode(Encoding.GetEncoding("ISO-8859-1")), StringComparison.OrdinalIgnoreCase));
+            Assert.True(string.Equals("%C3%B8", parameter.UrlEncode(), StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/RestSharp.Tests/StringExtensionsTests.cs
+++ b/RestSharp.Tests/StringExtensionsTests.cs
@@ -36,7 +36,7 @@ namespace RestSharp.Tests
         public void UrlEncodeTest()
         {
             const string parameter = "ø";
-            Assert.AreEqual("%F8", parameter.UrlEncode(Encoding.GetEncoding("ISO -8859-1")));
+            Assert.AreEqual("%F8", parameter.UrlEncode(Encoding.GetEncoding("ISO-8859-1")));
             Assert.AreEqual("%C3%B8", parameter.UrlEncode());
         }
     }

--- a/RestSharp.Tests/StringExtensionsTests.cs
+++ b/RestSharp.Tests/StringExtensionsTests.cs
@@ -31,5 +31,13 @@ namespace RestSharp.Tests
             var encodedAndDecoded = stringWithLimitLength.UrlEncode().UrlDecode();
             Assert.AreEqual(numGreaterThanLimit, encodedAndDecoded.Length);
         }
+
+        [Test]
+        public void UrlEncodeTest()
+        {
+            const string parameter = "ø";
+            Assert.AreEqual("%F8", parameter.UrlEncode(Encoding.GetEncoding("ISO -8859-1")));
+            Assert.AreEqual("%C3%B8", parameter.UrlEncode());
+        }
     }
 }

--- a/RestSharp.Tests/StringExtensionsTests.cs
+++ b/RestSharp.Tests/StringExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using NUnit.Framework;
 using RestSharp.Extensions;
 

--- a/RestSharp.Tests/UrlBuilderTests.cs
+++ b/RestSharp.Tests/UrlBuilderTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
+using System.Text;
 
 namespace RestSharp.Tests
 {
@@ -296,6 +297,24 @@ namespace RestSharp.Tests
             Uri output = client.BuildUri(request);
 
             Assert.AreEqual(expected, output);
+        }
+
+        [Test]
+        public void Should_build_uri_using_selected_encoding()
+        {
+            RestRequest request = new RestRequest();
+            // adding parameter with o-slash character which is encoded differently between
+            // utf-8 and iso-8859-1
+            request.AddOrUpdateParameter("town", "Hillerød");
+
+            RestClient client = new RestClient("http://example.com/resource");
+
+            Uri expectedDefaultEncoding = new Uri("http://example.com/resource?town=Hiller%C3%B8d");
+            Uri expectedIso89591Encoding = new Uri("http://example.com/resource?town=Hiller%F8d");
+            Assert.AreEqual(expectedDefaultEncoding, client.BuildUri(request));
+            // now changing encoding
+            client.Encoding = Encoding.GetEncoding("ISO-8859-1");
+            Assert.AreEqual(expectedIso89591Encoding, client.BuildUri(request));
         }
 
     }

--- a/RestSharp/Extensions/StringExtensions.cs
+++ b/RestSharp/Extensions/StringExtensions.cs
@@ -71,6 +71,11 @@ namespace RestSharp.Extensions
             return HttpUtility.HtmlEncode(input);
         }
 
+        public static string UrlEncode(this string input, Encoding encoding)
+        {
+            return HttpUtility.UrlEncode(input, encoding);
+        }
+
         public static string HtmlAttributeEncode(this string input)
         {
             return HttpUtility.HtmlAttributeEncode(input);

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -290,7 +290,7 @@ namespace RestSharp
                 return new Uri(assembled);
 
             // build and attach querystring
-            var data = EncodeParameters(parameters);
+            var data = EncodeParameters(parameters, Encoding);
             var separator = assembled != null && assembled.Contains("?")
                 ? "&"
                 : "?";
@@ -343,13 +343,13 @@ namespace RestSharp
         private void AuthenticateIfNeeded(RestClient client, IRestRequest request) =>
             Authenticator?.Authenticate(client, request);
 
-        private static string EncodeParameters(IEnumerable<Parameter> parameters) =>
-            string.Join("&", parameters.Select(EncodeParameter).ToArray());
+        private static string EncodeParameters(IEnumerable<Parameter> parameters, Encoding encoding) =>
+            string.Join("&", parameters.Select(parameter => EncodeParameter(parameter, encoding)).ToArray());
 
-        private static string EncodeParameter(Parameter parameter) =>
+        private static string EncodeParameter(Parameter parameter, Encoding encoding) =>
             parameter.Value == null
-                ? string.Concat(parameter.Name.UrlEncode(), "=")
-                : string.Concat(parameter.Name.UrlEncode(), "=", parameter.Value.ToString().UrlEncode());
+                ? string.Concat(parameter.Name.UrlEncode(encoding), "=")
+                : string.Concat(parameter.Name.UrlEncode(encoding), "=", parameter.Value.ToString().UrlEncode(encoding));
 
         private void ConfigureHttp(IRestRequest request, IHttp http)
         {


### PR DESCRIPTION
No matter what encoding I selected, the Url query string parameters were
always encoded using the default UTFencoding.
Reason: i needed to call a GET method that required me to send my query
string encoded in ISO-8859-1 encoding. I tried many options but 'ø'
would always become '%C3%B8' even though I had set the encoding property
to ISO-8859-1 which should get me '%F8'
This change uses the currently selected encoding in the RestClient.cs
and uses it to encode parameters and names instead of using UrlEncode
which (although works for most cases) might not work for everybody.