### PR TITLE
Mistake in Post extension method

### DIFF
--- a/RestSharp/RestClientExtensions.cs
+++ b/RestSharp/RestClientExtensions.cs
@@ -246,7 +246,7 @@ namespace RestSharp
             => client.Execute(request, Method.GET);
 
         public static IRestResponse Post(this IRestClient client, IRestRequest request) 
-            => client.Execute(request, Method.PUT);
+            => client.Execute(request, Method.POST);
 
         public static IRestResponse Put(this IRestClient client, IRestRequest request) 
             => client.Execute(request, Method.PUT);


### PR DESCRIPTION
Method parameter to client.Execute should be Method.POST, not Method.PUT.

## Description

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:
- [ X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
