### PR TITLE
Important change in Docs in Utf8Json

### DIFF
--- a/docs/usage/serialization.md
+++ b/docs/usage/serialization.md
@@ -77,7 +77,7 @@ If you need to use different settings, you can supply your instance of
 
 ## Utf8Json
 
-The 'Utf8Json' package is known to be the fastest JSON serializer for .NET.
+The `Utf8Json` package is known to be the fastest JSON serializer for .NET.
 
 RestSharp supports `Utf8Json` serializer via a separate package. You can install it
 from NuGet:


### PR DESCRIPTION
All other includes of properties or other imp things are with grey background but here in this case Utf8Json wasn't there with grey background. It's a minor change but as a reader anyone can figure it out the difference. I hope you will consider this change as it is small but an important Visual change.

## Description

<!-- If your pull request solves an issue, please reference it here -->

This pull request does not any code related issue but particularly a display related important issue from Docs. All important words like properties are in grey color but Utf8Json does not have any grey background color and this difference can be spotted while reading the docs.

## Purpose
This pull request is a:  Bugfix (non-breaking change which fixes an issue)

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
