### PR TITLE
fix #1480 - ToCamelCase broken for a single word with multiple upperc…

### DIFF
--- a/src/RestSharp/Extensions/StringExtensions.cs
+++ b/src/RestSharp/Extensions/StringExtensions.cs
@@ -222,8 +222,11 @@ namespace RestSharp.Extensions
 
             string CaseWord(string word)
             {
-                var restOfWord = word.Substring(1).ToLower(culture);
+                var restOfWord = word.Substring(1);
                 var firstChar = char.ToUpper(word[0], culture);
+
+                if (restOfWord.IsUpperCase())
+                    restOfWord = restOfWord.ToLower(culture);
 
                 return string.Concat(firstChar, restOfWord);
             }
@@ -273,6 +276,13 @@ namespace RestSharp.Extensions
                 ),
                 "-"
             );
+
+        /// <summary>
+        ///     Checks to see if a string is all uppper case
+        /// </summary>
+        /// <param name="inputString">String to check</param>
+        /// <returns>bool</returns>
+        public static bool IsUpperCase(this string inputString) => IsUpperCaseRegex.IsMatch(inputString);
 
         /// <summary>
         /// Add an underscore prefix to a pascal-cased string

--- a/test/RestSharp.Tests/StringExtensionsTests.cs
+++ b/test/RestSharp.Tests/StringExtensionsTests.cs
@@ -66,6 +66,14 @@ namespace RestSharp.Tests
             Assert.AreEqual(finish, result);
         }
 
+        [Test, TestCase("DueDate", "dueDate"), TestCase("ID", "id"), TestCase("IDENTIFIER", "identifier"), TestCase("primaryId", "primaryId"), TestCase("A", "a"), TestCase("ThisIsATest", "thisIsATest")]
+        public void ToCamelCase(string start, string finish)
+        {
+            var result = start.ToCamelCase(CultureInfo.InvariantCulture);
+
+            Assert.AreEqual(finish, result);
+        }
+
         [Test]
         public void Does_not_throw_on_invalid_encoding()
         {


### PR DESCRIPTION
## Description

potential fix for #1480 

ToCamelCase() was lowercasing complex words with multiple uppercase characters eg. DueDate would become duedate, rather than dueDate (which it previously did from 106.10.1 and below)

## Purpose
This pull request is a:

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
