### PR TITLE
Proposed fix for #1765

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,14 +16,10 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
     </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-        <MinVerSkip>true</MinVerSkip>
-        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All"/>
+        <PackageReference Include="MinVer" Version="3.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/RestSharp/Request/RequestContent.cs
+++ b/src/RestSharp/Request/RequestContent.cs
@@ -162,7 +162,7 @@ class RequestContent : IDisposable {
             var formContent = new FormUrlEncodedContent(
                 _request.Parameters
                     .Where(x => x.Type == ParameterType.GetOrPost)
-                    .Select(x => new KeyValuePair<string, string>(x.Name!, x.Value!.ToString()!))
+                    .Select(x => new KeyValuePair<string, string>(x.Name!, x.Value!.ToString()!))!
             );
             Content = formContent;
         }

--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -121,7 +121,7 @@ public partial class RestClient : IDisposable {
     /// </summary>
     /// <param name="handler">Message handler instance to use for HttpClient</param>
     /// <param name="disposeHandler">Dispose the handler when disposing RestClient, true by default</param>
-    public RestClient(HttpMessageHandler handler, bool disposeHandler = true) : this(new HttpClient(handler, disposeHandler), null, true) { }
+    public RestClient(HttpMessageHandler handler, bool disposeHandler = true) : this(new HttpClient(handler, disposeHandler), true) { }
 
     void ConfigureHttpClient(HttpClient httpClient) {
         if (Options.Timeout > 0) httpClient.Timeout = TimeSpan.FromMilliseconds(Options.Timeout);


### PR DESCRIPTION
* Make `RestClient.Options` public, read-only
* Add a `RestClient` constructor with `HttpClient` only, which won't be changed in any way by RestSharp