### PR TITLE
Double uppercase issue

### DIFF
--- a/src/RestSharp/Serializers/Json/JsonSerializer.cs
+++ b/src/RestSharp/Serializers/Json/JsonSerializer.cs
@@ -120,7 +120,7 @@ namespace RestSharp.Serialization.Json
                 if (!data.TryGetValue(name, out var value))
                 {
                     var parts       = name.Split('.');
-                    IDictionary<string, object> currentData = new Dictionary<string, object>(data, StringComparer.CurrentCultureIgnoreCase);
+                    IDictionary<string, object> currentData = new Dictionary<string, object>(data, StringComparer.Create(Culture, true));
 
                     for (var i = 0; i < parts.Length; ++i)
                     {

--- a/src/RestSharp/Serializers/Json/JsonSerializer.cs
+++ b/src/RestSharp/Serializers/Json/JsonSerializer.cs
@@ -120,7 +120,7 @@ namespace RestSharp.Serialization.Json
                 if (!data.TryGetValue(name, out var value))
                 {
                     var parts       = name.Split('.');
-                    var currentData = data;
+                    IDictionary<string, object> currentData = new Dictionary<string, object>(data, StringComparer.CurrentCultureIgnoreCase);
 
                     for (var i = 0; i < parts.Length; ++i)
                     {

--- a/test/RestSharp.Tests/JsonTests.cs
+++ b/test/RestSharp.Tests/JsonTests.cs
@@ -437,6 +437,17 @@ namespace RestSharp.Tests
         }
 
         [Test]
+        public void Can_Deserialize_Names_With_Double_Uppercase()
+        {
+            var doc = JsonData.CreateJsonWithDoubleUppercase();
+            var serializer = new JsonSerializer();
+            var response = new RestResponse { Content = doc };
+            var p = serializer.Deserialize<PersonForJson>(response);
+
+            Assert.AreEqual(435, p.PersonId);
+        }
+
+        [Test]
         public void Can_Deserialize_Names_With_Dashes_With_Default_Root()
         {
             var doc        = JsonData.CreateJsonWithDashes();

--- a/test/RestSharp.Tests/SampleClasses/misc.cs
+++ b/test/RestSharp.Tests/SampleClasses/misc.cs
@@ -127,6 +127,8 @@ namespace RestSharp.Tests.SampleClasses
         public Order Order { get; set; }
 
         public Disposition Disposition { get; set; }
+
+        public int PersonId { get; set; }
     }
 
     public enum Order { First, Second, Third }

--- a/test/RestSharp.Tests/TestData/JsonData.cs
+++ b/test/RestSharp.Tests/TestData/JsonData.cs
@@ -126,6 +126,15 @@ namespace RestSharp.Tests.TestData
             return doc.ToString();
         }
 
+        public static string CreateJsonWithDoubleUppercase()
+        {
+            var doc = new JsonObject
+            {
+                ["personID"] = 435,
+            };
+            return doc.ToString();
+        }
+
         public static string CreateJson()
         {
             var doc = new JsonObject


### PR DESCRIPTION
## Description
This addresses an issue brought up in #1471 where attributes that ended in "ID" (or any sequence of upper-case letters) was not able to match with properties where those two letters were also both capitalized (i.e. "id", "Id").  I didn't see in the docs that case-insensitive matching was a requirement, but for many people it seems that it is implied.

Addressing this issue in the GetNameVariants method in StringExtensions.cs would seem to involve a lot of extra methods just to achieve a case-insensitive comparison, so I updated the Map method to create a new case-insensitive dictionary rather than simply referencing the previous one.

## Purpose
This pull request is a:

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ x] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added necessary documentation (if appropriate)
