### PR TITLE
AddHeaders Implementation for RestRequest

### DIFF
--- a/RestSharp.Tests/RequestHeaderTests.cs
+++ b/RestSharp.Tests/RequestHeaderTests.cs
@@ -25,5 +25,58 @@ namespace RestSharp.Tests
             ArgumentException exception = Assert.Throws<ArgumentException>(() => request.AddHeaders(headers));
             Assert.AreEqual("Duplicate header names exist: ACCEPT", exception.Message);
         }
+
+        [Test]
+        public void AddHeaders_DifferentCaseDuplicatesExist_ThrowsException()
+        {
+            ICollection<KeyValuePair<string, string>> headers = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("Accept", "application/json"),
+                new KeyValuePair<string, string>("Accept-Language", "en-us,en;q=0.5"),
+                new KeyValuePair<string, string>("Keep-Alive", "300"),
+                new KeyValuePair<string, string>("acCEpt", "application/json")
+            };
+
+            RestRequest request = new RestRequest();
+
+            ArgumentException exception = Assert.Throws<ArgumentException>(() => request.AddHeaders(headers));
+            Assert.AreEqual("Duplicate header names exist: ACCEPT", exception.Message);
+        }
+
+        [Test]
+        public void AddHeaders_NoDuplicatesExist_Has3Headers()
+        {
+            ICollection<KeyValuePair<string, string>> headers = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("Accept", "application/json"),
+                new KeyValuePair<string, string>("Accept-Language", "en-us,en;q=0.5"),
+                new KeyValuePair<string, string>("Keep-Alive", "300")
+            };
+
+            RestRequest request = new RestRequest();
+            request.AddHeaders(headers);
+
+            IEnumerable<Parameter> httpParameters = request.Parameters.Where(parameter => parameter.Type == ParameterType.HttpHeader);
+
+            Assert.AreEqual(3, httpParameters.Count());
+        }
+
+        [Test]
+        public void AddHeaders_NoDuplicatesExistUsingDictionary_Has3Headers()
+        {
+            Dictionary<string, string> headers = new Dictionary<string, string>()
+            {
+                { "Accept", "application/json" },
+                { "Accept-Language", "en-us,en;q=0.5" },
+                { "Keep-Alive", "300" }
+            };
+
+            RestRequest request = new RestRequest();
+            request.AddHeaders(headers);
+
+            IEnumerable<Parameter> httpParameters = request.Parameters.Where(parameter => parameter.Type == ParameterType.HttpHeader);
+
+            Assert.AreEqual(3, httpParameters.Count());
+        }
     }
 }

--- a/RestSharp.Tests/RequestHeaderTests.cs
+++ b/RestSharp.Tests/RequestHeaderTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace RestSharp.Tests
+{
+    public class RequestHeaderTests
+    {
+        [Test]
+        public void AddHeaders_SameCaseDuplicatesExist_ThrowsException()
+        {
+            ICollection<KeyValuePair<string, string>> headers = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("Accept", "application/json"),
+                new KeyValuePair<string, string>("Accept-Language", "en-us,en;q=0.5"),
+                new KeyValuePair<string, string>("Keep-Alive", "300"),
+                new KeyValuePair<string, string>("Accept", "application/json")
+            };
+
+            RestRequest request = new RestRequest();
+
+            ArgumentException exception = Assert.Throws<ArgumentException>(() => request.AddHeaders(headers));
+            Assert.AreEqual("Duplicate header names exist: ACCEPT", exception.Message);
+        }
+    }
+}

--- a/RestSharp/IRestRequest.cs
+++ b/RestSharp/IRestRequest.cs
@@ -336,6 +336,14 @@ namespace RestSharp
         /// <param name="value">Value of the header to add</param>
         /// <returns></returns>
         IRestRequest AddHeader(string name, string value);
+        
+        /// <summary>
+        /// Uses AddHeader(name, value) in a convenient way to pass
+        /// in multiple headers at once.
+        /// </summary>
+        /// <param name="headers">Key/Value pairs containing the name: value of the headers</param>
+        /// <returns>This request</returns>
+        IRestRequest AddHeaders(ICollection<KeyValuePair<string, string>> headers);
 
         /// <summary>
         /// Shortcut to AddParameter(name, value, Cookie) overload

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -552,6 +552,30 @@ namespace RestSharp
                 throw new ArgumentException("The specified value is not a valid Host header string.", nameof(value));
             return AddParameter(name, value, ParameterType.HttpHeader);
         }
+        
+        /// <summary>
+        /// Uses AddHeader(name, value) in a convenient way to pass
+        /// in multiple headers at once.
+        /// </summary>
+        /// <param name="headers">Key/Value pairs containing the name: value of the headers</param>
+        /// <returns>This request</returns>
+        public IRestRequest AddHeaders(ICollection<KeyValuePair<string, string>> headers)
+        {
+            var duplicateKeys = headers
+                .GroupBy(pair => pair.Key.ToUpperInvariant())
+                .Where(group => group.Count() > 1)
+                .Select(group => group.Key);
+
+            if (duplicateKeys.Count() > 0)
+                throw new ArgumentException($"Duplicate header names exist: {string.Join(", ", duplicateKeys)}");
+
+            foreach (var pair in headers)
+            {
+                AddHeader(pair.Key, pair.Value);
+            }
+
+            return this;
+        }
 
         /// <inheritdoc />
         /// <summary>


### PR DESCRIPTION
## Description

I've implemented a simple utility feature to take a KeyValuePair collection (Dictionary, etc.) and add headers to the RestRequest from the given collection.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
