### PR TITLE
Fix culture

### DIFF
--- a/src/RestSharp/Extensions/StringExtensions.cs
+++ b/src/RestSharp/Extensions/StringExtensions.cs
@@ -242,6 +242,7 @@ namespace RestSharp.Extensions
         /// Convert the first letter of a string to lower case
         /// </summary>
         /// <param name="word">String to convert</param>
+        /// <param name="culture"></param>
         /// <returns>string</returns>
         public static string MakeInitialLowerCase(this string word, CultureInfo culture) => string.Concat(word.Substring(0, 1).ToLower(culture), word.Substring(1));
 

--- a/src/RestSharp/Extensions/StringExtensions.cs
+++ b/src/RestSharp/Extensions/StringExtensions.cs
@@ -236,14 +236,14 @@ namespace RestSharp.Extensions
         /// <param name="culture"></param>
         /// <returns>String</returns>
         public static string ToCamelCase(this string lowercaseAndUnderscoredWord, CultureInfo culture)
-            => MakeInitialLowerCase(ToPascalCase(lowercaseAndUnderscoredWord, culture));
+            => MakeInitialLowerCase(ToPascalCase(lowercaseAndUnderscoredWord, culture), culture);
 
         /// <summary>
         /// Convert the first letter of a string to lower case
         /// </summary>
         /// <param name="word">String to convert</param>
         /// <returns>string</returns>
-        public static string MakeInitialLowerCase(this string word) => string.Concat(word.Substring(0, 1).ToLower(), word.Substring(1));
+        public static string MakeInitialLowerCase(this string word, CultureInfo culture) => string.Concat(word.Substring(0, 1).ToLower(culture), word.Substring(1));
 
         /// <summary>
         /// Add underscores to a pascal-cased string


### PR DESCRIPTION
## Description

Use given culture when call `.ToLower`

The function `MakeInitialLowerCase` have breaking change. We can decide to use `CultureInfo.InvariantCulture` as default fallback.

Fix for Issue: https://github.com/restsharp/RestSharp/issues/1491

## Purpose
This pull request is a:

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
