### PR TITLE
Cleaning up parameters

### DIFF
--- a/src/RestSharp/Extensions/MiscExtensions.cs
+++ b/src/RestSharp/Extensions/MiscExtensions.cs
@@ -39,8 +39,8 @@ static class MiscExtensions {
 
         return ms.ToArray();
     }
-    
-    internal static IEnumerable<(string Name, object Value)> GetProperties(this object obj, params string[] includedProperties) {
+
+    internal static IEnumerable<(string Name, string? Value)> GetProperties(this object obj, params string[] includedProperties) {
         // automatically create parameters from object props
         var type  = obj.GetType();
         var props = type.GetProperties();
@@ -63,12 +63,13 @@ static class MiscExtensions {
                 if (array.Length > 0 && elementType != null) {
                     // convert the array to an array of strings
                     var values = array.Cast<object>().Select(item => item.ToString());
+                    yield return (prop.Name, string.Join(",", values));
 
-                    val = string.Join(",", values);
+                    continue;
                 }
             }
 
-            yield return(prop.Name, val);
+            yield return (prop.Name, val.ToString());
         }
 
         bool IsAllowedProperty(string propertyName)

--- a/src/RestSharp/KnownHeaders.cs
+++ b/src/RestSharp/KnownHeaders.cs
@@ -31,4 +31,5 @@ public static class KnownHeaders {
     public const string ContentType        = "Content-Type";
     public const string LastModified       = "Last-Modified";
     public const string ContentMD5         = "Content-MD5";
+    public const string Host               = "Host";
 }

--- a/src/RestSharp/Parameters/FileParameter.cs
+++ b/src/RestSharp/Parameters/FileParameter.cs
@@ -20,11 +20,6 @@ namespace RestSharp;
 [PublicAPI]
 public record FileParameter {
     /// <summary>
-    /// The length of data to be sent
-    /// </summary>
-    public long ContentLength { get; }
-
-    /// <summary>
     /// Provides raw data for file
     /// </summary>
     public Func<Stream> GetFile { get; }
@@ -44,10 +39,9 @@ public record FileParameter {
     /// </summary>
     public string Name { get; }
 
-    FileParameter(string name, string fileName, long contentLength, Func<Stream> getFile, string? contentType = null) {
+    FileParameter(string name, string fileName, Func<Stream> getFile, string? contentType = null) {
         Name          = name;
         FileName      = fileName;
-        ContentLength = contentLength;
         GetFile       = getFile;
         ContentType   = contentType ?? "application/octet-stream";
     }
@@ -61,7 +55,7 @@ public record FileParameter {
     /// <param name="contentType">The content type to use in the request.</param>
     /// <returns>The <see cref="FileParameter" /></returns>
     public static FileParameter Create(string name, byte[] data, string filename, string? contentType = null) {
-        return new FileParameter(name, filename, data.Length, GetFile, contentType);
+        return new FileParameter(name, filename, GetFile, contentType);
 
         Stream GetFile() {
             var stream = new MemoryStream();
@@ -86,7 +80,7 @@ public record FileParameter {
         string       fileName,
         string?      contentType = null
     )
-        => new(name, fileName, contentLength, getFile, contentType ?? Serializers.ContentType.File);
+        => new(name, fileName, getFile, contentType ?? Serializers.ContentType.File);
 
     public static FileParameter FromFile(string fullPath, string? name = null, string? contentType = null) {
         if (!File.Exists(Ensure.NotEmptyString(fullPath, nameof(fullPath))))
@@ -94,9 +88,8 @@ public record FileParameter {
 
         var fileName = Path.GetFileName(fullPath);
         var parameterName = name ?? fileName;
-        var length = new FileInfo(fullPath).Length;
         
-        return new FileParameter(parameterName, fileName, length, GetFile);
+        return new FileParameter(parameterName, fileName, GetFile);
 
         Stream GetFile() => File.OpenRead(fullPath);
     }

--- a/src/RestSharp/Parameters/GetOrPostParameter.cs
+++ b/src/RestSharp/Parameters/GetOrPostParameter.cs
@@ -11,10 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
 
 namespace RestSharp;
 
 public record GetOrPostParameter : NamedParameter {
+    /// <summary>
+    /// Instantiates an HTTP parameter instance (QueryString for GET, DELETE, OPTIONS and HEAD; Encoded form for POST and PUT)
+    /// </summary>
+    /// <param name="name">Name of the parameter</param>
+    /// <param name="value">Value of the parameter</param>
+    /// <param name="encode">Encode the value or not, default true</param>
     public GetOrPostParameter(string name, string? value, bool encode = true) : base(name, value, ParameterType.GetOrPost, encode) { }
 }

--- a/src/RestSharp/Parameters/HeaderParameter.cs
+++ b/src/RestSharp/Parameters/HeaderParameter.cs
@@ -16,5 +16,10 @@
 namespace RestSharp;
 
 public record HeaderParameter : Parameter {
+    /// <summary>
+    /// Instantiates a header parameter
+    /// </summary>
+    /// <param name="name">Parameter name</param>
+    /// <param name="value">Parameter value</param>
     public HeaderParameter(string? name, string? value) : base(name, value, ParameterType.HttpHeader, false) { }
 }

--- a/src/RestSharp/Parameters/QueryParameter.cs
+++ b/src/RestSharp/Parameters/QueryParameter.cs
@@ -16,5 +16,11 @@
 namespace RestSharp;
 
 public record QueryParameter : NamedParameter {
+    /// <summary>
+    /// Instantiates a new query parameter instance that will be added to the request URL as {name}={value} part of the query string.
+    /// </summary>
+    /// <param name="name">Parameter name</param>
+    /// <param name="value">Parameter value</param>
+    /// <param name="encode">Optional: encode the value, default is true</param>
     public QueryParameter(string name, string? value, bool encode = true) : base(name, value, ParameterType.QueryString, encode) { }
 }

--- a/src/RestSharp/Parameters/UrlSegmentParameter.cs
+++ b/src/RestSharp/Parameters/UrlSegmentParameter.cs
@@ -11,11 +11,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
 
 namespace RestSharp;
 
 public record UrlSegmentParameter : NamedParameter {
+    /// <summary>
+    /// Instantiates a new query parameter instance that will be added to the request URL part of the query string.
+    /// The request resource should have a placeholder {name} that will be replaced with the parameter value when the request is made.
+    /// </summary>
+    /// <param name="name">Parameter name</param>
+    /// <param name="value">Parameter value</param>
+    /// <param name="encode">Optional: encode the value, default is true</param>
     public UrlSegmentParameter(string name, string value, bool encode = true)
         : base(name, Ensure.NotEmpty(value, nameof(value)).Replace("%2F", "/").Replace("%2f", "/"), ParameterType.UrlSegment, encode) { }
 }

--- a/src/RestSharp/Request/RestRequest.cs
+++ b/src/RestSharp/Request/RestRequest.cs
@@ -174,9 +174,18 @@ public class RestRequest {
         }
     }
 
-    public RestRequest AddParameter(Parameter p) => this.With(x => x.Parameters.AddParameter(p));
+    /// <summary>
+    /// Adds a parameter object to the request parameters
+    /// </summary>
+    /// <param name="parameter">Parameter to add</param>
+    /// <returns></returns>
+    public RestRequest AddParameter(Parameter parameter) => this.With(x => x.Parameters.AddParameter(parameter));
 
-    public void RemoveParameter(Parameter p) => Parameters.RemoveParameter(p);
+    /// <summary>
+    /// Removes a parameter object from the request parameters
+    /// </summary>
+    /// <param name="parameter">Parameter to remove</param>
+    public void RemoveParameter(Parameter parameter) => Parameters.RemoveParameter(parameter);
 
     internal RestRequest AddFile(FileParameter file) => this.With(x => x._files.Add(file));
 }

--- a/src/RestSharp/RestClientExtensions.Json.cs
+++ b/src/RestSharp/RestClientExtensions.Json.cs
@@ -45,10 +45,10 @@ public static partial class RestClientExtensions {
             var param = $"{name}";
 
             if (resource.Contains(param)) {
-                resource = resource.Replace(param, value.ToString());
+                resource = resource.Replace(param, value);
             }
             else {
-                query.Add(new QueryParameter(name, value?.ToString()));
+                query.Add(new QueryParameter(name, value));
             }
         }
 

--- a/test/RestSharp.Tests/ParametersTests.cs
+++ b/test/RestSharp.Tests/ParametersTests.cs
@@ -15,10 +15,21 @@ public class ParametersTests {
 
         var expected = headers.Select(x => new HeaderParameter(x.Key, x.Value));
 
-        var client  = new RestClient(BaseUrl);
+        var client = new RestClient(BaseUrl);
         client.AddDefaultHeaders(headers);
 
         var actual = client.DefaultParameters.Select(x => x as HeaderParameter);
         expected.Should().BeSubsetOf(actual);
+    }
+
+    [Fact]
+    public void AddUrlSegmentWithInt() {
+        const string name = "foo";
+
+        var request  = new RestRequest().AddUrlSegment(name, 1);
+        var actual   = request.Parameters.FirstOrDefault(x => x.Name == name);
+        var expected = new UrlSegmentParameter(name, "1");
+        
+        expected.Should().BeEquivalentTo(actual);
     }
 }


### PR DESCRIPTION
- Added generic overloads for request extensions that add parameters. It will be possible to use `string` or a struct (like `int`, `long`, etc), but not classes.
- Add missing optional `encode` argument to some extensions
- Removed the `ContentLength` requirement for file parameters as it's not used