### PR TITLE
Bug/url encode consumer key issue#1654

### DIFF
--- a/src/RestSharp/Authenticators/OAuth/OAuth1Authenticator.cs
+++ b/src/RestSharp/Authenticators/OAuth/OAuth1Authenticator.cs
@@ -251,7 +251,7 @@ public class OAuth1Authenticator : IAuthenticator {
             => new[] { new Parameter("Authorization", GetAuthorizationHeader(), ParameterType.HttpHeader) };
 
         IEnumerable<Parameter> CreateUrlParameters()
-            => oauth.Parameters.Select(p => new Parameter(p.Name, HttpUtility.UrlDecode(p.Value), ParameterType.GetOrPost));
+            => oauth.Parameters.Select(p => new Parameter(p.Name, p.Value, ParameterType.GetOrPost));
 
         string GetAuthorizationHeader() {
             var oathParameters =

--- a/src/RestSharp/Authenticators/OAuth/OAuthWorkflow.cs
+++ b/src/RestSharp/Authenticators/OAuth/OAuthWorkflow.cs
@@ -171,7 +171,7 @@ sealed class OAuthWorkflow {
 
     WebPairCollection GenerateAuthParameters(string timestamp, string nonce) {
         var authParameters = new WebPairCollection {
-            new("oauth_consumer_key", Ensure.NotNull(ConsumerKey, nameof(ConsumerKey))),
+            new("oauth_consumer_key", Ensure.NotNull(HttpUtility.UrlEncode(ConsumerKey), nameof(ConsumerKey))),
             new("oauth_nonce", nonce),
             new("oauth_signature_method", SignatureMethod.ToRequestValue()),
             new("oauth_timestamp", timestamp),

--- a/test/RestSharp.IntegrationTests/OAuth1Tests.cs
+++ b/test/RestSharp.IntegrationTests/OAuth1Tests.cs
@@ -174,6 +174,27 @@ public class OAuth1Tests {
     }
 
     [Fact]
+    public void Ensure_Consumer_Key_Is_Url_Encoded() {
+
+        const string consumerKey = "Consumer+Key/Containing+Reserved+Characters";
+        const string consumerSecret = "enterConsumerSecretHere";
+        const string baseUrl = "http://restsharp.org";
+
+        var expected = HttpUtility.UrlEncode(consumerKey);
+
+        var client = new RestClient(baseUrl);
+        var request = new RestRequest(Method.Get);
+        var authenticator = OAuth1Authenticator.ForRequestToken(consumerKey, consumerSecret, OAuthSignatureMethod.HmacSha256);
+
+
+        authenticator.ParameterHandling = OAuthParameterHandling.UrlOrPostParameters;
+        authenticator.Authenticate(client, request);
+
+        var actual = request.Parameters.Where(x => x.Name.Equals("oauth_consumer_key")).Select(x => x.Value).FirstOrDefault();
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
     public void Can_Authenticate_OAuth1_With_Querystring_Parameters() {
         const string consumerKey    = "enterConsumerKeyHere";
         const string consumerSecret = "enterConsumerSecretHere";


### PR DESCRIPTION
## Description

To fix issue #1654. Please note that that this PR add urlencoding to consumer key and in affect removes the generic urldecode. 
Could be a possible breaking change as parameters are not urldecoded by default anymore. I did not find any code that suggest that the parameter could be encoded. 

## Purpose
This pull request is a:

- [] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
