### PR TITLE
Encode oauth_token. Fixes #1495

### DIFF
--- a/src/RestSharp/Authenticators/OAuth/OAuthWorkflow.cs
+++ b/src/RestSharp/Authenticators/OAuth/OAuthWorkflow.cs
@@ -10,7 +10,7 @@
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
-//   limitations under the License. 
+//   limitations under the License.
 
 using System;
 using System.Collections.Generic;
@@ -215,7 +215,7 @@ namespace RestSharp.Authenticators.OAuth
                 new WebPair("oauth_version", Version ?? "1.0")
             };
 
-            if (!Token.IsEmpty()) authParameters.Add(new WebPair("oauth_token", Token));
+            if (!Token.IsEmpty()) authParameters.Add(new WebPair("oauth_token", Token, true));
 
             if (!CallbackUrl.IsEmpty()) authParameters.Add(new WebPair("oauth_callback", CallbackUrl, true));
 

--- a/test/RestSharp.Tests/OAuth1AuthenticatorTests.cs
+++ b/test/RestSharp.Tests/OAuth1AuthenticatorTests.cs
@@ -140,5 +140,31 @@ namespace RestSharp.Tests
                 )
             );
         }
+
+        [Test]
+        [TestCase(OAuthType.AccessToken, "Token", "Token")]
+        [TestCase(OAuthType.ProtectedResource, "Token", "Token")]
+        [TestCase(OAuthType.AccessToken, "SVyDD+RsFzSoZChk=", "SVyDD%2BRsFzSoZChk%3D")]
+        [TestCase(OAuthType.ProtectedResource, "SVyDD+RsFzSoZChk=", "SVyDD%2BRsFzSoZChk%3D")]
+        public void Authenticate_ShouldEncodeOAuthTokenParameter(OAuthType type,string value, string expected)
+        {
+            // Arrange
+            const string url = "https://no-query.string";
+
+            var client  = new RestClient(url);
+            var request = new RestRequest();
+            _authenticator.Type  = type;
+            _authenticator.Token = value;
+
+            // Act
+            _authenticator.Authenticate(client, request);
+
+            // Assert
+            var authParameter = request.Parameters.Single(x => x.Name == "Authorization");
+            var authHeader         = (string) authParameter.Value;
+
+            Assert.IsNotNull(authHeader);
+            Assert.IsTrue(authHeader.Contains($"oauth_token=\"{expected}\""));
+        }
     }
 }


### PR DESCRIPTION
## Description
In reference to #1495 
 
According to RFC, the `oauth_token` must be encoded.  Some OAuth providers return token that contains `=` symbol, the current implementation doesn't encode it to %3D.  This PR adding encoding for `oauth_token`.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
