### PR TITLE
fix: throw error if ThrowOnAnyError flag is true

### DIFF
--- a/src/RestSharp/Http.Sync.cs
+++ b/src/RestSharp/Http.Sync.cs
@@ -118,6 +118,9 @@ namespace RestSharp
             }
             catch (Exception ex)
             {
+                if (ThrowOnAnyError)
+                    throw;
+
                 return ExtractErrorResponse(ex);
             }
 

--- a/src/RestSharp/Http.cs
+++ b/src/RestSharp/Http.cs
@@ -229,6 +229,8 @@ namespace RestSharp
         /// <inheritdoc />
         public Action<HttpWebRequest>? WebRequestConfigurator { get; set; }
 
+        public bool ThrowOnAnyError { get; set; }
+
         [Obsolete]
         public static IHttp Create() => new Http();
 

--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -421,7 +421,8 @@ namespace RestSharp
                 CookieContainer         = CookieContainer,
                 AutomaticDecompression  = AutomaticDecompression,
                 WebRequestConfigurator  = WebRequestConfigurator,
-                Encode                  = Encode
+                Encode                  = Encode,
+                ThrowOnAnyError         = ThrowOnAnyError,
             };
 
             var requestParameters = new List<Parameter>();

--- a/test/RestSharp.Tests/RestRequestTests.cs
+++ b/test/RestSharp.Tests/RestRequestTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Net;
+using NUnit.Framework;
 
 namespace RestSharp.Tests
 {
@@ -25,6 +26,14 @@ namespace RestSharp.Tests
             Assert.AreEqual("another", request.Parameters[1].Name);
             Assert.AreEqual("notencoded", request.Parameters[1].Value);
             Assert.AreEqual(ParameterType.QueryStringWithoutEncode, request.Parameters[1].Type);
+        }
+
+        [Test]
+        public void RestRequest_Fail_On_Exception()
+        {
+            var req = new RestRequest("nonexisting");
+            var client = new RestClient("http://localhost:12345") { ThrowOnAnyError = true };
+            Assert.Throws<WebException>(() => client.Execute(req));
         }
     }
 }


### PR DESCRIPTION
## Description

fix #1511 

RestClient property ThrowOnAnyError is not work correct becouse all exceptions are handled before this check:
```C#
try
{
    var http = ConfigureHttp(request);
                
    request.OnBeforeRequest?.Invoke(http);

    response = RestResponse.FromHttpResponse(getResponse(http, httpMethod), request);
}
catch (Exception ex)
{
    if (ThrowOnAnyError) throw;
                
    response.ResponseStatus = ResponseStatus.Error;
    response.ErrorMessage   = ex.Message;
    response.ErrorException = ex;
}
```

In getResponse we have:
```C#
catch (Exception ex)
{
    return ExtractErrorResponse(ex);
}
```

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
