### PR TITLE
fix: tiny typo

### DIFF
--- a/docs/v107/README.md
+++ b/docs/v107/README.md
@@ -153,7 +153,7 @@ The next RestSharp version presumably solves the following issues:
 - HTTP/2 support
 - Intermediate certificate issue
 - Uploading large files (use file parameters with `Stream`)
-- Downloading large files (use `DownloadFileStreanAsync`)
+- Downloading large files (use `DownloadFileStreamAsync`)
 
 ## Deprecated interfaces
 


### PR DESCRIPTION
DownloadFileStreanAsync -> DownloadFileStreamAsync

## Description

Just fixes a tiny typo in the 107 migration docs

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
