### PR TITLE
Make use SerializeAs(Content = true) attribute for IList properties.

### DIFF
--- a/RestSharp.Tests/XmlSerializerTests.cs
+++ b/RestSharp.Tests/XmlSerializerTests.cs
@@ -87,6 +87,13 @@ namespace RestSharp.Tests
         }
 
         [SerializeAs(Name = "People")]
+        private class Contacts
+        {
+            [SerializeAs(Content = true)]
+            public List<Person> People { get; set; }
+        }
+
+        [SerializeAs(Name = "People")]
         private class PersonList : List<Person>
         {
         }
@@ -278,6 +285,49 @@ namespace RestSharp.Tests
             doc.Add(root);
 
             return doc;
+        }
+
+        [Test]
+        public void Can_serialize_a_list_which_is_the_content_of_root_element()
+        {
+            var contacts = new Contacts
+            {
+                People = new List<Person>
+                {
+                    new Person
+                    {
+                        Name = "Foo",
+                        Age = 50,
+                        Price = 19.95m,
+                        StartDate = new DateTime(2009, 12, 18, 10, 2, 23),
+                        Items = new List<Item>
+                        {
+                            new Item {Name = "One", Value = 1},
+                            new Item {Name = "Two", Value = 2},
+                            new Item {Name = "Three", Value = 3}
+                        }
+                    },
+                    new Person
+                    {
+                        Name = "Bar",
+                        Age = 23,
+                        Price = 23.23m,
+                        StartDate = new DateTime(2009, 12, 23, 10, 23, 23),
+                        Items = new List<Item>
+                        {
+                            new Item {Name = "One", Value = 1},
+                            new Item {Name = "Two", Value = 2},
+                            new Item {Name = "Three", Value = 3}
+                        }
+                    }
+                }
+            };
+
+            var xml = new XmlSerializer();
+            var doc = xml.Serialize(contacts);
+            var expected = GetPeopleXDoc(CultureInfo.InvariantCulture);
+
+            Assert.AreEqual(expected.ToString(), doc);
         }
 
         [Test]

--- a/RestSharp/Serialization/Xml/XmlSerializer.cs
+++ b/RestSharp/Serialization/Xml/XmlSerializer.cs
@@ -214,7 +214,20 @@ namespace RestSharp.Serializers
                         var instance = new XElement(itemTypeName.AsNamespaced(Namespace));
 
                         Map(instance, item);
-                        element.Add(instance);
+
+                        if (setTextContent)
+                        {
+                            root.Add(instance);
+                        }
+                        else
+                        {
+                            element.Add(instance);
+                        }
+                    }
+
+                    if (setTextContent)
+                    {
+                        continue;
                     }
                 }
                 else


### PR DESCRIPTION
## Description

IList properties marked with [SerializeAs(Content = true)] attribute can be serialized as parent's XML tag content.

In this thread you'll find more info: https://stackoverflow.com/questions/56849421/serialize-list-property-as-parents-content-with-restsharp-xmlserializer

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
