### PR TITLE
Fixed proxy tests for localized environments

### DIFF
--- a/RestSharp.IntegrationTests/ProxyTests.cs
+++ b/RestSharp.IntegrationTests/ProxyTests.cs
@@ -37,11 +37,9 @@ namespace RestSharp.IntegrationTests
                 Assert.IsInstanceOf<WebException>(response.ErrorException);
 
 #if NETCORE
-                Assert.AreEqual("An error occurred while sending the request. The server name or address could not be resolved", response.ErrorMessage);
-#endif
-
-#if !NETCORE
-                Assert.AreEqual("The proxy name could not be resolved: 'non_existent_proxy'", response.ErrorMessage);
+                Assert.AreEqual(WebExceptionStatus.NameResolutionFailure, ((WebException)response.ErrorException).Status);
+#else
+                Assert.AreEqual(WebExceptionStatus.ProxyNameResolutionFailure, ((WebException)response.ErrorException).Status);
 #endif
             }
         }


### PR DESCRIPTION
## Description

One integration proxy test is failing on non-EN environments due to checking localized ErrorMessage. This is resolved by checking Status (exception type) instead.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
