### PR TITLE
Using the exact name provided in DeserializeAs attribute, if any, on …

### DIFF
--- a/RestSharp.Tests/NamespacedXmlTests.cs
+++ b/RestSharp.Tests/NamespacedXmlTests.cs
@@ -22,6 +22,7 @@ using System.Xml.Linq;
 using NUnit.Framework;
 using RestSharp.Deserializers;
 using RestSharp.Tests.SampleClasses;
+using RestSharp.Tests.SampleClasses.DeserializeAsTest;
 using RestSharp.Tests.SampleClasses.Lastfm;
 
 namespace RestSharp.Tests
@@ -161,6 +162,49 @@ namespace RestSharp.Tests
             Assert.AreEqual(2, a.Count);
             Assert.AreEqual("first", a[0].Value);
             Assert.AreEqual("second", a[1].Value);
+        }
+
+        [Test]
+        public void Can_Deserialize_Attribute_Using_Exact_Name_Defined_In_DeserializeAs_Attribute()
+        {
+            const string @namespace = "http://restsharp.org";
+            XNamespace ns = XNamespace.Get(@namespace);
+            XDocument doc = new XDocument(
+                new XElement(ns + "response",
+                    new XAttribute(ns + "attribute-value", "711"),
+                        "random value"));
+
+            var expected = new NodeWithAttributeAndValue
+            {
+                AttributeValue = "711"
+            };
+
+            XmlDeserializer xml = new XmlDeserializer() { Namespace = @namespace };
+            NodeWithAttributeAndValue output = xml.Deserialize<NodeWithAttributeAndValue>(new RestResponse { Content = doc.ToString() });
+
+            Assert.AreEqual(expected.AttributeValue, output.AttributeValue);
+        }
+
+        [Test]
+        public void Can_Deserialize_Node_Using_Exact_Name_Defined_In_DeserializeAs_Attribute()
+        {
+            const string @namespace = "http://restsharp.org";
+            XNamespace ns = XNamespace.Get(@namespace);
+            XDocument doc = new XDocument(
+                new XElement(ns + "response",
+                    new XElement(ns + "node-value", "711")));
+            
+            var expected = new SingleNode
+            {
+                Node = "711"
+            };
+
+            XmlDeserializer xml = new XmlDeserializer();
+            SingleNode output = xml.Deserialize<SingleNode>(new RestResponse { Content = doc.ToString() });
+
+            Assert.IsNotNull(output);
+
+            Assert.AreEqual(expected.Node, output.Node);
         }
 
         private static string CreateListOfPrimitivesXml()

--- a/RestSharp.Tests/SampleClasses/DeserializeAsTest/misc.cs
+++ b/RestSharp.Tests/SampleClasses/DeserializeAsTest/misc.cs
@@ -1,0 +1,21 @@
+﻿using RestSharp.Deserializers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RestSharp.Tests.SampleClasses.DeserializeAsTest
+{
+    public class NodeWithAttributeAndValue
+    {
+        [DeserializeAs(Name = "attribute-value", Attribute = true)]
+        public string AttributeValue { get; set; }
+    }
+
+    public class SingleNode
+    {
+        [DeserializeAs(Name = "node-value")]
+        public string Node { get; set; }
+    }
+}

--- a/RestSharp.Tests/XmlDeserializerTests.cs
+++ b/RestSharp.Tests/XmlDeserializerTests.cs
@@ -25,6 +25,7 @@ using System.Xml.Linq;
 using NUnit.Framework;
 using RestSharp.Deserializers;
 using RestSharp.Tests.SampleClasses;
+using RestSharp.Tests.SampleClasses.DeserializeAsTest;
 using Event = RestSharp.Tests.SampleClasses.Lastfm.Event;
 
 namespace RestSharp.Tests
@@ -54,7 +55,7 @@ namespace RestSharp.Tests
             Assert.AreEqual("Jackson", output.FriendlyName);
             Assert.AreEqual("oddball", output.GoodPropertyName);
         }
-
+        
         [Test]
         public void Can_Use_DeserializeAs_Attribute_for_List()
         {
@@ -785,6 +786,40 @@ namespace RestSharp.Tests
             Assert.AreEqual(output.Value, 255);
         }
 
+        [Test]
+        public void Can_Deserialize_Attribute_Using_Exact_Name_Defined_In_DeserializeAs_Attribute()
+        {
+            var content = @"<response attribute-value=""711""></response>";
+
+            var expected = new NodeWithAttributeAndValue
+            {
+                AttributeValue = "711"
+            };
+
+            XmlDeserializer xml = new XmlDeserializer();
+            NodeWithAttributeAndValue output = xml.Deserialize<NodeWithAttributeAndValue>(new RestResponse { Content = content });
+
+            Assert.AreEqual(expected.AttributeValue, output.AttributeValue);
+        }
+
+        [Test]
+        public void Can_Deserialize_Node_Using_Exact_Name_Defined_In_DeserializeAs_Attribute()
+        {
+            var content = @"<response><node-value>711</node-value></response>";
+
+            var expected = new SingleNode
+            {
+                Node = "711"
+            };
+
+            XmlDeserializer xml = new XmlDeserializer();
+            SingleNode output = xml.Deserialize<SingleNode>(new RestResponse { Content = content });
+
+            Assert.IsNotNull(output);
+
+            Assert.AreEqual(expected.Node, output.Node);
+        }
+        
         [Test]
         public void Able_to_use_alternative_name_for_arrays()
         {

--- a/RestSharp/Deserializers/XmlAttributeDeserializer.cs
+++ b/RestSharp/Deserializers/XmlAttributeDeserializer.cs
@@ -24,10 +24,10 @@ namespace RestSharp.Deserializers
 {
     public class XmlAttributeDeserializer : XmlDeserializer
     {
-        protected override object GetValueFromXml(XElement root, XName name, PropertyInfo prop)
+        protected override object GetValueFromXml(XElement root, XName name, PropertyInfo prop, bool useExactName)
         {
             bool isAttribute = false;
-
+            
             //Check for the DeserializeAs attribute on the property
             DeserializeAsAttribute options = prop.GetAttribute<DeserializeAsAttribute>();
 
@@ -37,11 +37,11 @@ namespace RestSharp.Deserializers
                 isAttribute = options.Attribute;
             }
 
-            if (!isAttribute) return base.GetValueFromXml(root, name, prop);
+            if (!isAttribute) return base.GetValueFromXml(root, name, prop, useExactName);
             
-            XAttribute attributeVal = GetAttributeByName(root, name);
+            XAttribute attributeVal = GetAttributeByName(root, name, useExactName);
 
-            return attributeVal != null ? attributeVal.Value : base.GetValueFromXml(root, name, prop);
+            return attributeVal != null ? attributeVal.Value : base.GetValueFromXml(root, name, prop, useExactName);
         }
     }
 }


### PR DESCRIPTION
## Description

…Deserialization

When using DeserializeAs attribute on a class property, I specified a name that the attribute/node is supposed to have (which included a dash between words). Deserialization didn't work. I removed a DeserializeAs attribute altogether, and deserialization worked. This means that there was a bug in the use of the DeserializeAs.Name property. The way I see it, if the name is explicitly specified in DeserializeAs attribute, the deserializer should use that value.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
Seems to be non-breaking change as none of the pre-existing tests failed after the modification.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
