### PR TITLE
doc: fixed return value of RestClient.PostAsync()

### DIFF
--- a/docs/v107/README.md
+++ b/docs/v107/README.md
@@ -70,7 +70,7 @@ var response = await client.PostAsync<MyResponse>(request, cancellationToken);
 
 All the synchronous methods are gone. If you absolutely must call without using `async` and `await`, use `GetAwaiter().GetResult()` blocking call.
 
-The `IRestResponse` interface is deprecated. You get an instance of `RestRequest` or `RestRequest<T>` in return.
+The `IRestResponse` interface is deprecated. You get an instance of `RestResponse` or `RestResponse<T>` in return.
 
 You can also use a simplified API for making POST and PUT requests:
 


### PR DESCRIPTION
## Description

Documentation fix