### PR TITLE
Better use of AdvancedResponseWriter

### DIFF
--- a/RestSharp.IntegrationTests/FileTests.cs
+++ b/RestSharp.IntegrationTests/FileTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Reflection;
+using System.Text;
 using NUnit.Framework;
 using RestSharp.IntegrationTests.Helpers;
 
@@ -61,6 +62,24 @@ namespace RestSharp.IntegrationTests
             byte[] expected = File.ReadAllBytes(_path + "\\Assets\\Koala.jpg");
 
             Assert.AreEqual(expected, fromTemp);
+        }
+
+        [Test]
+        public void AdvancedResponseWriter_without_ResponseWriter_reads_stream()
+        {
+            var rr = new RestRequest("Assets/Koala.jpg")
+            {
+                AdvancedResponseWriter = (stream, context) =>
+                {
+                    var buf = new byte[16];
+                    stream.Read(buf, 0, buf.Length);
+
+                    var str = Encoding.ASCII.GetString(buf, 6, 4);
+                    Assert.AreEqual("JFIF", str);
+                }
+            };
+
+            _client.Execute(rr);
         }
     }
 }

--- a/RestSharp.IntegrationTests/FileTests.cs
+++ b/RestSharp.IntegrationTests/FileTests.cs
@@ -67,19 +67,20 @@ namespace RestSharp.IntegrationTests
         [Test]
         public void AdvancedResponseWriter_without_ResponseWriter_reads_stream()
         {
+            string tag = string.Empty;
+
             var rr = new RestRequest("Assets/Koala.jpg")
             {
                 AdvancedResponseWriter = (stream, context) =>
                 {
                     var buf = new byte[16];
                     stream.Read(buf, 0, buf.Length);
-
-                    var str = Encoding.ASCII.GetString(buf, 6, 4);
-                    Assert.AreEqual("JFIF", str);
+                    tag = Encoding.ASCII.GetString(buf, 6, 4);
                 }
             };
 
             _client.Execute(rr);
+            Assert.IsTrue("JFIF".CompareTo(tag) == 0);
         }
     }
 }

--- a/RestSharp/Http.cs
+++ b/RestSharp/Http.cs
@@ -390,10 +390,6 @@ namespace RestSharp
                 response.ContentType = webResponse.ContentType;
                 response.ContentLength = webResponse.ContentLength;
 
-                var webResponseStream = webResponse.GetResponseStream();
-
-                ProcessResponseStream(webResponseStream, response);
-
                 response.StatusCode = webResponse.StatusCode;
                 response.StatusDescription = webResponse.StatusDescription;
                 response.ResponseUri = webResponse.ResponseUri;
@@ -430,18 +426,24 @@ namespace RestSharp
                     });
                 }
 
+                var webResponseStream = webResponse.GetResponseStream();
+                ProcessResponseStream(webResponseStream, response);
+
                 webResponse.Close();
             }
         }
 
         private void ProcessResponseStream(Stream webResponseStream, HttpResponse response)
         {
-            if (ResponseWriter == null)
-                response.RawBytes = webResponseStream.ReadAsBytes();
+            if (AdvancedResponseWriter != null)
+                AdvancedResponseWriter(webResponseStream, response);
             else
-                ResponseWriter(webResponseStream);
-
-            AdvancedResponseWriter?.Invoke(webResponseStream, response);
+            {
+                if (ResponseWriter == null)
+                    response.RawBytes = webResponseStream.ReadAsBytes();
+                else
+                    ResponseWriter(webResponseStream);
+            }
         }
 
         private static readonly Regex AddRangeRegex = new Regex("(\\w+)=(\\d+)-(\\d+)$");


### PR DESCRIPTION
## Description

1. Moved ProcessResponseStream() call to the bottom of ExtractResponseData() to make HttpResponse members available to AdvancedResponseWriter.
2. Check for AdvancedResponseWriter first and call only that or fallback to ResponseWriter.

## Purpose
This pull request is a:

- [X] Improvement
