### PR TITLE
Add APPVEYOR constant instead of replacing existing constants

### DIFF
--- a/RestSharp.IntegrationTests/RestSharp.IntegrationTests.csproj
+++ b/RestSharp.IntegrationTests/RestSharp.IntegrationTests.csproj
@@ -11,6 +11,9 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
     <DefineConstants>NETCORE</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(AppVeyor)'=='true'">
+    <DefineConstants>$(DefineConstants);APPVEYOR</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.8.1" />

--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,4 @@
 dotnet restore
-msbuild /t:build /p:Configuration=Release /p:DefineConstants=APPVEYOR
+msbuild /t:build /p:Configuration=Release /p:AppVeyor=true
 dotnet test --no-build
 msbuild /t:Pack


### PR DESCRIPTION
## Description

Using `/p:DefineConstants` doesn't add `APPVEYOR` as a constant, but sets it as the *only* defined constant. 
This fixes #1294 

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

I'm not entirely sure how to add a test to ensure this, but I inspected the compiled dlls using `ILSpy` after running `build.bat`

`net452`
```c#
webRequest.UnsafeAuthenticatedConnectionSharing = UnsafeAuthenticatedConnectionSharing;
try
```

`netstandard2.0`
```c#
webRequest.UnsafeAuthenticatedConnectionSharing = UnsafeAuthenticatedConnectionSharing;
webRequest.Proxy = null; // <--- this is what we want
try
```

Inspecting `RestSharp.IntegrationTests.dll` also showed, that `Can_Cancel_GET_TaskAsync()` was correctly excluded as expected when running `build.bat` and included when building otherwise.