### PR TITLE
Fixed Uri builder when the Resource is an absolute Uri (with protocol, etc...).

### DIFF
--- a/RestSharp.Tests/UrlBuilderTests.cs
+++ b/RestSharp.Tests/UrlBuilderTests.cs
@@ -298,5 +298,17 @@ namespace RestSharp.Tests
             Assert.AreEqual(expected, output);
         }
 
+        [Test]
+        public void GET_with_resource_full_uri()
+        {
+            RestRequest request = new RestRequest("https://www.example1.com/connect/authorize");
+            
+            RestClient client = new RestClient("https://www.example1.com/");
+            Uri expected = new Uri("https://www.example1.com/connect/authorize");
+            Uri output = client.BuildUri(request);
+
+            Assert.AreEqual(expected, output);
+        }
+
     }
 }

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -266,12 +266,11 @@ namespace RestSharp
 
             if (BaseUrl != null && !string.IsNullOrEmpty(BaseUrl.AbsoluteUri))
             {
+                var usingBaseUri = BaseUrl;
                 if (!BaseUrl.AbsoluteUri.EndsWith("/") && !string.IsNullOrEmpty(assembled))
-                    assembled = string.Concat("/", assembled);
-
-                assembled = string.IsNullOrEmpty(assembled)
-                    ? BaseUrl.AbsoluteUri
-                    : string.Format("{0}{1}", BaseUrl, assembled);
+                    usingBaseUri = new Uri(BaseUrl.AbsoluteUri + "/");
+                
+                assembled = new Uri(usingBaseUri, assembled).AbsoluteUri;
             }
 
             IEnumerable<Parameter> parameters;

--- a/RestSharp/RestSharp.csproj
+++ b/RestSharp/RestSharp.csproj
@@ -8,7 +8,7 @@
     <Description>Simple REST and HTTP API Client</Description>
     <Authors>John Sheehan, RestSharp Community</Authors>
     <Version>106.0.0</Version>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <AssemblyOriginatorKeyFile>..\RestSharp.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>


### PR DESCRIPTION
Details in the test case and this issue: https://github.com/restsharp/RestSharp/issues/1035

```
            RestRequest request = new RestRequest("https://www.example1.com/connect/authorize");
            
            RestClient client = new RestClient("https://www.example1.com/");
            Uri expected = new Uri("https://www.example1.com/connect/authorize");
```