### PR TITLE
Fix typo in RestRequest.cs

### DIFF
--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -37,7 +37,7 @@ namespace RestSharp
         /// <summary>
         ///     Local list of Allowed Decompression Methods
         /// </summary>
-        private readonly IList<DecompressionMethods> _alloweDecompressionMethods;
+        private readonly IList<DecompressionMethods> _allowedDecompressionMethods;
 
         private Action<Stream> _responseWriter;
         private Action<Stream, IHttpResponse> _advancedResponseWriter;
@@ -53,7 +53,7 @@ namespace RestSharp
             Files = new List<FileParameter>();
             XmlSerializer = new XmlSerializer();
             JsonSerializer = new JsonSerializer();
-            _alloweDecompressionMethods = new List<DecompressionMethods>();
+            _allowedDecompressionMethods = new List<DecompressionMethods>();
 
             OnBeforeDeserialization = r => { };
         }
@@ -117,8 +117,8 @@ namespace RestSharp
         ///     List of Allowed Decompresison Methods
         /// </summary>
         public IList<DecompressionMethods> AllowedDecompressionMethods =>
-            _alloweDecompressionMethods.Any()
-                ? _alloweDecompressionMethods
+            _allowedDecompressionMethods.Any()
+                ? _allowedDecompressionMethods
                 : new[] {DecompressionMethods.None, DecompressionMethods.Deflate, DecompressionMethods.GZip};
 
         /// <summary>
@@ -605,8 +605,8 @@ namespace RestSharp
         /// <returns></returns>
         public IRestRequest AddDecompressionMethod(DecompressionMethods decompressionMethod)
         {
-            if (!_alloweDecompressionMethods.Contains(decompressionMethod))
-                _alloweDecompressionMethods.Add(decompressionMethod);
+            if (!_allowedDecompressionMethods.Contains(decompressionMethod))
+                _allowedDecompressionMethods.Add(decompressionMethod);
 
             return this;
         }


### PR DESCRIPTION
Fix typo "_alloweDecompressionMethods" to "_allowedDecompressionMethods".

## Description

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [X] Typo fix
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

I've added description of the typo fix in the commit description.