### PR TITLE
Fix setting deserializer's RootElement from request's RootElement

### DIFF
--- a/RestSharp.IntegrationTests/RootElementTests.cs
+++ b/RestSharp.IntegrationTests/RootElementTests.cs
@@ -27,7 +27,7 @@ namespace RestSharp.IntegrationTests
 
 
         [Test]
-        public void Handles_Different_Root_Element_On_Http_Error()
+        public void Copy_RootElement_From_Request_To_IWithRootElement_Deserializer()
         {
             _server.SetHandler(Handlers.Generic<ResponseHandler>());
             RestRequest request = new RestRequest("success")

--- a/RestSharp.IntegrationTests/RootElementTests.cs
+++ b/RestSharp.IntegrationTests/RootElementTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using NUnit.Framework;
+using RestSharp.IntegrationTests.Helpers;
+using RestSharp.IntegrationTests.SampleDeserializers;
+using RestSharp.Serialization;
+
+namespace RestSharp.IntegrationTests
+{
+    [TestFixture]
+    public class RootElementTests
+    {
+        private readonly Uri _baseUrl = new Uri("http://localhost:8888/");
+        private SimpleServer _server;
+        private RestClient _client;
+
+        [SetUp]
+        public void SetupServer()
+        {
+            _server = SimpleServer.Create(_baseUrl.AbsoluteUri, UrlToStatusCodeHandler);
+            _client = new RestClient(_baseUrl);
+        }
+
+        [TearDown]
+        public void ShutdownServer() => _server.Dispose();
+
+
+        [Test]
+        public void Handles_Different_Root_Element_On_Http_Error()
+        {
+            _server.SetHandler(Handlers.Generic<ResponseHandler>());
+            RestRequest request = new RestRequest("success")
+            {
+                RootElement = "Success"
+            };
+            var deserializer = new CustomDeserializer();
+            _client.AddHandler(ContentType.Xml, () => deserializer);
+            _client.Execute<Response>(request);
+
+            Assert.AreEqual(deserializer.RootElement, request.RootElement);
+        }
+
+        public class ResponseHandler
+        {
+
+            private void success(HttpListenerContext context)
+            {
+                context.Response.StatusCode = 200;
+                context.Response.Headers.Add("Content-Type", ContentType.Xml);
+                context.Response.OutputStream.WriteStringUtf8(
+                    @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Response>
+    <Success>
+        <Message>Works!</Message>
+    </Success>
+</Response>");
+            }
+        }
+
+        public class Response
+        {
+            public string Message { get; set; }
+        }
+
+        private static void UrlToStatusCodeHandler(HttpListenerContext obj)
+        {
+            obj.Response.StatusCode = int.Parse(obj.Request.Url.Segments.Last());
+        }
+    }
+}

--- a/RestSharp.IntegrationTests/SampleDeserializers/CustomDeserializer.cs
+++ b/RestSharp.IntegrationTests/SampleDeserializers/CustomDeserializer.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using RestSharp.Serialization.Xml;
+
+namespace RestSharp.IntegrationTests.SampleDeserializers
+{
+    class CustomDeserializer : IXmlDeserializer
+    {
+        public T Deserialize<T>(IRestResponse response)
+        {
+            return default(T);
+        }
+
+        public string RootElement { get; set; }
+        public string Namespace { get; set; }
+        public string DateFormat { get; set; }
+    }
+}

--- a/RestSharp/RestClient.cs
+++ b/RestSharp/RestClient.cs
@@ -729,7 +729,7 @@ namespace RestSharp
                             xml.Namespace = request.XmlNamespace;
                     }
 
-                    if (handler is IWithRootElement deserializer && request.RootElement.IsEmpty())
+                    if (handler is IWithRootElement deserializer && !request.RootElement.IsEmpty())
                         deserializer.RootElement = request.RootElement;
 
                     if (handler != null)

--- a/RestSharp/Serialization/Xml/IXmlDeserializer.cs
+++ b/RestSharp/Serialization/Xml/IXmlDeserializer.cs
@@ -2,7 +2,7 @@ using RestSharp.Deserializers;
 
 namespace RestSharp.Serialization.Xml
 {
-    public interface IXmlDeserializer : IDeserializer
+    public interface IXmlDeserializer : IDeserializer, IWithRootElement
     {
         string RootElement { get; set; }
 


### PR DESCRIPTION
## Description

When you set request's RootElement property, that's not setting back in deserializer's RootElement.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)


