### PR TITLE
Fix typo in v107 documentation

### DIFF
--- a/docs/v107/README.md
+++ b/docs/v107/README.md
@@ -97,9 +97,9 @@ The `Utf8` serializer package is deprecated as the package is not being updated.
 For XML requests and responses RestSharp uses `DotNetXmlSerializer` and `DotNetXmlDeserializer`.
 Previously used default `XmlSerializer`, `XmlDeserializer`, and `XmlAttrobuteDeserializer` are moved to a separate package `RestSharp.Serializers.Xml`.
 
-### NTML authentication
+### NTLM authentication
 
-The `NtmlAuthenticator` is deprecated.
+The `NtlmAuthenticator` is deprecated.
 
 NTLM authenticator was doing nothing more than telling `WebRequest` to use certain credentials. Now with RestSharp, the preferred way would be to set the `Credentials` or `UseDefaultCredentials` property in `RestClientOptions`.
 


### PR DESCRIPTION
I believe the *Ntlm*Authenticator was deprecated.

https://github.com/restsharp/RestSharp/blob/ca15b2599d9e85efd9ac43c7112188b9b0cc67a0/src/RestSharp/Authenticators/NtlmAuthenticator.cs#L23