### PR TITLE
An array of objects is also valid Json and should be handled by JsonSerializer.

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -871,7 +871,18 @@ namespace RestSharp.Tests
             Assert.AreEqual(preformattedString, result);
         }
 
-        [Test]
+	    [Test]
+	    public void Serialize_Json_Returns_Same_Json_Array()
+	    {
+		    string preformattedString = "[{ \"name\" : \"value\" }]";
+
+		    var json = new JsonSerializer();
+		    string result = json.Serialize( preformattedString );
+
+		    Assert.AreEqual( preformattedString, result );
+	    }
+
+		[Test]
         public void Serialize_Json_Does_Not_Double_Escape()
         {
             string preformattedString = "{ \"name\" : \"value\" }";

--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -871,18 +871,18 @@ namespace RestSharp.Tests
             Assert.AreEqual(preformattedString, result);
         }
 
-	    [Test]
-	    public void Serialize_Json_Returns_Same_Json_Array()
-	    {
-		    string preformattedString = "[{ \"name\" : \"value\" }]";
+        [Test]
+        public void Serialize_Json_Returns_Same_Json_Array()
+        {
+            string preformattedString = "[{ \"name\" : \"value\" }]";
 
-		    var json = new JsonSerializer();
-		    string result = json.Serialize( preformattedString );
+            var json = new JsonSerializer();
+            string result = json.Serialize( preformattedString );
 
-		    Assert.AreEqual( preformattedString, result );
-	    }
+            Assert.AreEqual( preformattedString, result );
+        }
 
-		[Test]
+        [Test]
         public void Serialize_Json_Does_Not_Double_Escape()
         {
             string preformattedString = "{ \"name\" : \"value\" }";

--- a/RestSharp/Serialization/Json/JsonSerializer.cs
+++ b/RestSharp/Serialization/Json/JsonSerializer.cs
@@ -19,29 +19,47 @@ namespace RestSharp.Serialization.Json
             ContentType = "application/json";
         }
 
-        /// <summary>
-        /// Serialize the object as JSON
-        /// </summary>
-        /// <param name="obj">Object to serialize</param>
-        /// <returns>JSON as String</returns>
-        public string Serialize(object obj)
+		/// <summary>
+		/// Serialize the object as JSON
+		/// If the object is already a serialized string returns it's value
+		/// </summary>
+		/// <param name="obj">Object to serialize</param>
+		/// <returns>JSON as String</returns>
+		public string Serialize(object obj)
         {
-            if (obj is string value)
-            {
-                var trimmed = value.Trim();
-                if (trimmed.StartsWith("{") && trimmed.EndsWith("}"))
-                {
-                    return value;
-                }
-            }
+			if( IsSerializedString( obj, out var serializedString ) )
+			{
+				return serializedString;
+			}
 
-            return SimpleJson.SimpleJson.SerializeObject(obj);
+			return SimpleJson.SimpleJson.SerializeObject(obj);
         }
 
-        /// <summary>
-        /// Content type for serialized content
-        /// </summary>
-        public string ContentType { get; set; }
+	    /// <summary>
+	    /// Determines if the object is already a serialized string.
+	    /// </summary>
+	    private static bool IsSerializedString( object obj, out string serializedString )
+	    {
+		    if( obj is string value )
+		    {
+			    string trimmed = value.Trim();
+
+			    if( ( trimmed.StartsWith( "{" ) && trimmed.EndsWith( "}" ) )
+			        || ( trimmed.StartsWith( "[{" ) && trimmed.EndsWith( "}]" ) ) )
+			    {
+				    serializedString = value;
+				    return true;
+			    }
+		    }
+
+		    serializedString = null;
+		    return false;
+	    }
+
+		/// <summary>
+		/// Content type for serialized content
+		/// </summary>
+		public string ContentType { get; set; }
         
         public string RootElement { get; set; }
 

--- a/RestSharp/Serialization/Json/JsonSerializer.cs
+++ b/RestSharp/Serialization/Json/JsonSerializer.cs
@@ -19,47 +19,47 @@ namespace RestSharp.Serialization.Json
             ContentType = "application/json";
         }
 
-		/// <summary>
-		/// Serialize the object as JSON
-		/// If the object is already a serialized string returns it's value
-		/// </summary>
-		/// <param name="obj">Object to serialize</param>
-		/// <returns>JSON as String</returns>
-		public string Serialize(object obj)
+        /// <summary>
+        /// Serialize the object as JSON
+        /// If the object is already a serialized string returns it's value
+        /// </summary>
+        /// <param name="obj">Object to serialize</param>
+        /// <returns>JSON as String</returns>
+        public string Serialize(object obj)
         {
-			if( IsSerializedString( obj, out var serializedString ) )
-			{
-				return serializedString;
-			}
+            if( IsSerializedString( obj, out var serializedString ) )
+            {
+                return serializedString;
+            }
 
-			return SimpleJson.SimpleJson.SerializeObject(obj);
+            return SimpleJson.SimpleJson.SerializeObject(obj);
         }
 
-	    /// <summary>
-	    /// Determines if the object is already a serialized string.
-	    /// </summary>
-	    private static bool IsSerializedString( object obj, out string serializedString )
-	    {
-		    if( obj is string value )
-		    {
-			    string trimmed = value.Trim();
+        /// <summary>
+        /// Determines if the object is already a serialized string.
+        /// </summary>
+        private static bool IsSerializedString( object obj, out string serializedString )
+        {
+            if( obj is string value )
+            {
+                string trimmed = value.Trim();
 
-			    if( ( trimmed.StartsWith( "{" ) && trimmed.EndsWith( "}" ) )
-			        || ( trimmed.StartsWith( "[{" ) && trimmed.EndsWith( "}]" ) ) )
-			    {
-				    serializedString = value;
-				    return true;
-			    }
-		    }
+                if( ( trimmed.StartsWith( "{" ) && trimmed.EndsWith( "}" ) )
+                    || ( trimmed.StartsWith( "[{" ) && trimmed.EndsWith( "}]" ) ) )
+                {
+                    serializedString = value;
+                    return true;
+                }
+            }
 
-		    serializedString = null;
-		    return false;
-	    }
+            serializedString = null;
+            return false;
+        }
 
-		/// <summary>
-		/// Content type for serialized content
-		/// </summary>
-		public string ContentType { get; set; }
+        /// <summary>
+        /// Content type for serialized content
+        /// </summary>
+        public string ContentType { get; set; }
         
         public string RootElement { get; set; }
 


### PR DESCRIPTION
## Description
This is an expansion on #1201 which allowed JsonSerializer to handle already serialized strings.

[ { "key", "value"} ] Is also valid json and could be sent as a string. The Serialize method should handle all valid json formats.

I chose to move IsSerializedString to its own method because it was beginning to create readability issues in the Serialize method.

Please let me know if anything needs to be cleaned up in my changes!
<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
