### PR TITLE
added support for IList in serializer. 

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -113,7 +113,16 @@ namespace RestSharp.Tests
             Assert.IsNotEmpty(output);
             Assert.IsTrue(output.Count() == 5);
         }
+        [Test]
+        public void Can_Deserialize_IList_of_Simple_Types()
+        {
+            const string content = "{\"numbers\":[1,2,3,4,5]}";
+            JsonSerializer json = new JsonSerializer { RootElement = "numbers" };
+            var output = json.Deserialize<IList<int>>(new RestResponse { Content = content });
 
+            Assert.IsNotEmpty(output);
+            Assert.IsTrue(output.Count() == 5);
+        }
         [Test]
         public void Can_Deserialize_Lists_of_Simple_Types()
         {

--- a/RestSharp/Serialization/Json/JsonSerializer.cs
+++ b/RestSharp/Serialization/Json/JsonSerializer.cs
@@ -310,6 +310,13 @@ namespace RestSharp.Serialization.Json
                     return BuildList(listType, value);
                 }
 
+                if (genericTypeDef == typeof(IList<>))
+                {
+                    Type itemType = typeInfo.GetGenericArguments()[0];
+                    Type listType = typeof(List<>).MakeGenericType(itemType);
+                    return BuildList(listType, value);
+                }
+
                 if (genericTypeDef == typeof(List<>))
                 {
                     return BuildList(type, value);


### PR DESCRIPTION
…ur models, which uses IList for all list types

## Description

 We use autorest to generate our models, which generates all Lists from the swagger doc as type IList

## Purpose
This pull request is a:


- [x] New feature (non-breaking change which adds functionality)



## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
