### PR TITLE
Ensure culture is used everywhere where it is appropriate

### DIFF
--- a/src/RestSharp/Authenticators/OAuth/Extensions/OAuthExtensions.cs
+++ b/src/RestSharp/Authenticators/OAuth/Extensions/OAuthExtensions.cs
@@ -22,7 +22,7 @@ namespace RestSharp.Authenticators.OAuth.Extensions
     {
         public static string ToRequestValue(this OAuthSignatureMethod signatureMethod)
         {
-            var value    = signatureMethod.ToString().ToUpper();
+            var value    = signatureMethod.ToString().ToUpperInvariant();
             var shaIndex = value.IndexOf("SHA", StringComparison.Ordinal);
 
             return shaIndex > -1 ? value.Insert(shaIndex, "-") : value;

--- a/src/RestSharp/Extensions/ReflectionExtensions.cs
+++ b/src/RestSharp/Extensions/ReflectionExtensions.cs
@@ -62,7 +62,7 @@ namespace RestSharp.Extensions
             return false;
         }
 
-        internal static object ChangeType(this object source, Type newType) => Convert.ChangeType(source, newType);
+        internal static object ChangeType(this object source, Type newType, CultureInfo culture) => Convert.ChangeType(source, newType, culture);
 
         /// <summary>
         /// Find a value from a System.Enum by trying several possible variants

--- a/src/RestSharp/Extensions/StringExtensions.cs
+++ b/src/RestSharp/Extensions/StringExtensions.cs
@@ -172,7 +172,7 @@ namespace RestSharp.Extensions
 
             var matches = regex.Matches(input);
             var match   = matches[0];
-            var ms      = Convert.ToInt64(match.Groups[1].Value);
+            var ms      = Convert.ToInt64(match.Groups[1].Value, culture);
             var epoch   = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
             dt = epoch.AddMilliseconds(ms);
@@ -236,14 +236,15 @@ namespace RestSharp.Extensions
         /// <param name="culture"></param>
         /// <returns>String</returns>
         public static string ToCamelCase(this string lowercaseAndUnderscoredWord, CultureInfo culture)
-            => MakeInitialLowerCase(ToPascalCase(lowercaseAndUnderscoredWord, culture));
+            => MakeInitialLowerCase(ToPascalCase(lowercaseAndUnderscoredWord, culture), culture);
 
         /// <summary>
         /// Convert the first letter of a string to lower case
         /// </summary>
         /// <param name="word">String to convert</param>
+        /// <param name="culture"></param>
         /// <returns>string</returns>
-        public static string MakeInitialLowerCase(this string word) => string.Concat(word.Substring(0, 1).ToLower(), word.Substring(1));
+        public static string MakeInitialLowerCase(this string word, CultureInfo culture) => string.Concat(word.Substring(0, 1).ToLower(culture), word.Substring(1));
 
         /// <summary>
         /// Add underscores to a pascal-cased string

--- a/src/RestSharp/Http.cs
+++ b/src/RestSharp/Http.cs
@@ -1,4 +1,4 @@
-﻿//   Copyright © 2009-2020 John Sheehan, Andrew Young, Alexey Zimarev and RestSharp community
+//   Copyright © 2009-2020 John Sheehan, Andrew Young, Alexey Zimarev and RestSharp community
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ namespace RestSharp
     {
         const string LineBreak = "\r\n";
 
-        public string FormBoundary { get; } = "---------" + Guid.NewGuid().ToString().ToUpper();
+        public string FormBoundary { get; } = "---------" + Guid.NewGuid().ToString().ToUpperInvariant();
 
         static readonly Regex AddRangeRegex = new Regex("(\\w+)=(\\d+)-(\\d+)$");
 
@@ -50,8 +50,8 @@ namespace RestSharp
 
             void AddSyncHeaderActions()
             {
-                _restrictedHeaderActions.Add("Connection", (r, v) => { r.KeepAlive = v.ToLower().Contains("keep-alive"); });
-                _restrictedHeaderActions.Add("Content-Length", (r, v) => r.ContentLength = Convert.ToInt64(v));
+                _restrictedHeaderActions.Add("Connection", (r, v) => { r.KeepAlive = v.ToLowerInvariant().Contains("keep-alive"); });
+                _restrictedHeaderActions.Add("Content-Length", (r, v) => r.ContentLength = Convert.ToInt64(v, NumberFormatInfo.InvariantInfo));
                 _restrictedHeaderActions.Add("Expect", (r, v) => r.Expect                = v);
 
                 _restrictedHeaderActions.Add(
@@ -95,8 +95,8 @@ namespace RestSharp
                     if (!m.Success) return;
 
                     var rangeSpecifier = m.Groups[1].Value;
-                    var from           = Convert.ToInt64(m.Groups[2].Value);
-                    var to             = Convert.ToInt64(m.Groups[3].Value);
+                    var from           = Convert.ToInt64(m.Groups[2].Value, NumberFormatInfo.InvariantInfo);
+                    var to             = Convert.ToInt64(m.Groups[3].Value, NumberFormatInfo.InvariantInfo);
 
                     r.AddRange(rangeSpecifier, from, to);
                 }
@@ -245,7 +245,7 @@ namespace RestSharp
                 ? "--{0}{3}Content-Type: {4}{3}Content-Disposition: form-data; name=\"{1}\"{3}{3}{2}{3}"
                 : "--{0}{3}Content-Disposition: form-data; name=\"{1}\"{3}{3}{2}{3}";
 
-            return string.Format(format, FormBoundary, param.Name, param.Value, LineBreak, param.ContentType);
+            return string.Format(CultureInfo.InvariantCulture, format, FormBoundary, param.Name, param.Value, LineBreak, param.ContentType);
         }
 
         string GetMultipartFooter() => $"--{FormBoundary}--{LineBreak}";

--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -267,7 +267,7 @@ namespace RestSharp
 
         void DoBuildUriValidations(IRestRequest request)
         {
-            if (BaseUrl == null && !request.Resource.ToLower().StartsWith("http"))
+            if (BaseUrl == null && !request.Resource.StartsWith("http", StringComparison.OrdinalIgnoreCase))
                 throw new ArgumentOutOfRangeException(
                     nameof(request),
                     "Request resource doesn't contain a valid scheme for an empty client base URL"

--- a/src/RestSharp/Serializers/Json/JsonSerializer.cs
+++ b/src/RestSharp/Serializers/Json/JsonSerializer.cs
@@ -236,7 +236,7 @@ namespace RestSharp.Serialization.Json
             }
 
             var type = typeInfo.AsType();
-            if (typeInfo.IsPrimitive) return value.ChangeType(type);
+            if (typeInfo.IsPrimitive) return value.ChangeType(type, Culture);
 
             if (typeInfo.IsEnum) return type.FindEnumValue(stringValue, Culture);
 

--- a/src/RestSharp/Serializers/SerializeAsAttribute.cs
+++ b/src/RestSharp/Serializers/SerializeAsAttribute.cs
@@ -1,4 +1,4 @@
-﻿//   Copyright © 2009-2020 John Sheehan, Andrew Young, Alexey Zimarev and RestSharp community
+//   Copyright © 2009-2020 John Sheehan, Andrew Young, Alexey Zimarev and RestSharp community
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ namespace RestSharp.Serializers
             {
                 NameStyle.CamelCase  => name.ToCamelCase(Culture),
                 NameStyle.PascalCase => name.ToPascalCase(Culture),
-                NameStyle.LowerCase  => name.ToLower(),
+                NameStyle.LowerCase  => name.ToLower(Culture),
                 _                    => input
             };
         }

--- a/src/RestSharp/Serializers/Xml/XmlDeserializer.cs
+++ b/src/RestSharp/Serializers/Xml/XmlDeserializer.cs
@@ -182,7 +182,7 @@ namespace RestSharp.Deserializers
                 if (asType == typeof(bool))
                 {
                     var toConvert = value.ToString()
-                        .ToLower();
+                        .ToLower(Culture);
 
                     prop.SetValue(x, XmlConvert.ToBoolean(toConvert), null);
                 }
@@ -190,7 +190,7 @@ namespace RestSharp.Deserializers
                 {
                     try
                     {
-                        prop.SetValue(x, value.ChangeType(asType), null);
+                        prop.SetValue(x, value.ChangeType(asType, Culture), null);
                     }
                     catch (FormatException ex)
                     {
@@ -245,7 +245,7 @@ namespace RestSharp.Deserializers
                         else
                         {
                             //fallback to parse
-                            deserialisedValue = DateTimeOffset.Parse(toConvert);
+                            deserialisedValue = DateTimeOffset.Parse(toConvert, Culture);
                             prop.SetValue(x, deserialisedValue, null);
                         }
                     }
@@ -366,7 +366,7 @@ namespace RestSharp.Deserializers
 
             if (!elements.Any())
             {
-                var lowerName = name.ToLower().AsNamespaced(Namespace);
+                var lowerName = name.ToLower(Culture).AsNamespaced(Namespace);
 
                 elements = root.Descendants(lowerName).ToList();
             }
@@ -385,7 +385,7 @@ namespace RestSharp.Deserializers
 
             if (!elements.Any())
             {
-                var lowerName = name.ToLower().AsNamespaced(Namespace);
+                var lowerName = name.ToLower(Culture).AsNamespaced(Namespace);
 
                 elements = root.Descendants()
                     .Where(e => e.Name.LocalName.RemoveUnderscoresAndDashes() == lowerName)
@@ -412,7 +412,7 @@ namespace RestSharp.Deserializers
             }
             else if (t.GetTypeInfo().IsPrimitive)
             {
-                item = element.Value.ChangeType(t);
+                item = element.Value.ChangeType(t, Culture);
             }
             else
             {
@@ -448,7 +448,7 @@ namespace RestSharp.Deserializers
 
         protected virtual XElement GetElementByName(XElement root, XName name)
         {
-            var lowerName = name.LocalName.ToLower().AsNamespaced(name.NamespaceName);
+            var lowerName = name.LocalName.ToLower(Culture).AsNamespaced(name.NamespaceName);
             var camelName = name.LocalName.ToCamelCase(Culture).AsNamespaced(name.NamespaceName);
 
             if (root.Element(name) != null)
@@ -487,7 +487,7 @@ namespace RestSharp.Deserializers
                 : new List<XName>
                 {
                     name.LocalName,
-                    name.LocalName.ToLower()
+                    name.LocalName.ToLower(Culture)
                         .AsNamespaced(name.NamespaceName),
                     name.LocalName.ToCamelCase(Culture)
                         .AsNamespaced(name.NamespaceName)


### PR DESCRIPTION
## Description

The serializers already have support for setting a culture, but it is not used everywhere. This pull request simply ensures that the culture is forwarded to all ToString() and Convert.ToXXX() method.

There are also minor changes elsewhere with the same issues. See [Microsoft's best practices on strings](https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings) regarding the use of ToUpper/ToLower and ordinal comparisons.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
