### PR TITLE
OAuth1: Allow empty customer secrets, according to the specifications.

### DIFF
--- a/src/RestSharp/Authenticators/OAuth/OAuth1Authenticator.cs
+++ b/src/RestSharp/Authenticators/OAuth/OAuth1Authenticator.cs
@@ -12,15 +12,13 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License. 
 
+using JetBrains.Annotations;
+using RestSharp.Authenticators.OAuth;
+using RestSharp.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Web;
-using JetBrains.Annotations;
-using RestSharp.Authenticators.OAuth;
-using RestSharp.Authenticators.OAuth.Extensions;
-using RestSharp.Extensions;
 
 // ReSharper disable CheckNamespace
 
@@ -42,7 +40,7 @@ namespace RestSharp.Authenticators
 
         internal virtual string ConsumerKey { get; set; }
 
-        internal virtual string ConsumerSecret { get; set; }
+        internal virtual string? ConsumerSecret { get; set; }
 
         internal virtual string Token { get; set; }
 
@@ -84,7 +82,7 @@ namespace RestSharp.Authenticators
 
         public static OAuth1Authenticator ForRequestToken(
             string consumerKey,
-            string consumerSecret,
+            string? consumerSecret,
             OAuthSignatureMethod signatureMethod = OAuthSignatureMethod.HmacSha1
         )
         {
@@ -101,7 +99,7 @@ namespace RestSharp.Authenticators
             return authenticator;
         }
 
-        public static OAuth1Authenticator ForRequestToken(string consumerKey, string consumerSecret, string callbackUrl)
+        public static OAuth1Authenticator ForRequestToken(string consumerKey, string? consumerSecret, string callbackUrl)
         {
             var authenticator = ForRequestToken(consumerKey, consumerSecret);
 
@@ -112,7 +110,7 @@ namespace RestSharp.Authenticators
 
         public static OAuth1Authenticator ForAccessToken(
             string consumerKey,
-            string consumerSecret,
+            string? consumerSecret,
             string token,
             string tokenSecret,
             OAuthSignatureMethod signatureMethod = OAuthSignatureMethod.HmacSha1
@@ -131,7 +129,7 @@ namespace RestSharp.Authenticators
 
         public static OAuth1Authenticator ForAccessToken(
             string consumerKey,
-            string consumerSecret,
+            string? consumerSecret,
             string token,
             string tokenSecret,
             string verifier
@@ -155,7 +153,7 @@ namespace RestSharp.Authenticators
         /// <returns></returns>
         public static OAuth1Authenticator ForAccessTokenRefresh(
             string consumerKey,
-            string consumerSecret,
+            string? consumerSecret,
             string token,
             string tokenSecret,
             string sessionHandle
@@ -180,7 +178,7 @@ namespace RestSharp.Authenticators
         /// <returns></returns>
         public static OAuth1Authenticator ForAccessTokenRefresh(
             string consumerKey,
-            string consumerSecret,
+            string? consumerSecret,
             string token,
             string tokenSecret,
             string verifier,
@@ -206,7 +204,7 @@ namespace RestSharp.Authenticators
         /// <returns></returns>
         public static OAuth1Authenticator ForClientAuthentication(
             string consumerKey,
-            string consumerSecret,
+            string? consumerSecret,
             string username,
             string password,
             OAuthSignatureMethod signatureMethod = OAuthSignatureMethod.HmacSha1
@@ -234,7 +232,7 @@ namespace RestSharp.Authenticators
         /// <returns></returns>
         public static OAuth1Authenticator ForProtectedResource(
             string consumerKey,
-            string consumerSecret,
+            string? consumerSecret,
             string accessToken,
             string accessTokenSecret,
             OAuthSignatureMethod signatureMethod = OAuthSignatureMethod.HmacSha1

--- a/src/RestSharp/Authenticators/OAuth/OAuthTools.cs
+++ b/src/RestSharp/Authenticators/OAuth/OAuthTools.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Security.Cryptography;
 using System.Text;
 using RestSharp.Authenticators.OAuth.Extensions;
@@ -209,7 +208,7 @@ namespace RestSharp.Authenticators.OAuth
         public static string GetSignature(
             OAuthSignatureMethod signatureMethod,
             string signatureBase,
-            string consumerSecret
+            string? consumerSecret
         )
             => GetSignature(signatureMethod, OAuthSignatureTreatment.Escaped, signatureBase, consumerSecret, null);
 
@@ -226,7 +225,7 @@ namespace RestSharp.Authenticators.OAuth
             OAuthSignatureMethod signatureMethod,
             OAuthSignatureTreatment signatureTreatment,
             string signatureBase,
-            string consumerSecret
+            string? consumerSecret
         )
             => GetSignature(signatureMethod, signatureTreatment, signatureBase, consumerSecret, null);
 
@@ -243,14 +242,15 @@ namespace RestSharp.Authenticators.OAuth
             OAuthSignatureMethod signatureMethod,
             OAuthSignatureTreatment signatureTreatment,
             string signatureBase,
-            string consumerSecret,
+            string? consumerSecret,
             string? tokenSecret
         )
         {
-            if (tokenSecret.IsEmpty()) tokenSecret = string.Empty;
+            if (tokenSecret.IsEmpty()) tokenSecret       = string.Empty;
+            if (consumerSecret.IsEmpty()) consumerSecret = string.Empty;
 
-            var unencodedConsumerSecret = consumerSecret;
-            consumerSecret = Uri.EscapeDataString(consumerSecret);
+            var unencodedConsumerSecret = consumerSecret!;
+            consumerSecret = Uri.EscapeDataString(consumerSecret!);
             tokenSecret    = Uri.EscapeDataString(tokenSecret!);
 
             var signature = signatureMethod switch

--- a/src/RestSharp/Authenticators/OAuth/OAuthWorkflow.cs
+++ b/src/RestSharp/Authenticators/OAuth/OAuthWorkflow.cs
@@ -13,7 +13,6 @@
 //   limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using RestSharp.Authenticators.OAuth.Extensions;
@@ -31,7 +30,7 @@ namespace RestSharp.Authenticators.OAuth
 
         public string ConsumerKey { get; set; }
 
-        public string ConsumerSecret { get; set; }
+        public string? ConsumerSecret { get; set; }
 
         public string Token { get; set; }
 
@@ -179,14 +178,12 @@ namespace RestSharp.Authenticators.OAuth
         {
             Ensure.NotEmpty(RequestTokenUrl, nameof(RequestTokenUrl));
             Ensure.NotEmpty(ConsumerKey, nameof(ConsumerKey));
-            Ensure.NotEmpty(ConsumerSecret, nameof(ConsumerSecret));
         }
 
         void ValidateAccessRequestState()
         {
             Ensure.NotEmpty(AccessTokenUrl, nameof(AccessTokenUrl));
             Ensure.NotEmpty(ConsumerKey, nameof(ConsumerKey));
-            Ensure.NotEmpty(ConsumerSecret, nameof(ConsumerSecret));
             Ensure.NotEmpty(Token, nameof(Token));
         }
 
@@ -194,14 +191,12 @@ namespace RestSharp.Authenticators.OAuth
         {
             Ensure.NotEmpty(AccessTokenUrl, nameof(AccessTokenUrl));
             Ensure.NotEmpty(ConsumerKey, nameof(ConsumerKey));
-            Ensure.NotEmpty(ConsumerSecret, nameof(ConsumerSecret));
             Ensure.NotEmpty(ClientUsername, nameof(ClientUsername));
         }
 
         void ValidateProtectedResourceState()
         {
             Ensure.NotEmpty(ConsumerKey, nameof(ConsumerKey));
-            Ensure.NotEmpty(ConsumerSecret, nameof(ConsumerSecret));
         }
 
         WebPairCollection GenerateAuthParameters(string timestamp, string nonce)

--- a/test/RestSharp.Tests/OAuth1AuthenticatorTests.cs
+++ b/test/RestSharp.Tests/OAuth1AuthenticatorTests.cs
@@ -172,19 +172,20 @@ namespace RestSharp.Tests
         /// For more information, check the section 4 on https://oauth.net/core/1.0a/.
         /// </summary>
         [Test]
-        public void Authenticate_ShouldAllowEmptyConsumerSecret_OnHttpAuthorizationHeaderHandling()
+        [TestCase(OAuthType.AccessToken)]
+        [TestCase(OAuthType.ProtectedResource)]
+        [TestCase(OAuthType.AccessToken)]
+        [TestCase(OAuthType.ProtectedResource)]
+        public void Authenticate_ShouldAllowEmptyConsumerSecret_OnHttpAuthorizationHeaderHandling(OAuthType type)
         { 
             // Arrange
             const string url = "https://no-query.string";
 
-            var client = new RestClient(url);
+            var client  = new RestClient(url);
             var request = new RestRequest();
-
-            _authenticator.ParameterHandling = OAuthParameterHandling.HttpAuthorizationHeader;
-
-            // According to OAuth Core 1.0 Revision A: the Consumer Secret MAY be an empty string
-            _authenticator.ConsumerSecret    = null;
-
+            _authenticator.Type           = type;
+            _authenticator.ConsumerSecret = null;
+            
             // Act
             _authenticator.Authenticate(client, request);
 


### PR DESCRIPTION
## Description

OAuth 1.0a specifications allow to use of an empty custom secret (see [here](https://oauth.net/core/1.0a/, section 4: _The Consumer Secret MAY be an empty string [..]_). Similarly to #776, I needed to call MAAS API, where the customer secret must not be provided (0-legged OAuth). This pull request removes the constraint of providing customer secrets for OAuth1.

This has been tested over the API of MAAS, which does not require any customer secret.

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have added tests that prove my fix is effective or that my feature works (added one to verify that the customer secret can be empty).
- [X] I have added necessary documentation (explained the purpose of this PR on a comment over the provided unit test).

Don't hesitate to ask for changes in that pull request if needed.

Cheers