### PR TITLE
Handle RsaSha1 properly in .NET Core 2.0

### DIFF
--- a/RestSharp.Tests/Extensions/RSACryptoServiceProviderExtensionsTests.cs
+++ b/RestSharp.Tests/Extensions/RSACryptoServiceProviderExtensionsTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Security.Cryptography;
+using NUnit.Framework;
+using RestSharp.Extensions;
+
+namespace RestSharp.Tests.Extensions
+{
+    [TestFixture]
+    public class RSACryptoServiceProviderExtensionsTests
+    {
+        [Test]
+        public void FromXmlStringImpl_GivenPrivateKeyXml_GivesSameResultAsDotNetImplementation()
+        {
+            const string samplePrivateKeyXml =
+                "<RSAKeyValue><Modulus>twJgSXtGu3QQKComA/6wgcTPFS6cky+EHA+fCAZm+Suz0KpiYqvk4LHV+MQQvVy1TpWjpC1iXtEa5BfMS8zDLfrXaXA6RSZ3QEw8YfmmMrKDwUULIORgqcW8Uybalp5fMdbOieAQNXpOLNjnjPZVmFrQvB+CzfltYo82aEiOTjk=</Modulus><Exponent>AQAB</Exponent><P>8x4Omo3kOOExZP/XbtWLHlW7WfEtJNXIATzYlpOQAM1+mwJ7qBAP2umzudUdfXJECMKyv1e+eVeb0WatIsj+vw==</P><Q>wLTwSuM+KG57O4VTddyBSXRHLJvahfWlB1VettJvcqgQk2zK4XwoZU7POjq5fx6kfAUyAYaaxHfwKhKBIy1pBw==</Q><DP>F3LRs8R1u6q0qeonLDB6f42DSXSChyf7Z2sn9LX80KcBTBAcPyR1cwbRZ94PPxczSqkEtoHPBEMX60V883rxXw==</DP><DQ>UQ/LxLSygO94hyEeaoXHHM784Zbt5Uvfj6YpoV4D44cu8dThwtgnZfYw1Z2+Serp5gGJd3rXv610KT5/c/y2IQ==</DQ><InverseQ>jV3wG0+jRpbnkpYLBMVFmLlhJ68oZnpI+fbVnm5mBMr3Rzytz2HfgaGpmI6MY+ni9JV0pfntKNT6uo/Jji34gQ==</InverseQ><D>D4MZDEFxvmPZFr5z2HTXGzjGYMJBrUwiw4ojbbe1NLuakz5N9pUhYlZQj7R2wsY/6/hNFZZvNyA8SkcmHuqtRGyEmE9JOzRA5YhxkC6rfy9oTR2ybIrv9mUGU7P76PBPO2VQJdIIgAdTXMIz8o3IOStINpEkGWzptQ1yxZ8Apx0=</D></RSAKeyValue>";
+
+            using (var customBasedProvider = new RSACryptoServiceProvider())
+            using (var dotnetBasedProvider = new RSACryptoServiceProvider())
+            {
+                RSACryptoServiceProviderExtensions.FromXmlStringImpl(customBasedProvider, samplePrivateKeyXml);
+                dotnetBasedProvider.FromXmlString(samplePrivateKeyXml);
+
+                var dotnetBasedParameters = customBasedProvider.ExportParameters(true);
+                var customBasedParameters = customBasedProvider.ExportParameters(true);
+
+                Assert.AreEqual(dotnetBasedParameters.D, customBasedParameters.D);
+                Assert.AreEqual(dotnetBasedParameters.DP, customBasedParameters.DP);
+                Assert.AreEqual(dotnetBasedParameters.DQ, customBasedParameters.DQ);
+                Assert.AreEqual(dotnetBasedParameters.Exponent, customBasedParameters.Exponent);
+                Assert.AreEqual(dotnetBasedParameters.InverseQ, customBasedParameters.InverseQ);
+                Assert.AreEqual(dotnetBasedParameters.Modulus, customBasedParameters.Modulus);
+                Assert.AreEqual(dotnetBasedParameters.P, customBasedParameters.P);
+                Assert.AreEqual(dotnetBasedParameters.Q, customBasedParameters.Q);
+            }
+        }
+    }
+}

--- a/RestSharp.Tests/Extensions/RSACryptoServiceProviderExtensionsTests.cs
+++ b/RestSharp.Tests/Extensions/RSACryptoServiceProviderExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Cryptography;
+﻿using System;
+using System.Security.Cryptography;
 using NUnit.Framework;
 using RestSharp.Extensions;
 
@@ -30,6 +31,34 @@ namespace RestSharp.Tests.Extensions
                 Assert.AreEqual(dotnetBasedParameters.Modulus, customBasedParameters.Modulus);
                 Assert.AreEqual(dotnetBasedParameters.P, customBasedParameters.P);
                 Assert.AreEqual(dotnetBasedParameters.Q, customBasedParameters.Q);
+            }
+        }
+
+        [Test]
+        public void FromXmlStringImpl_GivenInvalidPrivateKeyXml_ThrowsInvalidOperationException()
+        {
+            const string samplePrivateKeyXml =
+                "<something></something>";
+
+            using (var provider = new RSACryptoServiceProvider())
+            {
+                var exception = Assert.Throws<InvalidOperationException>(() =>
+                    RSACryptoServiceProviderExtensions.FromXmlStringImpl(provider, samplePrivateKeyXml));
+                Assert.AreEqual("Invalid XML RSA key.", exception.Message);
+            }
+        }
+
+        [Test]
+        public void FromXmlStringImpl_GivenPrivateKeyXmlWithUnknownNode_ThrowsInvalidOperationException()
+        {
+            const string samplePrivateKeyXml =
+                "<RSAKeyValue><pi>unexpected</pi></RSAKeyValue>";
+
+            using (var provider = new RSACryptoServiceProvider())
+            {
+                var exception = Assert.Throws<InvalidOperationException>(() =>
+                    RSACryptoServiceProviderExtensions.FromXmlStringImpl(provider, samplePrivateKeyXml));
+                Assert.AreEqual("Unknown node name: pi", exception.Message);
             }
         }
     }

--- a/RestSharp/Authenticators/OAuth/OAuthTools.cs
+++ b/RestSharp/Authenticators/OAuth/OAuthTools.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Xml;
 using RestSharp.Authenticators.OAuth.Extensions;
+using RestSharp.Extensions;
 
 namespace RestSharp.Authenticators.OAuth
 {
@@ -346,7 +347,7 @@ namespace RestSharp.Authenticators.OAuth
                     using (var provider = new RSACryptoServiceProvider { PersistKeyInCsp = false })
                     {
 #if NETSTANDARD2_0
-                        FromXmlString(provider, unencodedConsumerSecret);
+                        provider.FromXmlString2(unencodedConsumerSecret);
 #else
                         provider.FromXmlString(unencodedConsumerSecret);
 #endif
@@ -376,43 +377,5 @@ namespace RestSharp.Authenticators.OAuth
 
             return result;
         }
-
-#if NETSTANDARD2_0
-        /// <summary>
-        ///  .NET Core 2.0 doesn't provide an implementation of RSACryptoServiceProvider.FromXmlString/ToXmlString, so we have to do it ourselves.
-        /// Source: https://gist.github.com/Jargon64/5b172c452827e15b21882f1d76a94be4/
-        /// </summary>
-        private static void FromXmlString(RSACryptoServiceProvider rsa, string xmlString)
-        {
-            var parameters = new RSAParameters();
-
-            var xmlDoc = new XmlDocument();
-            xmlDoc.LoadXml(xmlString);
-
-            if (xmlDoc.DocumentElement.Name.Equals("RSAKeyValue"))
-            {
-                foreach (XmlNode node in xmlDoc.DocumentElement.ChildNodes)
-                {
-                    switch (node.Name)
-                    {
-                        case "Modulus": parameters.Modulus = Convert.FromBase64String(node.InnerText); break;
-                        case "Exponent": parameters.Exponent = Convert.FromBase64String(node.InnerText); break;
-                        case "P": parameters.P = Convert.FromBase64String(node.InnerText); break;
-                        case "Q": parameters.Q = Convert.FromBase64String(node.InnerText); break;
-                        case "DP": parameters.DP = Convert.FromBase64String(node.InnerText); break;
-                        case "DQ": parameters.DQ = Convert.FromBase64String(node.InnerText); break;
-                        case "InverseQ": parameters.InverseQ = Convert.FromBase64String(node.InnerText); break;
-                        case "D": parameters.D = Convert.FromBase64String(node.InnerText); break;
-                    }
-                }
-            }
-            else
-            {
-                throw new InvalidOperationException("Invalid XML RSA key.");
-            }
-
-            rsa.ImportParameters(parameters);
-        }
-#endif
     }
 }

--- a/RestSharp/Authenticators/OAuth/OAuthTools.cs
+++ b/RestSharp/Authenticators/OAuth/OAuthTools.cs
@@ -346,11 +346,7 @@ namespace RestSharp.Authenticators.OAuth
                 {
                     using (var provider = new RSACryptoServiceProvider { PersistKeyInCsp = false })
                     {
-#if NETSTANDARD2_0
                         provider.FromXmlString2(unencodedConsumerSecret);
-#else
-                        provider.FromXmlString(unencodedConsumerSecret);
-#endif
 
                         SHA1Managed hasher = new SHA1Managed();
                         byte[] hash = hasher.ComputeHash(encoding.GetBytes(signatureBase));

--- a/RestSharp/Extensions/RSACryptoServiceProviderExtensions.cs
+++ b/RestSharp/Extensions/RSACryptoServiceProviderExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Xml;
+
+namespace RestSharp.Extensions
+{
+    public static class RSACryptoServiceProviderExtensions
+    {
+        /// <summary>
+        /// Imports the specified XML String into the crypto service provider
+        /// </summary>
+        /// <remarks>
+        ///  .NET Core 2.0 doesn't provide an implementation of RSACryptoServiceProvider.FromXmlString/ToXmlString, so we have to do it ourselves.
+        /// Source: https://gist.github.com/Jargon64/5b172c452827e15b21882f1d76a94be4/
+        /// </remarks>
+        public static void FromXmlString2(this RSACryptoServiceProvider rsa, string xmlString)
+        {
+            var parameters = new RSAParameters();
+
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(xmlString);
+
+            if (xmlDoc.DocumentElement.Name.Equals("RSAKeyValue"))
+            {
+                foreach (XmlNode node in xmlDoc.DocumentElement.ChildNodes)
+                {
+                    switch (node.Name)
+                    {
+                        case "Modulus": parameters.Modulus = Convert.FromBase64String(node.InnerText); break;
+                        case "Exponent": parameters.Exponent = Convert.FromBase64String(node.InnerText); break;
+                        case "P": parameters.P = Convert.FromBase64String(node.InnerText); break;
+                        case "Q": parameters.Q = Convert.FromBase64String(node.InnerText); break;
+                        case "DP": parameters.DP = Convert.FromBase64String(node.InnerText); break;
+                        case "DQ": parameters.DQ = Convert.FromBase64String(node.InnerText); break;
+                        case "InverseQ": parameters.InverseQ = Convert.FromBase64String(node.InnerText); break;
+                        case "D": parameters.D = Convert.FromBase64String(node.InnerText); break;
+                    }
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("Invalid XML RSA key.");
+            }
+
+            rsa.ImportParameters(parameters);
+        }
+    }
+}

--- a/RestSharp/Extensions/RSACryptoServiceProviderExtensions.cs
+++ b/RestSharp/Extensions/RSACryptoServiceProviderExtensions.cs
@@ -15,6 +15,9 @@ namespace RestSharp.Extensions
         /// </remarks>
         public static void FromXmlString2(this RSACryptoServiceProvider rsa, string xmlString)
         {
+#if !NETSTANDARD2_0
+            rsa.FromXmlString(xmlString);
+#else
             var parameters = new RSAParameters();
 
             var xmlDoc = new XmlDocument();
@@ -43,6 +46,7 @@ namespace RestSharp.Extensions
             }
 
             rsa.ImportParameters(parameters);
+#endif
         }
     }
 }

--- a/RestSharp/Extensions/RSACryptoServiceProviderExtensions.cs
+++ b/RestSharp/Extensions/RSACryptoServiceProviderExtensions.cs
@@ -29,26 +29,43 @@ namespace RestSharp.Extensions
             var xmlDoc = new XmlDocument();
             xmlDoc.LoadXml(xmlString);
 
-            if (xmlDoc.DocumentElement.Name.Equals("RSAKeyValue"))
-            {
-                foreach (XmlNode node in xmlDoc.DocumentElement.ChildNodes)
-                {
-                    switch (node.Name)
-                    {
-                        case "Modulus": parameters.Modulus = Convert.FromBase64String(node.InnerText); break;
-                        case "Exponent": parameters.Exponent = Convert.FromBase64String(node.InnerText); break;
-                        case "P": parameters.P = Convert.FromBase64String(node.InnerText); break;
-                        case "Q": parameters.Q = Convert.FromBase64String(node.InnerText); break;
-                        case "DP": parameters.DP = Convert.FromBase64String(node.InnerText); break;
-                        case "DQ": parameters.DQ = Convert.FromBase64String(node.InnerText); break;
-                        case "InverseQ": parameters.InverseQ = Convert.FromBase64String(node.InnerText); break;
-                        case "D": parameters.D = Convert.FromBase64String(node.InnerText); break;
-                    }
-                }
-            }
-            else
+            if (!xmlDoc.DocumentElement.Name.Equals("RSAKeyValue"))
             {
                 throw new InvalidOperationException("Invalid XML RSA key.");
+            }
+
+
+            foreach (XmlNode node in xmlDoc.DocumentElement.ChildNodes)
+            {
+                switch (node.Name)
+                {
+                    case "Modulus":
+                        parameters.Modulus = Convert.FromBase64String(node.InnerText);
+                        break;
+                    case "Exponent":
+                        parameters.Exponent = Convert.FromBase64String(node.InnerText);
+                        break;
+                    case "P":
+                        parameters.P = Convert.FromBase64String(node.InnerText);
+                        break;
+                    case "Q":
+                        parameters.Q = Convert.FromBase64String(node.InnerText);
+                        break;
+                    case "DP":
+                        parameters.DP = Convert.FromBase64String(node.InnerText);
+                        break;
+                    case "DQ":
+                        parameters.DQ = Convert.FromBase64String(node.InnerText);
+                        break;
+                    case "InverseQ":
+                        parameters.InverseQ = Convert.FromBase64String(node.InnerText);
+                        break;
+                    case "D":
+                        parameters.D = Convert.FromBase64String(node.InnerText);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unknown node name: " + node.Name);
+                }
             }
 
             rsa.ImportParameters(parameters);

--- a/RestSharp/Extensions/RSACryptoServiceProviderExtensions.cs
+++ b/RestSharp/Extensions/RSACryptoServiceProviderExtensions.cs
@@ -18,6 +18,12 @@ namespace RestSharp.Extensions
 #if !NETSTANDARD2_0
             rsa.FromXmlString(xmlString);
 #else
+            FromXmlStringImpl(rsa, xmlString);
+#endif
+        }
+
+        internal static void FromXmlStringImpl(RSACryptoServiceProvider rsa, string xmlString)
+        {
             var parameters = new RSAParameters();
 
             var xmlDoc = new XmlDocument();
@@ -46,7 +52,6 @@ namespace RestSharp.Extensions
             }
 
             rsa.ImportParameters(parameters);
-#endif
         }
     }
 }


### PR DESCRIPTION
## Description
There are some issues on .NET's side about the
missing functionality of RSACryptoServiceProvider
ToXmlString/FromXmlString:

* https://github.com/dotnet/corefx/issues/23686
* https://github.com/dotnet/core/issues/874

So, let's do it ourselves, and if in the future we'll
get it in the .NET itself, we can remove this code

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

@alexeyzimarev Would be awesome if we could get a release with this fix, right now we can't use the library in a .NET Core 2.0 & OAuth 1 app .