### PR TITLE
Fixed #881

### DIFF
--- a/RestSharp/Authenticators/HttpBasicAuthenticator.cs
+++ b/RestSharp/Authenticators/HttpBasicAuthenticator.cs
@@ -43,7 +43,7 @@ namespace RestSharp.Authenticators
             // request.Credentials = new NetworkCredential(_username, _password);
 
             // only add the Authorization parameter if it hasn't been added by a previous Execute
-            if (!request.Parameters.Any(p => p.Name.Equals("Authorization", StringComparison.OrdinalIgnoreCase)))
+            if (!request.Parameters.Any(p => "Authorization".Equals(p.Name, StringComparison.OrdinalIgnoreCase)))
                 request.AddParameter("Authorization", authHeader, ParameterType.HttpHeader);
         }
     }


### PR DESCRIPTION
Fixed NullReferenceException from HttpBasicAuthenticator when a parameter name is null