### PR TITLE
Allow null resource in RestRequest constructor

### DIFF
--- a/RestSharp.Tests/RestRequestTests.cs
+++ b/RestSharp.Tests/RestRequestTests.cs
@@ -107,5 +107,16 @@ namespace RestSharp.Tests
             Assert.AreEqual("hello", request.Parameters[0].Name);
             Assert.AreEqual("world", request.Parameters[0].Value);
         }
+
+        [Test]
+        public void Can_Set_Null_Resource()
+        {
+            Assert.DoesNotThrow(
+                () =>
+                    {
+                        RestRequest request = new RestRequest((string)null);
+                        Assert.NotNull(request);
+                    });
+        }
     }
 }

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -81,7 +81,7 @@ namespace RestSharp
             Method = method;
             RequestFormat = dataFormat;
 
-            var queryStringStart = Resource.IndexOf('?');
+            var queryStringStart = (Resource ?? string.Empty).IndexOf('?');
             if (queryStringStart >= 0)
             {
                 var queryParams = System.Web.HttpUtility.ParseQueryString(Resource.Substring(queryStringStart));


### PR DESCRIPTION
## Description
Trying to create a RestRequest with a null resource throws an NullReferenceException

## Purpose
This pull request is a:

- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
