### PR TITLE
Add method in Interface

### DIFF
--- a/RestSharp/IRestRequest.cs
+++ b/RestSharp/IRestRequest.cs
@@ -354,6 +354,14 @@ namespace RestSharp
         IRestRequest AddUrlSegment(string name, string value);
 
         /// <summary>
+        ///     Shortcut to AddParameter(name, value, UrlSegment) overload
+        /// </summary>
+        /// <param name="name">Name of the segment to add</param>
+        /// <param name="value">Value of the segment to add</param>
+        /// <returns></returns>
+        IRestRequest AddUrlSegment(string name, object value);
+           
+        /// <summary>
         /// Shortcut to AddParameter(name, value, QueryString) overload
         /// </summary>
         /// <param name="name">Name of the parameter to add</param>


### PR DESCRIPTION
Add IRestRequest AddUrlSegment(string name, object value) to maintain consistency with implementation class RestRequest

## Description

The implementation class RestRequest have two methods: 

`public IRestRequest AddUrlSegment(string name, object value)`
`public IRestRequest AddUrlSegment(string name, string value)`

But in `IRestRequest` don't have this method:

`public IRestRequest AddUrlSegment(string name, object value)`

It's cause a problem that the user call `AddUrlSegment(string name, object value)` twice, in second call, the return of `IRestRequest` force the user a send two `strings` instead `<string, object>`

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
