### PR TITLE
JsonSerializer to use Newtonsoft.Json instead of SimpleJson

### DIFF
--- a/RestSharp/RestSharp.csproj
+++ b/RestSharp/RestSharp.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>

--- a/RestSharp/Serializers/JsonSerializer.cs
+++ b/RestSharp/Serializers/JsonSerializer.cs
@@ -1,9 +1,12 @@
-﻿
+﻿using Newtonsoft.Json;
+
 namespace RestSharp.Serializers
 {
     /// <summary>
     /// Default JSON serializer for request bodies
     /// Doesn't currently use the SerializeAs attribute, defers to Newtonsoft's attributes
+    /// To Use Newtonsoft's attributes in place of the SerializeAs attribute use
+    /// [JsonProperty(PropertyName = "<name>")]
     /// </summary>
     public class JsonSerializer : ISerializer
     {
@@ -22,7 +25,7 @@ namespace RestSharp.Serializers
         /// <returns>JSON as String</returns>
         public string Serialize(object obj)
         {
-            return SimpleJson.SimpleJson.SerializeObject(obj);
+            return JsonConvert.SerializeObject(obj);
         }
 
         /// <summary>


### PR DESCRIPTION
Since the documentation at the top of the JsonSerializer class defers to Newtonsoft.Json's attributes and most of the class is not actually implemented, simply use the Newtonsoft serializer directly.

## Description

An issue I and my team had been running into was with the JsonSerializer not recognizing the SerializeAs attribute (as is noted in the summary documentation above the JsonSerializer class) but also not recognizing the JsonProperty attribute from Newtonsoft and I could not find any references to Newtonsoft in the project dependencies. Adding a reference to Newtonsoft locally then testing our own project proved successful when we used the JsonConvert class to serialize our objects instead of SimpleJson. 

I had also noted that in issue #1033 the suggestion was posited to use Json.NET to serialize instead the JsonSerializer provided at the moment.

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)
