### PR TITLE
Ensure the correct culture is used

### DIFF
--- a/src/RestSharp/Authenticators/OAuth/Extensions/OAuthExtensions.cs
+++ b/src/RestSharp/Authenticators/OAuth/Extensions/OAuthExtensions.cs
@@ -22,7 +22,7 @@ namespace RestSharp.Authenticators.OAuth.Extensions
     {
         public static string ToRequestValue(this OAuthSignatureMethod signatureMethod)
         {
-            var value    = signatureMethod.ToString().ToUpper();
+            var value    = signatureMethod.ToString().ToUpperInvariant();
             var shaIndex = value.IndexOf("SHA", StringComparison.Ordinal);
 
             return shaIndex > -1 ? value.Insert(shaIndex, "-") : value;

--- a/src/RestSharp/Authenticators/OAuth/OAuthTools.cs
+++ b/src/RestSharp/Authenticators/OAuth/OAuthTools.cs
@@ -191,7 +191,7 @@ namespace RestSharp.Authenticators.OAuth
         public static string ConcatenateRequestElements(string method, string url, WebPairCollection parameters)
         {
             // Separating &'s are not URL encoded
-            var requestMethod     = method.ToUpper().Then("&");
+            var requestMethod     = method.ToUpperInvariant().Then("&");
             var requestUrl        = UrlEncodeRelaxed(ConstructRequestUrl(url.AsUri())).Then("&");
             var requestParameters = UrlEncodeRelaxed(NormalizeRequestParameters(parameters));
 

--- a/src/RestSharp/Http.cs
+++ b/src/RestSharp/Http.cs
@@ -36,7 +36,7 @@ namespace RestSharp
     {
         const string LineBreak = "\r\n";
 
-        public string FormBoundary { get; } = "---------" + Guid.NewGuid().ToString().ToUpper();
+        public string FormBoundary { get; } = "---------" + Guid.NewGuid().ToString().ToUpperInvariant();
 
         // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
         static readonly Regex AddRangeRegex = new Regex("(\\w+)=(\\d+)-(\\d+)$");
@@ -53,7 +53,7 @@ namespace RestSharp
 
             void AddSyncHeaderActions()
             {
-                _restrictedHeaderActions.Add("Connection", (r, v) => { r.KeepAlive = v.ToLower().Contains("keep-alive"); });
+                _restrictedHeaderActions.Add("Connection", (r, v) => { r.KeepAlive = v.ToLowerInvariant().Contains("keep-alive"); });
                 _restrictedHeaderActions.Add("Content-Length", (r, v) => r.ContentLength = Convert.ToInt64(v));
                 _restrictedHeaderActions.Add("Expect", (r, v) => r.Expect                = v);
 

--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -268,7 +268,7 @@ namespace RestSharp
 
         void DoBuildUriValidations(IRestRequest request)
         {
-            if (BaseUrl == null && !request.Resource.ToLower().StartsWith("http"))
+            if (BaseUrl == null && !request.Resource.ToLowerInvariant().StartsWith("http"))
                 throw new ArgumentOutOfRangeException(
                     nameof(request),
                     "Request resource doesn't contain a valid scheme for an empty client base URL"
@@ -547,8 +547,8 @@ namespace RestSharp
                 response = raw.ToAsyncResponse<T>();
 
                 // Only attempt to deserialize if the request has not errored due
-                // to a transport or framework exception.  HTTP errors should attempt to 
-                // be deserialized 
+                // to a transport or framework exception.  HTTP errors should attempt to
+                // be deserialized
                 if (response.ErrorException == null)
                 {
                     var func    = GetHandler(raw.ContentType);

--- a/src/RestSharp/Serializers/SerializeAsAttribute.cs
+++ b/src/RestSharp/Serializers/SerializeAsAttribute.cs
@@ -76,7 +76,7 @@ namespace RestSharp.Serializers
             {
                 NameStyle.CamelCase  => name.ToCamelCase(Culture),
                 NameStyle.PascalCase => name.ToPascalCase(Culture),
-                NameStyle.LowerCase  => name.ToLower(),
+                NameStyle.LowerCase  => name.ToLower(Culture),
                 _                    => input
             };
         }

--- a/src/RestSharp/Serializers/Xml/XmlDeserializer.cs
+++ b/src/RestSharp/Serializers/Xml/XmlDeserializer.cs
@@ -182,7 +182,7 @@ namespace RestSharp.Deserializers
                 if (asType == typeof(bool))
                 {
                     var toConvert = value.ToString()
-                        .ToLower();
+                        .ToLower(Culture);
 
                     prop.SetValue(x, XmlConvert.ToBoolean(toConvert), null);
                 }
@@ -366,7 +366,7 @@ namespace RestSharp.Deserializers
 
             if (!elements.Any())
             {
-                var lowerName = name.ToLower().AsNamespaced(Namespace);
+                var lowerName = name.ToLower(Culture).AsNamespaced(Namespace);
 
                 elements = root.Descendants(lowerName).ToList();
             }
@@ -385,7 +385,7 @@ namespace RestSharp.Deserializers
 
             if (!elements.Any())
             {
-                var lowerName = name.ToLower().AsNamespaced(Namespace);
+                var lowerName = name.ToLower(Culture).AsNamespaced(Namespace);
 
                 elements = root.Descendants()
                     .Where(e => e.Name.LocalName.RemoveUnderscoresAndDashes() == lowerName)
@@ -448,7 +448,7 @@ namespace RestSharp.Deserializers
 
         protected virtual XElement GetElementByName(XElement root, XName name)
         {
-            var lowerName = name.LocalName.ToLower().AsNamespaced(name.NamespaceName);
+            var lowerName = name.LocalName.ToLower(Culture).AsNamespaced(name.NamespaceName);
             var camelName = name.LocalName.ToCamelCase(Culture).AsNamespaced(name.NamespaceName);
 
             if (root.Element(name) != null)
@@ -487,7 +487,7 @@ namespace RestSharp.Deserializers
                 : new List<XName>
                 {
                     name.LocalName,
-                    name.LocalName.ToLower()
+                    name.LocalName.ToLower(Culture)
                         .AsNamespaced(name.NamespaceName),
                     name.LocalName.ToCamelCase(Culture)
                         .AsNamespaced(name.NamespaceName)


### PR DESCRIPTION
## Description

In reference to #1472 and #1492 I found some more code places where no culture is used.

e.g. `XMLSerializer` contains a `CultureInfo`. This will should be used for all `.ToLower()` calls.
e.g. `Http` contains no `CultureInfo`. I have changed `.ToLower()` to `.ToLowerInvariant()`.

## Purpose
This pull request is a:

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
