### PR TITLE
Issue 1273

### DIFF
--- a/RestSharp.Tests/RestRequestTests.cs
+++ b/RestSharp.Tests/RestRequestTests.cs
@@ -11,5 +11,20 @@ namespace RestSharp.Tests
 
             Assert.AreEqual("resource", request.Resource);
         }
+
+        [Test]
+        public void RestRequest_Test_Already_Encoded()
+        {
+            var request = new RestRequest("/api/get?query=Id%3d198&another=notencoded");
+
+            Assert.AreEqual("/api/get", request.Resource);
+            Assert.AreEqual(2, request.Parameters.Count);
+            Assert.AreEqual("query", request.Parameters[0].Name);
+            Assert.AreEqual("Id%3d198", request.Parameters[0].Value);
+            Assert.AreEqual(ParameterType.QueryStringWithoutEncode, request.Parameters[0].Type);
+            Assert.AreEqual("another", request.Parameters[1].Name);
+            Assert.AreEqual("notencoded", request.Parameters[1].Value);
+            Assert.AreEqual(ParameterType.QueryStringWithoutEncode, request.Parameters[1].Type);
+        }
     }
 }

--- a/RestSharp.Tests/TestData/JsonData.cs
+++ b/RestSharp.Tests/TestData/JsonData.cs
@@ -26,7 +26,7 @@ namespace RestSharp.Tests.TestData
             };
 
             var friendsArray = new JsonArray();
-            friendsArray.AddRange(Enumerable.Range(0, 9).Select(i =>
+            friendsArray.AddRange(Enumerable.Range(0, 10).Select(i =>
                 new JsonObject
                 {
                     {"name", "Friend" + i},
@@ -62,7 +62,7 @@ namespace RestSharp.Tests.TestData
             };
 
             var friendsArray = new JsonArray();
-            friendsArray.AddRange(Enumerable.Range(0, 9).Select(i =>
+            friendsArray.AddRange(Enumerable.Range(0, 10).Select(i =>
                 new JsonObject
                 {
                     {"name", "Friend" + i},

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -88,7 +88,7 @@ namespace RestSharp
                 Resource = Resource.Substring(0, queryStringStart);
 
                 foreach (var param in queryParams)
-                    AddQueryParameter(param.Name, param.Value);
+                    AddQueryParameter(param.Name, param.Value, false);
             }
 
             IEnumerable<NameValuePair> ParseQuery(string query) =>


### PR DESCRIPTION
Do not encode querystring parameters that are sent to the RestRequest constructor. Also fix unit tests that were failing from range change.

## Description

Issue 1273

## Purpose
This pull request is a:

I don't know how to check one box. It is fixing an existing issue that was a breaking change. This reverts it back to the behavoir in 106.6.4

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
