### PR TITLE
Make SourceLink a development dependency only

### DIFF
--- a/RestSharp/RestSharp.csproj
+++ b/RestSharp/RestSharp.csproj
@@ -24,7 +24,7 @@
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## Description

106.6.8 exposes a unnecessary dependency on `Microsoft.SourceLink.GitHub`.

From https://github.com/dotnet/sourcelink#githubcom-and-github-enterprise
> Source Link package is a development dependency, which means it is only used during build. It is therefore recommended to set PrivateAssets to all on the package reference. This prevents consuming projects of your nuget package from attempting to install Source Link.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
