### PR TITLE
Add callback/event RestRequest.OnBeforeRequest

### DIFF
--- a/RestSharp/IRestRequest.cs
+++ b/RestSharp/IRestRequest.cs
@@ -374,6 +374,8 @@ namespace RestSharp
 
         Action<IRestResponse> OnBeforeDeserialization { get; set; }
 
+        Action<IHttp> OnAfterConfiguration { get; set; }
+
         void IncreaseNumAttempts();
     }
 }

--- a/RestSharp/IRestRequest.cs
+++ b/RestSharp/IRestRequest.cs
@@ -374,7 +374,7 @@ namespace RestSharp
 
         Action<IRestResponse> OnBeforeDeserialization { get; set; }
 
-        Action<IHttp> OnAfterConfiguration { get; set; }
+        Action<IHttp> OnBeforeRequest { get; set; }
 
         void IncreaseNumAttempts();
     }

--- a/RestSharp/RestClient.Async.cs
+++ b/RestSharp/RestClient.Async.cs
@@ -354,7 +354,7 @@ namespace RestSharp
         {
             AuthenticateIfNeeded(this, request);
             var http = ConfigureHttp(request);
-            request.OnAfterConfiguration(http);
+            request.OnBeforeRequest(http);
 
             var asyncHandle = new RestRequestAsyncHandle();
             Action<HttpResponse> responseCb = r => ProcessResponse(request, r, asyncHandle, callback);

--- a/RestSharp/RestClient.Async.cs
+++ b/RestSharp/RestClient.Async.cs
@@ -354,6 +354,7 @@ namespace RestSharp
         {
             AuthenticateIfNeeded(this, request);
             var http = ConfigureHttp(request);
+            request.OnAfterConfiguration(http);
 
             var asyncHandle = new RestRequestAsyncHandle();
             Action<HttpResponse> responseCb = r => ProcessResponse(request, r, asyncHandle, callback);

--- a/RestSharp/RestClient.Sync.cs
+++ b/RestSharp/RestClient.Sync.cs
@@ -111,7 +111,7 @@ namespace RestSharp
             try
             {
                 var http = ConfigureHttp(request);
-                request.OnAfterConfiguration(http);
+                request.OnBeforeRequest(http);
 
                 response = ConvertToRestResponse(request, getResponse(http, httpMethod));
             }

--- a/RestSharp/RestClient.Sync.cs
+++ b/RestSharp/RestClient.Sync.cs
@@ -111,6 +111,7 @@ namespace RestSharp
             try
             {
                 var http = ConfigureHttp(request);
+                request.OnAfterConfiguration(http);
 
                 response = ConvertToRestResponse(request, getResponse(http, httpMethod));
             }

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -55,7 +55,8 @@ namespace RestSharp
             _allowedDecompressionMethods = new List<DecompressionMethods>();
 
             OnBeforeDeserialization = r => { };
-        }
+            OnAfterConfiguration = (h) => { };
+	   }
 
         /// <summary>
         ///     Sets Method property to value of method
@@ -659,6 +660,11 @@ namespace RestSharp
         ///     A function to run prior to deserializing starting (e.g. change settings if error encountered)
         /// </summary>
         public Action<IRestResponse> OnBeforeDeserialization { get; set; }
+
+        /// <summary>
+        ///     A function to run after configuration of the HTTP request (e.g. set last minute headers)
+        /// </summary>
+        public Action<IHttp> OnAfterConfiguration { get; set; }
 
         /// <summary>
         ///     Used by the default deserializers to explicitly set which date format string to use when parsing dates.

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -55,7 +55,7 @@ namespace RestSharp
             _allowedDecompressionMethods = new List<DecompressionMethods>();
 
             OnBeforeDeserialization = r => { };
-            OnAfterConfiguration = (h) => { };
+            OnBeforeRequest = (h) => { };
 	   }
 
         /// <summary>
@@ -664,7 +664,7 @@ namespace RestSharp
         /// <summary>
         ///     A function to run after configuration of the HTTP request (e.g. set last minute headers)
         /// </summary>
-        public Action<IHttp> OnAfterConfiguration { get; set; }
+        public Action<IHttp> OnBeforeRequest { get; set; }
 
         /// <summary>
         ///     Used by the default deserializers to explicitly set which date format string to use when parsing dates.


### PR DESCRIPTION
## Description

The callback/event `OnAfterConfiguration` is executed after the HTTP object is configured, but before the HTTP request is made. This allows for some last minute header modifications, which in my case is necessary due to the delayed serialization in 106.6 and later.

I've tested using `OnAfterConfiguration` instead of setting `RestClient.Authenticator`, and it seems to do the trick.

Solves issue #1305 

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
