### PR TITLE
Update JsonNetSerializer.cs

### DIFF
--- a/src/RestSharp.Serializers.NewtonsoftJson/JsonNetSerializer.cs
+++ b/src/RestSharp.Serializers.NewtonsoftJson/JsonNetSerializer.cs
@@ -18,7 +18,7 @@ namespace RestSharp.Serializers.NewtonsoftJson
         /// </summary>
         public static readonly JsonSerializerSettings DefaultSettings = new JsonSerializerSettings
         {
-            ContractResolver     = new CamelCasePropertyNamesContractResolver(),
+            ContractResolver     = new DefaultContractResolver(),
             DefaultValueHandling = DefaultValueHandling.Include,
             TypeNameHandling     = TypeNameHandling.None,
             NullValueHandling    = NullValueHandling.Ignore,


### PR DESCRIPTION
This should not default to a non-standard contract resolver that ignores standard newtonsoft JSON.net attributes and causes much  confusion with many APIs where case matters.

The DefaultSettings should initialize with the DefaultContractResolver

## Description

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
This is a breaking change if someone used the library and instead of realizing the non-standard resolver is defaulted, adjusted their business process instead

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
