### PR TITLE
Add ability to deserialize an IList<> object, by creating a List<>

### DIFF
--- a/RestSharp.Tests/JsonTests.cs
+++ b/RestSharp.Tests/JsonTests.cs
@@ -115,6 +115,16 @@ namespace RestSharp.Tests
         }
 
         [Test]
+        public void Can_Deserialize_IList_of_Simple_Types()
+        {
+            const string content = "{\"numbers\":[1,2,3,4,5]}";
+            JsonSerializer json = new JsonSerializer { RootElement = "numbers" };
+            var output = json.Deserialize<IList<int>>(new RestResponse { Content = content });
+
+            Assert.IsNotEmpty(output);
+            Assert.IsTrue(output.Count() == 5);
+        }
+        [Test]
         public void Can_Deserialize_Lists_of_Simple_Types()
         {
             string doc = File.ReadAllText(Path.Combine(currentPath, "SampleData", "jsonlists.txt"));

--- a/RestSharp/Serialization/Json/JsonSerializer.cs
+++ b/RestSharp/Serialization/Json/JsonSerializer.cs
@@ -303,7 +303,7 @@ namespace RestSharp.Serialization.Json
             {
                 Type genericTypeDef = type.GetGenericTypeDefinition();
 
-                if (genericTypeDef == typeof(IEnumerable<>))
+                if (genericTypeDef == typeof(IEnumerable<>) || genericTypeDef == typeof(IList<>))
                 {
                     Type itemType = typeInfo.GetGenericArguments()[0];
                     Type listType = typeof(List<>).MakeGenericType(itemType);


### PR DESCRIPTION
## Description

I was encountering issues deserializing json with objects that defined IList<> types.  This is very similar to how IEnumerable is handled in existing code.

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
