### PR TITLE
Case insensitive header names

### DIFF
--- a/src/RestSharp/Request/RequestContent.cs
+++ b/src/RestSharp/Request/RequestContent.cs
@@ -27,9 +27,17 @@ class RequestContent : IDisposable {
     readonly List<Stream> _streams = new();
 
     internal static readonly string[] ContentHeaders = {
-        Allow, Expires,
-        ContentDisposition, ContentEncoding, ContentLanguage, ContentLength, ContentLocation, ContentRange, ContentType, ContentMD5,
-        LastModified
+        Allow.ToLower(),
+        Expires.ToLower(),
+        ContentDisposition.ToLower(),
+        ContentEncoding.ToLower(),
+        ContentLanguage.ToLower(),
+        ContentLength.ToLower(),
+        ContentLocation.ToLower(),
+        ContentRange.ToLower(),
+        ContentType.ToLower(),
+        ContentMD5.ToLower(),
+        LastModified.ToLower(),
     };
 
     HttpContent? Content { get; set; }
@@ -172,7 +180,7 @@ class RequestContent : IDisposable {
 
     void AddHeaders() {
         var contentHeaders = _request.Parameters
-            .Where(x => x.Type == ParameterType.HttpHeader && ContentHeaders.Contains(x.Name))
+            .Where(x => x.Type == ParameterType.HttpHeader && ContentHeaders.Contains(x.Name?.ToLower()))
             .ToArray();
 
         if (contentHeaders.Length > 0 && Content == null) {

--- a/test/RestSharp.Tests/RestContentTests.cs
+++ b/test/RestSharp.Tests/RestContentTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Net;
+
+namespace RestSharp.Tests;
+
+public class RestContentTests {
+    [Fact]
+    public void RestContent_CaseInsensitiveHeaders() {
+        var myContentType = "application/x-custom";
+        var request = new RestRequest("resource");
+        request.AddHeader("coNteNt-TypE", myContentType);
+        var client = new RestClient();
+        var content = new RequestContent(client, request);
+
+        var httpContent = content.BuildContent();
+
+        Assert.Equal(myContentType, httpContent.Headers.ContentType.MediaType);
+    }
+}


### PR DESCRIPTION
## Description

If we add a content header to a request, but use non-standard casing (e.g., adding the header `content-type`), currently RestSharp doesn't correctly add this header to `HttpContent`, and then later it attempts to add it to `HttpRequest` and fails:

```
System.InvalidOperationException: Misused header name, 'content-type'. Make sure request headers are used with HttpRequestMessage, response headers with HttpResponseMessage, and content headers with HttpContent objects.
   at System.Net.Http.Headers.HttpHeaders.GetHeaderDescriptor(String name)
   at System.Net.Http.Headers.HttpHeaders.Remove(String name)
   at RestSharp.HttpRequestMessageExtensions.<AddHeaders>g__AddHeader|0_2(Parameter parameter, HttpHeaders httpHeaders)
   at RestSharp.HttpRequestMessageExtensions.<>c__DisplayClass0_0.<AddHeaders>b__1(Parameter x)
   at RestSharp.Extensions.CollectionExtensions.ForEach[T](IEnumerable`1 items, Action`1 action)
   at RestSharp.HttpRequestMessageExtensions.AddHeaders(HttpRequestMessage message, RequestHeaders headers)
   at RestSharp.RestClient.ExecuteInternal(RestRequest request, CancellationToken cancellationToken)
```

This PR fixes this (and tests the fix).

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
