### PR TITLE
JsonSerializer to skip serialization of json strings

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -24,6 +24,7 @@ using System.IO;
 using System.Linq;
 using NUnit.Framework;
 using RestSharp.Deserializers;
+using RestSharp.Serializers;
 using RestSharp.Tests.SampleClasses;
 
 namespace RestSharp.Tests
@@ -857,7 +858,32 @@ namespace RestSharp.Tests
             Assert.AreEqual(output.CreatedOn.Kind, DateTimeKind.Utc);
             Assert.AreEqual(expected.ToString(), output.CreatedOn.ToString());
         }
-        
+
+        [Test]
+        public void Serialize_Json_Returns_Same_Json()
+        {
+            string preformattedString = "{ \"name\" : \"value\" } ";
+
+            var json = new JsonSerializer();
+            string result = json.Serialize(preformattedString);
+
+            Assert.AreEqual(preformattedString, result);
+        }
+
+        [Test]
+        public void Serialize_Json_Does_Not_Double_Encode()
+        {
+            string preformattedString = "{ \"name\" : \"value\" }";
+            int expectedSlashCount = preformattedString.Count(x => x == '\\');
+
+            var json = new JsonSerializer();
+            string result = json.Serialize(preformattedString);
+            int actualSlashCount = result.Count(x => x == '\\');
+
+            Assert.AreEqual(preformattedString, result);
+            Assert.AreEqual(expectedSlashCount, actualSlashCount);
+        }
+
         private static string CreateJsonWithUnderscores()
         {
             JsonObject doc = new JsonObject();

--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -871,7 +871,7 @@ namespace RestSharp.Tests
         }
 
         [Test]
-        public void Serialize_Json_Does_Not_Double_Encode()
+        public void Serialize_Json_Does_Not_Double_Escape()
         {
             string preformattedString = "{ \"name\" : \"value\" }";
             int expectedSlashCount = preformattedString.Count(x => x == '\\');

--- a/RestSharp.Tests/SimpleJsonTests.cs
+++ b/RestSharp.Tests/SimpleJsonTests.cs
@@ -1,9 +1,5 @@
 ﻿using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RestSharp.Tests
 {

--- a/RestSharp.Tests/SimpleJsonTests.cs
+++ b/RestSharp.Tests/SimpleJsonTests.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RestSharp.Tests
+{
+    [TestFixture]
+    public class SimpleJsonTests
+    {
+        [Test]
+        public void SerializeObject_should_not_assume_strings_wrapped_in_curly_braces_are_json()
+        {
+            var objectWithCurlyString = new { Name = "{value}" };
+
+            string result = SimpleJson.SerializeObject(objectWithCurlyString);
+
+            Assert.AreEqual("{\"Name\":\"{value}\"}", result);
+        }
+
+        [Test]
+        public void EscapeToJavascriptString_should_not_double_escape()
+        {
+            string preformattedString = "{ \"name\" : \"value\" }";
+            int expectedSlashCount = preformattedString.Count(x => x == '\\');
+
+            string result = SimpleJson.EscapeToJavascriptString(preformattedString);
+            int actualSlashCount = result.Count(x => x == '\\');
+
+            Assert.AreEqual(expectedSlashCount, actualSlashCount);
+        }
+    }
+}

--- a/RestSharp/Serializers/JsonSerializer.cs
+++ b/RestSharp/Serializers/JsonSerializer.cs
@@ -21,7 +21,20 @@ namespace RestSharp.Serializers
         /// </summary>
         /// <param name="obj">Object to serialize</param>
         /// <returns>JSON as String</returns>
-        public string Serialize(object obj) => SimpleJson.SerializeObject(obj);
+        public string Serialize(object obj)
+        {
+            if (obj is string value)
+            {
+                string trimmed = value.Trim();
+                if (trimmed.StartsWith("{") && trimmed.EndsWith("}"))
+                {
+                    return value;
+                }
+
+            }
+
+            return SimpleJson.SerializeObject(obj);
+        }
 
         /// <summary>
         /// Content type for serialized content


### PR DESCRIPTION
## Description

Fixing the double escape issue highlighted here https://github.com/restsharp/RestSharp/issues/1199 and https://github.com/restsharp/RestSharp/pull/1185.

While also still handling the scenario where the object may contain strings that appear to be json https://github.com/restsharp/RestSharp/issues/1189.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works