### PR TITLE
Allows ISO-8859-1 encoding for basic authentication

### DIFF
--- a/RestSharp/Authenticators/HttpBasicAuthenticator.cs
+++ b/RestSharp/Authenticators/HttpBasicAuthenticator.cs
@@ -22,15 +22,26 @@ using System.Text;
 
 namespace RestSharp.Authenticators
 {
+    /// <summary>
+    /// Allows "basic access authentication" for HTTP requests.
+    /// </summary>
+    /// <remarks>
+    /// Encoding can be specified depending on what your server expect (see https://stackoverflow.com/a/7243567).
+    /// UTF-8 is used by default but some servers might expect ISO-8859-1 encoding.
+    /// </remarks>
     public class HttpBasicAuthenticator : IAuthenticator
     {
         private readonly string authHeader;
 
         public HttpBasicAuthenticator(string username, string password)
+            : this(username, password, useIso88591: false)
         {
-            var token = Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Format("{0}:{1}", username, password)));
+        }
 
-            authHeader = string.Format("Basic {0}", token);
+        public HttpBasicAuthenticator(string username, string password, bool useIso88591)
+        {
+            var token = Convert.ToBase64String(Encoding.GetEncoding(useIso88591 ? "ISO-8859-1" : "UTF-8").GetBytes($"{username}:{password}"));
+            this.authHeader = $"Basic {token}";
         }
 
         public void Authenticate(IRestClient client, IRestRequest request)


### PR DESCRIPTION
## Description

*I've been experimenting [authentication issues ](https://bitbucket.org/farmas/atlassian.net-sdk/wiki/Home) with Jira .NET Api (which uses RestSharp under the hood).  When using french character 'é' I couldn't authenticate. It turns out that the Jira server expects ISO-8859-1 encoding.*

This pull request allows to use ISO-8859-1 encoding for the BASIC header.  Default encoding remains UTF-8.

In this thread you'll find some more info: https://stackoverflow.com/questions/7242316/what-encoding-should-i-use-for-http-basic-authentication  

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
