### PR TITLE
Use random value for multipart/form-data boundary.

### DIFF
--- a/src/RestSharp/Http.cs
+++ b/src/RestSharp/Http.cs
@@ -34,7 +34,7 @@ namespace RestSharp
     {
         const string LineBreak = "\r\n";
 
-        const string FormBoundary = "-----------------------------28947758029299";
+        public string FormBoundary { get; } = "---------" + Guid.NewGuid().ToString().ToUpper();
 
         static readonly Regex AddRangeRegex = new Regex("(\\w+)=(\\d+)-(\\d+)$");
 
@@ -234,7 +234,7 @@ namespace RestSharp
 
         static HttpWebRequest CreateRequest(Uri uri) => (HttpWebRequest) WebRequest.Create(uri);
 
-        static string GetMultipartFileHeader(HttpFile file)
+        string GetMultipartFileHeader(HttpFile file)
             => $"--{FormBoundary}{LineBreak}Content-Disposition: form-data; name=\"{file.Name}\";" +
                 $" filename=\"{file.FileName}\"{LineBreak}"                                        +
                 $"Content-Type: {file.ContentType ?? "application/octet-stream"}{LineBreak}{LineBreak}";
@@ -248,7 +248,7 @@ namespace RestSharp
             return string.Format(format, FormBoundary, param.Name, param.Value, LineBreak, param.ContentType);
         }
 
-        static string GetMultipartFooter() => $"--{FormBoundary}--{LineBreak}";
+        string GetMultipartFooter() => $"--{FormBoundary}--{LineBreak}";
 
         void PreparePostBody(WebRequest webRequest)
         {
@@ -272,7 +272,7 @@ namespace RestSharp
 
             string EncodeParameters() => string.Join("&", Parameters.Select(p => $"{Encode(p.Name)}={Encode(p.Value)}"));
 
-            static string GetMultipartFormContentType() => $"multipart/form-data; boundary={FormBoundary}";
+            string GetMultipartFormContentType() => $"multipart/form-data; boundary={FormBoundary}";
         }
 
         void WriteMultipartFormData(Stream requestStream)

--- a/src/RestSharp/IHttp.cs
+++ b/src/RestSharp/IHttp.cs
@@ -170,6 +170,11 @@ namespace RestSharp
         string Host { get; set; }
 
         /// <summary>
+        /// Boundary that will be used for multipart/form-data requests
+        /// </summary>
+        string FormBoundary { get; }
+
+        /// <summary>
         /// List of allowed decompression methods
         /// </summary>
         IList<DecompressionMethods> AllowedDecompressionMethods { get; set; }

--- a/test/RestSharp.IntegrationTests/MultipartFormDataTests.cs
+++ b/test/RestSharp.IntegrationTests/MultipartFormDataTests.cs
@@ -24,30 +24,30 @@ namespace RestSharp.IntegrationTests
         const string LineBreak = "\r\n";
 
         readonly string _expected =
-            "-------------------------------28947758029299"               + LineBreak +
+            "--{0}"                                                       + LineBreak +
             "Content-Disposition: form-data; name=\"foo\""                + LineBreak + LineBreak +
             "bar"                                                         + LineBreak +
-            "-------------------------------28947758029299"               + LineBreak +
+            "--{0}"                                                       + LineBreak +
             "Content-Disposition: form-data; name=\"a name with spaces\"" + LineBreak + LineBreak +
             "somedata"                                                    + LineBreak +
-            "-------------------------------28947758029299--"             + LineBreak;
+            "--{0}--"                                                     + LineBreak;
 
         readonly string _expectedFileAndBodyRequestContent =
-            "-------------------------------28947758029299"                                + LineBreak +
+            "--{0}"                                                                        + LineBreak +
             "Content-Type: application/json"                                               + LineBreak +
             "Content-Disposition: form-data; name=\"controlName\""                         + LineBreak + LineBreak +
             "test"                                                                         + LineBreak +
-            "-------------------------------28947758029299"                                + LineBreak +
+            "--{0}"                                                                        + LineBreak +
             "Content-Disposition: form-data; name=\"fileName\"; filename=\"TestFile.txt\"" + LineBreak +
             "Content-Type: application/octet-stream"                                       + LineBreak + LineBreak +
             "This is a test file for RestSharp."                                           + LineBreak +
-            "-------------------------------28947758029299--"                              + LineBreak;
+            "--{0}--"                                                                      + LineBreak;
 
         readonly string _expectedDefaultMultipartContentType =
-            "multipart/form-data; boundary=-----------------------------28947758029299";
+            "multipart/form-data; boundary={0}";
 
         readonly string _expectedCustomMultipartContentType =
-            "multipart/vnd.resteasy+form-data; boundary=-----------------------------28947758029299";
+            "multipart/vnd.resteasy+form-data; boundary={0}";
 
         SimpleServer _server;
         RestClient   _client;
@@ -139,9 +139,14 @@ namespace RestSharp.IntegrationTests
 
             AddParameters(request);
 
+            string boundary = null;
+            request.OnBeforeRequest += http => boundary = http.FormBoundary;
+
             var response = _client.Execute(request);
 
-            Assert.AreEqual(_expected, response.Content);
+            var expected = string.Format(_expected, boundary);
+
+            Assert.AreEqual(expected, response.Content);
         }
 
         [Test]
@@ -154,10 +159,16 @@ namespace RestSharp.IntegrationTests
 
             request.AddParameter("controlName", "test", "application/json", ParameterType.RequestBody);
 
+            string boundary = null;
+            request.OnBeforeRequest += http => boundary = http.FormBoundary;
+
             var response = _client.Execute(request);
 
-            Assert.AreEqual(_expectedFileAndBodyRequestContent, response.Content);
-            Assert.AreEqual(_expectedDefaultMultipartContentType, RequestHandler.CapturedContentType);
+            var expectedFileAndBodyRequestContent = string.Format(_expectedFileAndBodyRequestContent, boundary);
+            var expectedDefaultMultipartContentType= string.Format(_expectedDefaultMultipartContentType, boundary);
+
+            Assert.AreEqual(expectedFileAndBodyRequestContent, response.Content);
+            Assert.AreEqual(expectedDefaultMultipartContentType, RequestHandler.CapturedContentType);
         }
 
         [Test]
@@ -173,10 +184,16 @@ namespace RestSharp.IntegrationTests
 
             request.AddParameter("controlName", "test", "application/json", ParameterType.RequestBody);
 
+            string boundary = null;
+            request.OnBeforeRequest += http => boundary = http.FormBoundary;
+
             var response = _client.Execute(request);
 
-            Assert.AreEqual(_expectedFileAndBodyRequestContent, response.Content);
-            Assert.AreEqual(_expectedCustomMultipartContentType, RequestHandler.CapturedContentType);
+            var expectedFileAndBodyRequestContent = string.Format(_expectedFileAndBodyRequestContent, boundary);
+            var expectedCustomMultipartContentType= string.Format(_expectedCustomMultipartContentType, boundary);
+
+            Assert.AreEqual(expectedFileAndBodyRequestContent, response.Content);
+            Assert.AreEqual(expectedCustomMultipartContentType, RequestHandler.CapturedContentType);
         }
 
         [Test]
@@ -192,9 +209,14 @@ namespace RestSharp.IntegrationTests
 
             request.AddParameter("controlName", "test", "application/json", ParameterType.RequestBody);
 
+            string boundary = null;
+            request.OnBeforeRequest += http => boundary = http.FormBoundary;
+
             var response = _client.Execute(request);
 
-            Assert.AreEqual(_expectedFileAndBodyRequestContent, response.Content);
+            var expectedFileAndBodyRequestContent = string.Format(_expectedFileAndBodyRequestContent, boundary);
+
+            Assert.AreEqual(expectedFileAndBodyRequestContent, response.Content);
         }
 
         [Test]
@@ -210,8 +232,14 @@ namespace RestSharp.IntegrationTests
 
             request.AddParameter("controlName", "test", "application/json", ParameterType.RequestBody);
 
+            string boundary = null;
+            request.OnBeforeRequest += http => boundary = http.FormBoundary;
+
             var response = await _client.ExecuteAsync(request);
-            Assert.AreEqual(_expectedFileAndBodyRequestContent, response.Content);
+
+            var expectedFileAndBodyRequestContent = string.Format(_expectedFileAndBodyRequestContent, boundary);
+
+            Assert.AreEqual(expectedFileAndBodyRequestContent, response.Content);
         }
 
         [Test]
@@ -224,11 +252,17 @@ namespace RestSharp.IntegrationTests
 
             AddParameters(request);
 
+            string boundary = null;
+
+            var expected = string.Format(_expected, boundary);
+
+            request.OnBeforeRequest += http => boundary = http.FormBoundary;
+
             _client.ExecuteAsync(
                 request, (restResponse, handle) =>
                 {
                     Console.WriteLine(restResponse.Content);
-                    Assert.AreEqual(_expected, restResponse.Content);
+                    Assert.AreEqual(expected, restResponse.Content);
                 }
             );
         }

--- a/test/RestSharp.IntegrationTests/RequestBodyTests.cs
+++ b/test/RestSharp.IntegrationTests/RequestBodyTests.cs
@@ -175,7 +175,7 @@ namespace RestSharp.IntegrationTests
         [Test]
         public void MultipartFormData_Without_File_Creates_A_Valid_RequestBody()
         {
-            const string expectedFormBoundary = "-------------------------------28947758029299";
+            string expectedFormBoundary = null;
 
             var client = new RestClient(_server.Url);
 
@@ -183,6 +183,7 @@ namespace RestSharp.IntegrationTests
             {
                 AlwaysMultipartFormData = true
             };
+            request.OnBeforeRequest += http => expectedFormBoundary = http.FormBoundary;
 
             const string contentType   = "text/plain";
             const string bodyData      = "abc123 foo bar baz BING!";
@@ -192,7 +193,7 @@ namespace RestSharp.IntegrationTests
 
             client.Execute(request);
 
-            var expectedBody = expectedFormBoundary +
+            var expectedBody = "--" + expectedFormBoundary +
                 NewLine
                 + "Content-Type: " +
                 contentType
@@ -202,7 +203,7 @@ namespace RestSharp.IntegrationTests
                 + NewLine
                 + bodyData
                 + NewLine
-                + expectedFormBoundary + "--"
+                + "--" + expectedFormBoundary + "--"
                 + NewLine;
 
             Assert.AreEqual(


### PR DESCRIPTION
## Description

The request body might contain the previous, fixed value for FormBoundary.
This will cause a server to split the body on the wrong boundaries.

For example trying to post this file which already contains a boundary will generate an invalid request.

`-------------------------------28947758029299
Content-Disposition: form-data; name="somefile_REC.pdf"; filename="somefile_REC.pdf"
Content-Type: application/x-gzip

%PDF-1.4
[...] truncated
%%EOF

-------------------------------28947758029299--
`

By using a random value for the boundary collisions like this will be avoided.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
