### PR TITLE
Fixes #1172 - Allow custom content types for multipart requests

### DIFF
--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -339,6 +339,8 @@ namespace RestSharp
             {
                 if (needsContentType)
                     webRequest.ContentType = GetMultipartFormContentType();
+                else if (!webRequest.ContentType.Contains("boundary"))
+                    webRequest.ContentType = webRequest.ContentType + "; boundary=" + FORM_BOUNDARY; 
             }
             else if (HasBody)
             {


### PR DESCRIPTION
## Description

This PR fixes #1172 - Allow custom content types for multipart requests

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
