### PR TITLE
Fix Proxy in .NET Core 2.0, Add Proxy Test

### DIFF
--- a/RestSharp.IntegrationTests/ProxyTests.cs
+++ b/RestSharp.IntegrationTests/ProxyTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using NUnit.Framework;
+using RestSharp.IntegrationTests.Helpers;
+
+namespace RestSharp.IntegrationTests
+{
+    [TestFixture]
+    public class ProxyTests
+    {
+        private const string BASE_URL_SERVER = "http://localhost:8888/";
+        private string BASE_URL_CLIENT;
+
+        public ProxyTests()
+        {
+            BASE_URL_CLIENT = $"http://{Environment.MachineName}:8888/";
+        }
+
+        [Test]
+        public void Set_Invalid_Proxy_Fails()
+        {
+            const Method httpMethod = Method.GET;
+
+            using (SimpleServer.Create(BASE_URL_SERVER, Handlers.Generic<RequestBodyCapturer>()))
+            {
+                RestClient client = new RestClient(BASE_URL_CLIENT);
+                client.Proxy = new WebProxy("non_existent_proxy", false);
+                RestRequest request = new RestRequest(RequestBodyCapturer.RESOURCE, httpMethod);
+
+                const string contentType = "text/plain";
+                const string bodyData = "abc123 foo bar baz BING!";
+
+                request.AddParameter(contentType, bodyData, ParameterType.RequestBody);
+                var response = client.Execute(request);
+                Assert.False(response.IsSuccessful);
+                Assert.IsInstanceOf<WebException>(response.ErrorException);
+
+#if NETCORE
+                Assert.AreEqual("An error occurred while sending the request. The server name or address could not be resolved", response.ErrorMessage);
+#endif
+
+#if !NETCORE
+                Assert.AreEqual("The proxy name could not be resolved: 'non_existent_proxy'", response.ErrorMessage);
+#endif
+            }
+        }
+
+        [Test]
+        public void Set_Invalid_Proxy_Fails_RAW()
+        {
+            const Method httpMethod = Method.GET;
+
+            using (SimpleServer.Create(BASE_URL_SERVER, Handlers.Generic<RequestBodyCapturer>()))
+            {
+                const string contentType = "text/plain";
+                const string bodyData = "abc123 foo bar baz BING!";
+                var requestUri = new Uri(new Uri(BASE_URL_CLIENT), RequestBodyCapturer.RESOURCE);
+                var webRequest = (HttpWebRequest) WebRequest.Create(requestUri);
+                webRequest.Proxy = new WebProxy("non_existent_proxy", false);
+                //webRequest.Proxy = new WebProxy("non_existing", false);
+                // webRequest.Proxy = HttpWebRequest.DefaultWebProxy;
+               
+                Assert.Throws<WebException>(() => webRequest.GetResponse());
+
+                // Assert.False(response.IsSuccessful);
+                // Assert.IsInstanceOf<WebException>(response.ErrorException);
+                // Assert.AreEqual("The proxy name could not be resolved: 'non_existent_proxy'", response.ErrorMessage);
+            }
+        }
+
+        private class RequestBodyCapturer
+        {
+            public const string RESOURCE = "Capture";
+
+            public static string CapturedContentType { get; set; }
+
+            public static bool CapturedHasEntityBody { get; set; }
+
+            public static string CapturedEntityBody { get; set; }
+
+            public static void Capture(HttpListenerContext context)
+            {
+                HttpListenerRequest request = context.Request;
+
+                CapturedContentType = request.ContentType;
+                CapturedHasEntityBody = request.HasEntityBody;
+                CapturedEntityBody = StreamToString(request.InputStream);
+            }
+
+            private static string StreamToString(Stream stream)
+            {
+                StreamReader streamReader = new StreamReader(stream);
+                return streamReader.ReadToEnd();
+            }
+        }
+    }
+}

--- a/RestSharp/Http.Sync.cs
+++ b/RestSharp/Http.Sync.cs
@@ -201,6 +201,9 @@ namespace RestSharp
             webRequest.PreAuthenticate = PreAuthenticate;
             webRequest.Pipelined = Pipelined;
             webRequest.UnsafeAuthenticatedConnectionSharing = UnsafeAuthenticatedConnectionSharing;
+#if NETSTANDARD2_0
+            webRequest.Proxy = null;
+#endif
             webRequest.ServicePoint.Expect100Continue = false;
             
             AppendHeaders(webRequest);

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -577,17 +577,7 @@ namespace RestSharp
             }
 
             http.AllowedDecompressionMethods = request.AllowedDecompressionMethods;
-
-
-#if !NETSTANDARD2_0
             http.Proxy = Proxy ?? (WebRequest.DefaultWebProxy ?? HttpWebRequest.GetSystemWebProxy());
-#endif
-
-#if NETSTANDARD2_0
-            var _ = WebRequest.DefaultWebProxy;
-            WebRequest.DefaultWebProxy = http.Proxy;
-#endif
-
             http.RemoteCertificateValidationCallback = RemoteCertificateValidationCallback;
 
             return http;


### PR DESCRIPTION
## Description
https://stackoverflow.com/questions/50210080/restsharp-not-using-proxy-fiddler-in-net-core-2-0

Proxy functionality appears to be broken for .NET Core 2.0.
Using the Tests in the PR, the Set_Invalid_Proxy_Fails() Test fails when executing for .NET Core 2.0
```

C:\RestSharp (develop -> origin)
λ dotnet test --filter "Set_Invalid_Proxy_Fails" --no-build .\RestSharp.IntegrationTests\RestSharp.IntegrationTests.csproj  --framework netcoreapp2.0
Microsoft (R) Build Engine version 15.6.84.34536 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 39,37 ms for C:\RestSharp\RestSharp.IntegrationTests\RestSharp.IntegrationTests.csproj.
  Restore completed in 33,26 ms for C:\RestSharp\RestSharp\RestSharp.csproj.
Test run for C:\RestSharp\RestSharp.IntegrationTests\bin\Debug\netcoreapp2.0\RestSharp.IntegrationTests.dll(.NETCoreApp,Version=v2.0)
Microsoft (R) Test Execution Command Line Tool Version 15.6.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
NUnit Adapter 3.10.0.21: Test execution started
Running all tests in C:\RestSharp\RestSharp.IntegrationTests\bin\Debug\netcoreapp2.0\RestSharp.IntegrationTests.dll
NUnit3TestExecutor converted 78 of 78 NUnit test cases
NUnit Adapter 3.10.0.21: Test execution complete
Failed   Set_Invalid_Proxy_Fails
Error Message:
   Expected: instance of <System.Net.WebException>
  But was:  null

Stack Trace:
   at RestSharp.IntegrationTests.ProxyTests.Set_Invalid_Proxy_Fails() in C:\RestSharp\RestSharp.IntegrationTests\ProxyTests.cs:line 37


Total tests: 2. Passed: 1. Failed: 1. Skipped: 0.
Test Run Failed.
Test execution time: 2,1958 Seconds
```
but passes for .NET 4.5.2:
```

C:\RestSharp (develop -> origin)
λ dotnet test --filter "Set_Invalid_Proxy_Fails" --no-build .\RestSharp.IntegrationTests\RestSharp.IntegrationTests.csproj  --framework net452
Microsoft (R) Build Engine version 15.6.84.34536 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Restore completed in 33,51 ms for C:\RestSharp\RestSharp\RestSharp.csproj.
  Restore completed in 39,26 ms for C:\RestSharp\RestSharp.IntegrationTests\RestSharp.IntegrationTests.csproj.
Test run for C:\RestSharp\RestSharp.IntegrationTests\bin\Debug\net452\RestSharp.IntegrationTests.dll(.NETFramework,Version=v4.5.2)
Microsoft (R) Test Execution Command Line Tool Version 15.6.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
NUnit Adapter 3.10.0.21: Test execution started
Running all tests in C:\RestSharp\RestSharp.IntegrationTests\bin\Debug\net452\RestSharp.IntegrationTests.dll
NUnit3TestExecutor converted 78 of 78 NUnit test cases
NUnit Adapter 3.10.0.21: Test execution complete

Total tests: 2. Passed: 2. Failed: 0. Skipped: 0.
Test Run Successful.
Test execution time: 3,1799 Seconds
```
Removing the special handling for NETSTANDARD in RestClient.cs to use the Full Framework version, and by setting the Proxy to null before calling ServicePoint.Expect100Continue worked. Some more explanation here: https://github.com/dotnet/corefx/issues/26922 

Hope this helps

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
