### PR TITLE
Ignore Empty Uri Query Parameters

### DIFF
--- a/src/RestSharp/RestRequest.cs
+++ b/src/RestSharp/RestRequest.cs
@@ -88,7 +88,7 @@ namespace RestSharp
             }
 
             static IEnumerable<NameValuePair> ParseQuery(string query)
-                => query.Split('&')
+                => query.Split(new char[] { '&' }, StringSplitOptions.RemoveEmptyEntries)
                     .Select(
                         x =>
                         {


### PR DESCRIPTION
## Description

A different attempt at fixing #1404 then what was proposed in #1408.
But even this is not a perfect solution, as explained in https://github.com/restsharp/RestSharp/pull/1408#issuecomment-575213217 and https://github.com/restsharp/RestSharp/pull/1408#issuecomment-575596890.

Someone with more knowhow should probably rewrite the entire [`ParseQuery(string)`](https://github.com/restsharp/RestSharp/blob/master/src/RestSharp/RestRequest.cs#L83) method. Or even better find a more standard way of doing it that doesn't require us to maintain the function ourselves.

For a good idea about how the query parsing should handle can be seen in this little article: https://zzzzbov.com/blag/query-string-hell

## Purpose
This pull request is a: Bugfix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
