### PR TITLE
An array of objects is also valid Json and should be handled by JsonSerializer. 

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -870,7 +870,18 @@ namespace RestSharp.Tests
             Assert.AreEqual(preformattedString, result);
         }
 
-        [Test]
+	    [Test]
+	    public void Serialize_Json_Returns_Same_Json_Array()
+	    {
+		    string preformattedString = "[{ \"name\" : \"value\" }]";
+
+			var json = new JsonSerializer();
+		    string result = json.Serialize( preformattedString );
+
+			Assert.AreEqual( preformattedString, result );
+	    }
+
+		[Test]
         public void Serialize_Json_Does_Not_Double_Escape()
         {
             string preformattedString = "{ \"name\" : \"value\" }";

--- a/RestSharp/Serializers/JsonSerializer.cs
+++ b/RestSharp/Serializers/JsonSerializer.cs
@@ -18,23 +18,40 @@ namespace RestSharp.Serializers
 
         /// <summary>
         /// Serialize the object as JSON
+        /// If the object is already a serialized string returns that value
         /// </summary>
         /// <param name="obj">Object to serialize</param>
         /// <returns>JSON as String</returns>
         public string Serialize(object obj)
         {
-            if (obj is string value)
-            {
-                string trimmed = value.Trim();
-                if (trimmed.StartsWith("{") && trimmed.EndsWith("}"))
-                {
-                    return value;
-                }
-
-            }
+	        if (IsSerializedString(obj, out var serializedString))
+	        {
+		        return serializedString;
+	        }
 
             return SimpleJson.SerializeObject(obj);
         }
+
+		/// <summary>
+		/// Determines if the object is already a serialized string.
+		/// </summary>
+	    private static bool IsSerializedString(object obj, out string serializedString)
+	    {
+		    if( obj is string value )
+		    {
+			    string trimmed = value.Trim();
+
+			    if( ( trimmed.StartsWith( "{" ) && trimmed.EndsWith( "}" ) ) 
+				    || ( trimmed.StartsWith( "[{" ) && trimmed.EndsWith( "}]" ) ) )
+			    {
+				    serializedString = value;
+				    return true;
+			    }
+		    }
+
+		    serializedString = null;
+		    return false;
+	    }
 
         /// <summary>
         /// Content type for serialized content


### PR DESCRIPTION
## Description
This is an expansion on https://github.com/restsharp/RestSharp/pull/1201 which allowed JsonSerializer to handle already serialized strings.

[ { "key", "value"} ] Is also valid json and could be sent as a string. The Serialize method should handle all valid json formats.

I chose to move IsSerializedString to its own method because it was beginning to create readability issues in the Serialize method.

Please let me know if anything needs to be cleaned up in my changes!
<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
