### PR TITLE
Option AlwaysMultipartFormData with AddParamter(name, value contentType, ParameterType.RequestBody) without file breaks the request

### DIFF
--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -550,12 +550,12 @@ namespace RestSharp
             var body = request.Parameters.FirstOrDefault(p => p.Type == ParameterType.RequestBody);
 
             // Only add the body if there aren't any files to make it a multipart form request
-            // If there are files, then add the body to the HTTP Parameters
+            // If there are files or AlwaysMultipartFormData = true, then add the body to the HTTP Parameters
             if (body != null)
             {
                 http.RequestContentType = body.Name;
 
-                if (!http.Files.Any())
+                if (!http.AlwaysMultipartFormData && !http.Files.Any())
                 {
                     var val = body.Value;
 


### PR DESCRIPTION
## Description

Fixes the descripte issue in #1134 

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
