### PR TITLE
Fixed breaking change so object initialized Parameter classes do not …

### DIFF
--- a/RestSharp/Parameter.cs
+++ b/RestSharp/Parameter.cs
@@ -27,8 +27,11 @@ namespace RestSharp
     {
         public Parameter(string name, object value, ParameterType type)
         {
-            Ensure.NotEmpty(name, nameof(name));
-            
+            if (type != ParameterType.RequestBody)
+            {
+                Ensure.NotEmpty(name, nameof(name));
+            }
+
             Name = name;
             Value = value;
             Type = type;


### PR DESCRIPTION
Description
I've noticed that a recent change of parameter name validation breaks existing code.  I've added a new base class constructor that does not use the validation for the XmlParameter and JsonParameter inherited classes, and assigned the name in them respectively. 

Purpose
This pull request is a:

  Bugfix (non-breaking change which fixes an issue)
 