### PR TITLE
Fixed double escape bug in SimpleJson

### DIFF
--- a/RestSharp.Tests/SimpleJson.cs
+++ b/RestSharp.Tests/SimpleJson.cs
@@ -1009,7 +1009,21 @@ namespace RestSharp.Tests
             bool success = true;
             string stringValue = value as string;
             if (stringValue != null)
-                success = SerializeString(stringValue, builder);
+            {
+                // check for json formatting if we're already a string
+                string trimmed = stringValue.Trim();
+                if (trimmed.StartsWith("{") && trimmed.EndsWith("}"))
+                {
+                    object tmp;
+                    success = TryDeserializeObject(trimmed, out tmp);
+                    if (success)
+                        builder.Append(trimmed);
+                }
+                else
+                {
+                    success = SerializeString(stringValue, builder);
+                }
+            }
             else
             {
                 IDictionary<string, object> dict = value as IDictionary<string, object>;

--- a/RestSharp.Tests/SimpleJsonTests.cs
+++ b/RestSharp.Tests/SimpleJsonTests.cs
@@ -1,0 +1,38 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RestSharp.Tests
+{
+    [TestFixture]
+    public class SimpleJsonTests
+    {
+        [Test]
+        public void SerializeObject_should_not_modify_properly_formatted_json_strings()
+        {
+            string preformattedString = "{ \"name\" : \"value\" }";
+            int expectedSlashCount = preformattedString.Count(x => x == '\\');
+
+            string result = SimpleJson.SerializeObject(preformattedString);
+            int actualSlashCount = result.Count(x => x == '\\');
+            
+            Assert.AreEqual(preformattedString, result);
+            Assert.AreEqual(expectedSlashCount, actualSlashCount);
+        }
+
+        [Test]
+        public void EscapeToJavascriptString_should_not_double_escape()
+        {
+            string preformattedString = "{ \"name\" : \"value\" }";
+            int expectedSlashCount = preformattedString.Count(x => x == '\\');
+
+            string result = SimpleJson.EscapeToJavascriptString(preformattedString);
+            int actualSlashCount = result.Count(x => x == '\\');
+
+            Assert.AreEqual(expectedSlashCount, actualSlashCount);
+        }
+    }
+}

--- a/RestSharp/SimpleJson.cs
+++ b/RestSharp/SimpleJson.cs
@@ -606,6 +606,7 @@ namespace SimpleJson
             StringBuilder builder = new StringBuilder(BUILDER_CAPACITY);
             bool success = SerializeValue(jsonSerializerStrategy, json, builder);
             return (success ? builder.ToString() : null);
+            
         }
 
         public static string SerializeObject(object json)
@@ -1009,7 +1010,21 @@ namespace SimpleJson
             bool success = true;
             string stringValue = value as string;
             if (stringValue != null)
-                success = SerializeString(stringValue, builder);
+            {
+                // check for json formatting if we're already a string
+                string trimmed = stringValue.Trim();
+                if (trimmed.StartsWith("{") && trimmed.EndsWith("}"))
+                {
+                    object tmp;
+                    success = TryDeserializeObject(trimmed, out tmp);
+                    if (success)
+                        builder.Append(trimmed);
+                }
+                else
+                {
+                    success = SerializeString(stringValue, builder);
+                }
+            }
             else
             {
                 IDictionary<string, object> dict = value as IDictionary<string, object>;


### PR DESCRIPTION
## Description
If a valid json-formatted string is passed into AddJsonBody or AddBody it will be added with double escape characters for every escape-required character. The issue is in how SimpleJson implements serialization. This fix detects valid json and avoids modifying it.
<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
