### PR TITLE
throws an exception if pass an url as Uri class in RestRequest and do a request

### DIFF
--- a/RestSharp.Tests/RestClientTests.cs
+++ b/RestSharp.Tests/RestClientTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 
 namespace RestSharp.Tests
 {
@@ -33,6 +34,38 @@ namespace RestSharp.Tests
 
             Assert.DoesNotThrow(() => client.Execute(req));
             Assert.IsNull(client.Proxy);
-        }        
+        }
+        
+        [Test]
+        public void BuildUri_should_build_with_passing_link_as_Uri()
+        {
+            // arrange
+            var relative = new Uri("/foo/bar/baz", UriKind.Relative);
+            var absoluteUri = new Uri(new Uri(BASE_URL), relative);
+            var req = new RestRequest(absoluteUri);
+            
+            // act
+            var client = new RestClient();
+            var builtUri = client.BuildUri(req);
+            
+            // assert
+            Assert.AreEqual(absoluteUri, builtUri);
+        }
+        
+        [Test]
+        public void BuildUri_should_build_with_passing_link_as_Uri_with_set_BaseUrl()
+        {
+            // arrange
+            var baseUrl = new Uri(BASE_URL);
+            var relative = new Uri("/foo/bar/baz", UriKind.Relative);
+            var req = new RestRequest(relative);
+            
+            // act
+            var client = new RestClient(baseUrl);
+            var builtUri = client.BuildUri(req);
+            
+            // assert
+            Assert.AreEqual(new Uri(baseUrl, relative), builtUri);
+        }
     }
 }

--- a/RestSharp/RestRequest.cs
+++ b/RestSharp/RestRequest.cs
@@ -103,7 +103,7 @@ namespace RestSharp
 
         public RestRequest(Uri resource, Method method, DataFormat dataFormat)
             : this(resource.IsAbsoluteUri
-                ? resource.AbsolutePath + resource.Query
+                ? resource.AbsoluteUri
                 : resource.OriginalString, method, dataFormat)
         {
         }


### PR DESCRIPTION

## Description
Got an error when i am trying to do a request with passing url as Uri
"Request resource doesn't contain a valid scheme for an empty client base URL".
if i pass url as a string it works well.

i created some tests to show the problem

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)