### PR TITLE
Fix thread safety issues with RestClient when used as a single instance for Authentication and Cookies

### DIFF
--- a/src/RestSharp/Authenticators/JwtAuthenticator.cs
+++ b/src/RestSharp/Authenticators/JwtAuthenticator.cs
@@ -21,13 +21,6 @@ namespace RestSharp.Authenticators;
 public class JwtAuthenticator : AuthenticatorBase {
     public JwtAuthenticator(string accessToken) : base(GetToken(accessToken)) { }
 
-    /// <summary>
-    /// Set the new bearer token so the request gets the new header value
-    /// </summary>
-    /// <param name="accessToken"></param>
-    [PublicAPI]
-    public void SetBearerToken(string accessToken) => Token = GetToken(accessToken);
-
     static string GetToken(string accessToken) => $"Bearer {Ensure.NotEmpty(accessToken, nameof(accessToken))}";
 
     protected override ValueTask<Parameter> GetAuthenticationParameter(string accessToken)

--- a/src/RestSharp/Extensions/AsyncHelpers.cs
+++ b/src/RestSharp/Extensions/AsyncHelpers.cs
@@ -1,0 +1,125 @@
+﻿//  Copyright © 2009-2021 John Sheehan, Andrew Young, Alexey Zimarev and RestSharp community
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Adapted from Rebus
+
+using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
+
+namespace RestSharp.Extensions {
+    public static class AsyncHelpers {
+        /// <summary>
+        /// Executes a task synchronously on the calling thread by installing a temporary synchronization context that queues continuations
+        /// </summary>
+        /// <param name="task">Callback for asynchronous task to run</param>
+        public static void RunSync(Func<Task> task) {
+            var currentContext = SynchronizationContext.Current;
+            var customContext  = new CustomSynchronizationContext(task);
+
+            try {
+                SynchronizationContext.SetSynchronizationContext(customContext);
+                customContext.Run();
+            }
+            finally {
+                SynchronizationContext.SetSynchronizationContext(currentContext);
+            }
+        }
+
+        /// <summary>
+        /// Executes a task synchronously on the calling thread by installing a temporary synchronization context that queues continuations
+        /// </summary>
+        /// <param name="task">Callback for asynchronous task to run</param>
+        /// <typeparam name="T">Return type for the task</typeparam>
+        /// <returns>Return value from the task</returns>
+        public static T RunSync<T>(Func<Task<T>> task) {
+            T result = default!;
+            RunSync(async () => { result = await task(); });
+            return result;
+        }
+
+        /// <summary>
+        /// Synchronization context that can be "pumped" in order to have it execute continuations posted back to it
+        /// </summary>
+        class CustomSynchronizationContext : SynchronizationContext {
+            readonly ConcurrentQueue<Tuple<SendOrPostCallback, object?>> _items            = new();
+            readonly AutoResetEvent                                      _workItemsWaiting = new(false);
+            readonly Func<Task>                                          _task;
+            ExceptionDispatchInfo?                                       _caughtException;
+            bool                                                         _done;
+
+            /// <summary>
+            /// Constructor for the custom context
+            /// </summary>
+            /// <param name="task">Task to execute</param>
+            public CustomSynchronizationContext(Func<Task> task) =>
+                _task = task ?? throw new ArgumentNullException(nameof(task), "Please remember to pass a Task to be executed");
+
+            /// <summary>
+            /// When overridden in a derived class, dispatches an asynchronous message to a synchronization context.
+            /// </summary>
+            /// <param name="function">Callback function</param>
+            /// <param name="state">Callback state</param>
+            public override void Post(SendOrPostCallback function, object? state) {
+                _items.Enqueue(Tuple.Create(function, state));
+                _workItemsWaiting.Set();
+            }
+
+            /// <summary>
+            /// Enqueues the function to be executed and executes all resulting continuations until it is completely done
+            /// </summary>
+            public void Run() {
+                async void PostCallback(object? _) {
+                    try {
+                        await _task().ConfigureAwait(false);
+                    }
+                    catch (Exception exception) {
+                        _caughtException = ExceptionDispatchInfo.Capture(exception);
+                        throw;
+                    }
+                    finally {
+                        Post(_ => _done = true, null);
+                    }
+                }
+
+                Post(PostCallback, null);
+
+                while (!_done) {
+                    if (_items.TryDequeue(out var task)) {
+                        task.Item1(task.Item2);
+                        if (_caughtException == null) {
+                            continue;
+                        }
+                        _caughtException.Throw();
+                    }
+                    else {
+                        _workItemsWaiting.WaitOne();
+                    }
+                }
+            }
+
+            /// <summary>
+            /// When overridden in a derived class, dispatches a synchronous message to a synchronization context.
+            /// </summary>
+            /// <param name="function">Callback function</param>
+            /// <param name="state">Callback state</param>
+            public override void Send(SendOrPostCallback function, object? state) => throw new NotSupportedException("Cannot send to same thread");
+
+            /// <summary>
+            /// When overridden in a derived class, creates a copy of the synchronization context. Not needed, so just return ourselves.
+            /// </summary>
+            /// <returns>Copy of the context</returns>
+            public override SynchronizationContext CreateCopy() => this;
+        }
+    }
+}

--- a/src/RestSharp/KnownHeaders.cs
+++ b/src/RestSharp/KnownHeaders.cs
@@ -30,6 +30,7 @@ public static class KnownHeaders {
     public const string ContentLocation    = "Content-Location";
     public const string ContentRange       = "Content-Range";
     public const string ContentType        = "Content-Type";
+    public const string Cookie             = "Cookie";
     public const string LastModified       = "Last-Modified";
     public const string ContentMD5         = "Content-MD5";
     public const string Host               = "Host";

--- a/src/RestSharp/Request/RequestHeaders.cs
+++ b/src/RestSharp/Request/RequestHeaders.cs
@@ -14,7 +14,10 @@
 // 
 
 // ReSharper disable InvertIf
-namespace RestSharp; 
+
+using System.Net;
+
+namespace RestSharp;
 
 class RequestHeaders {
     public ParametersCollection Parameters { get; } = new();
@@ -31,6 +34,15 @@ class RequestHeaders {
             Parameters.AddParameter(new HeaderParameter(KnownHeaders.Accept, accepts));
         }
 
+        return this;
+    }
+
+    // Add Cookie header from the cookie container
+    public RequestHeaders AddCookieHeaders(CookieContainer cookieContainer, Uri uri) {
+        var cookies = cookieContainer.GetCookieHeader(uri);
+        if (cookies.Length > 0) {
+            Parameters.AddParameter(new HeaderParameter(KnownHeaders.Cookie, cookies));
+        }
         return this;
     }
 }

--- a/src/RestSharp/Request/RestRequest.cs
+++ b/src/RestSharp/Request/RestRequest.cs
@@ -21,8 +21,8 @@ namespace RestSharp;
 /// Container for data used to make requests
 /// </summary>
 public class RestRequest {
-    readonly Func<HttpResponseMessage, RestResponse>? _advancedResponseHandler;
-    readonly Func<Stream, Stream?>?                   _responseWriter;
+    Func<HttpResponseMessage, RestResponse>? _advancedResponseHandler;
+    Func<Stream, Stream?>?                   _responseWriter;
 
     /// <summary>
     /// Default constructor
@@ -159,7 +159,7 @@ public class RestRequest {
     /// </summary>
     public Func<Stream, Stream?>? ResponseWriter {
         get => _responseWriter;
-        init {
+        set {
             if (AdvancedResponseWriter != null)
                 throw new ArgumentException(
                     "AdvancedResponseWriter is not null. Only one response writer can be used."
@@ -174,7 +174,7 @@ public class RestRequest {
     /// </summary>
     public Func<HttpResponseMessage, RestResponse>? AdvancedResponseWriter {
         get => _advancedResponseHandler;
-        init {
+        set {
             if (ResponseWriter != null)
                 throw new ArgumentException("ResponseWriter is not null. Only one response writer can be used.");
 

--- a/src/RestSharp/Request/RestRequest.cs
+++ b/src/RestSharp/Request/RestRequest.cs
@@ -14,6 +14,7 @@
 
 using System.Net;
 using System.Net.Http.Headers;
+using System.Reflection;
 using RestSharp.Authenticators;
 using RestSharp.Extensions;
 // ReSharper disable UnusedAutoPropertyAccessor.Global
@@ -26,6 +27,8 @@ namespace RestSharp;
 public class RestRequest {
     Func<HttpResponseMessage, RestResponse>? _advancedResponseHandler;
     Func<Stream, Stream?>?                   _responseWriter;
+    static readonly Version                  Version          = new AssemblyName(typeof(RestClientOptions).Assembly.FullName!).Version!;
+    static readonly string                   DefaultUserAgent = $"RestSharp/{Version}";
 
     /// <summary>
     /// Default constructor
@@ -113,7 +116,11 @@ public class RestRequest {
     public Method Method { get; set; }
 
     /// <summary>
-    /// Custom request timeout
+    /// Sets the timeout in milliseconds for this requests using this client. Note that there is also a timeout
+    /// set on the base client, and the the shorter of the two values is what will end up being used. So if you need long
+    /// timeouts at the request level, you will want to set the value on the client to to a larger value than the maximum
+    /// you need per request, or set the client to infinite. If this value is 0, an infinite timeout is used (basically
+    /// it then times out using whatever was configured at the client level).
     /// </summary>
     public int Timeout { get; set; }
 
@@ -176,6 +183,11 @@ public class RestRequest {
     /// Explicit Host header value to use in requests independent from the request URI.
     /// </summary>
     public string? BaseHost { get; set; }
+
+    /// <summary>
+    /// Sets the user agent string to be used for this requests. Defaults to a RestSharp string if not provided.
+    /// </summary>
+    public string UserAgent { get; set; } = DefaultUserAgent;
 
     /// <summary>
     /// Sets the cache policy to use for this request

--- a/src/RestSharp/Request/RestRequest.cs
+++ b/src/RestSharp/Request/RestRequest.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net;
+using RestSharp.Authenticators;
 using RestSharp.Extensions;
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 
@@ -29,6 +31,11 @@ public class RestRequest {
     /// </summary>
     public RestRequest() => Method = Method.Get;
 
+    /// <summary>
+    /// Constructor for a rest request to a relative resource URL and optional method
+    /// </summary>
+    /// <param name="resource">Resource to use</param>
+    /// <param name="method">Method to use (defaults to Method.Get></param>
     public RestRequest(string? resource, Method method = Method.Get) : this() {
         Resource = resource ?? "";
         Method   = method;
@@ -58,6 +65,11 @@ public class RestRequest {
                 );
     }
 
+    /// <summary>
+    /// Constructor for a rest request to a specific resource Uri and optional method
+    /// </summary>
+    /// <param name="resource">Resource Uri to use</param>
+    /// <param name="method">Method to use (defaults to Method.Get></param>
     public RestRequest(Uri resource, Method method = Method.Get)
         : this(resource.IsAbsoluteUri ? resource.AbsoluteUri : resource.OriginalString, method) { }
 
@@ -82,6 +94,11 @@ public class RestRequest {
     /// See AddParameter() for explanation of the types of parameters that can be passed
     /// </summary>
     public ParametersCollection Parameters { get; } = new();
+
+    /// <summary>
+    /// Optional cookie container to use for the request. If not set, cookies are not passed.
+    /// </summary>
+    public CookieContainer? CookieContainer { get; set; }
 
     /// <summary>
     /// Container of all the files to be uploaded with the request.
@@ -153,6 +170,11 @@ public class RestRequest {
     /// Completion option for <seealso cref="HttpClient"/>
     /// </summary>
     public HttpCompletionOption CompletionOption { get; set; } = HttpCompletionOption.ResponseContentRead;
+
+    /// <summary>
+    /// Authenticator that will be used to populate request with necessary authentication data
+    /// </summary>
+    public IAuthenticator? Authenticator { get; set; }
 
     /// <summary>
     /// Set this to write response to Stream rather than reading into memory.

--- a/src/RestSharp/Request/RestRequest.cs
+++ b/src/RestSharp/Request/RestRequest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Net;
+using System.Net.Http.Headers;
 using RestSharp.Authenticators;
 using RestSharp.Extensions;
 // ReSharper disable UnusedAutoPropertyAccessor.Global
@@ -170,6 +171,16 @@ public class RestRequest {
     /// Completion option for <seealso cref="HttpClient"/>
     /// </summary>
     public HttpCompletionOption CompletionOption { get; set; } = HttpCompletionOption.ResponseContentRead;
+
+    /// <summary>
+    /// Explicit Host header value to use in requests independent from the request URI.
+    /// </summary>
+    public string? BaseHost { get; set; }
+
+    /// <summary>
+    /// Sets the cache policy to use for this request
+    /// </summary>
+    public CacheControlHeaderValue? CachePolicy { get; set; }
 
     /// <summary>
     /// Authenticator that will be used to populate request with necessary authentication data

--- a/src/RestSharp/Request/RestRequestExtensions.cs
+++ b/src/RestSharp/Request/RestRequestExtensions.cs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net;
 using System.Text.RegularExpressions;
+using RestSharp.Authenticators;
 using RestSharp.Extensions;
 using RestSharp.Serializers;
 
@@ -386,6 +388,32 @@ public static class RestRequestExtensions {
 
         return request;
     }
+
+    /// <summary>
+    /// Adds cookie to the <seealso cref="HttpClient"/> cookie container.
+    /// </summary>
+    /// <param name="request">RestRequest to add the cookies to</param>
+    /// <param name="name">Cookie name</param>
+    /// <param name="value">Cookie value</param>
+    /// <param name="path">Cookie path</param>
+    /// <param name="domain">Cookie domain, must not be an empty string</param>
+    /// <returns></returns>
+    public static RestRequest AddCookie(this RestRequest request, string name, string value, string path, string domain) {
+        if (request.CookieContainer == null) {
+            throw new ArgumentException("Please provide a cookie container to RestRequest!");
+        }
+        request.CookieContainer.Add(new Cookie(name, value, path, domain));
+        return request;
+    }
+
+    /// <summary>
+    /// Enable request authentication for this request using the passed in authenticator
+    /// </summary>
+    /// <param name="request">Request to attach the authenticator to</param>
+    /// <param name="authenticator">Authenticator to use</param>
+    /// <returns></returns>
+    public static RestRequest UseAuthenticator(this RestRequest request, IAuthenticator authenticator)
+        => request.With(x => x.Authenticator = authenticator);
 
     static void CheckAndThrowsForInvalidHost(string name, string value) {
         static bool InvalidHost(string host) => Uri.CheckHostName(PortSplitRegex.Split(host)[0]) == UriHostNameType.Unknown;

--- a/src/RestSharp/Response/RestResponse.cs
+++ b/src/RestSharp/Response/RestResponse.cs
@@ -64,7 +64,7 @@ public class RestResponse : RestResponseBase {
         HttpResponseMessage     httpResponse,
         RestRequest             request,
         Encoding                encoding,
-        CookieCollection        cookieCollection,
+        CookieCollection?       cookieCollection,
         CalculateResponseStatus calculateResponseStatus,
         CancellationToken       cancellationToken
     ) {

--- a/src/RestSharp/RestClient.Async.cs
+++ b/src/RestSharp/RestClient.Async.cs
@@ -19,6 +19,12 @@ namespace RestSharp;
 
 public partial class RestClient {
     /// <summary>
+    /// Executes the request synchronously, authenticating if needed
+    /// </summary>
+    /// <param name="request">Request to be executed</param>
+    public RestResponse Execute(RestRequest request) => AsyncHelpers.RunSync(() => ExecuteAsync(request));
+
+    /// <summary>
     /// Executes the request asynchronously, authenticating if needed
     /// </summary>
     /// <param name="request">Request to be executed</param>
@@ -98,6 +104,14 @@ public partial class RestClient {
     }
 
     record InternalResponse(HttpResponseMessage? ResponseMessage, Uri Url, Exception? Exception, CancellationToken TimeoutToken);
+
+    /// <summary>
+    /// A specialized method to download files as streams.
+    /// </summary>
+    /// <param name="request">Pre-configured request instance.</param>
+    /// <returns>The downloaded stream.</returns>
+    [PublicAPI]
+    public Stream? DownloadStream(RestRequest request) => AsyncHelpers.RunSync(() => DownloadStreamAsync(request));
 
     /// <summary>
     /// A specialized method to download files as streams.

--- a/src/RestSharp/RestClient.Async.cs
+++ b/src/RestSharp/RestClient.Async.cs
@@ -59,6 +59,7 @@ public partial class RestClient {
         var message    = new HttpRequestMessage(httpMethod, url) { Content = requestContent.BuildContent() };
         message.Headers.Host         = request.BaseHost;
         message.Headers.CacheControl = request.CachePolicy;
+        message.Headers.UserAgent.ParseAdd(request.UserAgent);
 
         using var timeoutCts = new CancellationTokenSource(request.Timeout > 0 ? request.Timeout : int.MaxValue);
         using var cts        = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);

--- a/src/RestSharp/RestClient.Async.cs
+++ b/src/RestSharp/RestClient.Async.cs
@@ -57,8 +57,8 @@ public partial class RestClient {
         var httpMethod = AsHttpMethod(request.Method);
         var url        = BuildUri(request);
         var message    = new HttpRequestMessage(httpMethod, url) { Content = requestContent.BuildContent() };
-        message.Headers.Host         = Options.BaseHost;
-        message.Headers.CacheControl = Options.CachePolicy;
+        message.Headers.Host         = request.BaseHost;
+        message.Headers.CacheControl = request.CachePolicy;
 
         using var timeoutCts = new CancellationTokenSource(request.Timeout > 0 ? request.Timeout : int.MaxValue);
         using var cts        = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);

--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -127,11 +127,6 @@ public partial class RestClient : IDisposable {
     /// </summary>
     public Uri BaseUrl => Options.BaseUrl!;
 
-    /// <summary>
-    /// Returns the currently configured BaseHost for this RestClient instance
-    /// </summary>
-    public string BaseHost => Options.BaseHost!;
-
     void ConfigureHttpClient(HttpClient httpClient) {
         if (Options.Timeout > 0) httpClient.Timeout = TimeSpan.FromMilliseconds(Options.Timeout);
         httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(Options.UserAgent);

--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -129,7 +129,6 @@ public partial class RestClient : IDisposable {
 
     void ConfigureHttpClient(HttpClient httpClient) {
         if (Options.Timeout > 0) httpClient.Timeout = TimeSpan.FromMilliseconds(Options.Timeout);
-        httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(Options.UserAgent);
     }
 
     void ConfigureHttpMessageHandler(HttpClientHandler handler) {

--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -129,6 +129,7 @@ public partial class RestClient : IDisposable {
 
     void ConfigureHttpClient(HttpClient httpClient) {
         if (Options.Timeout > 0) httpClient.Timeout = TimeSpan.FromMilliseconds(Options.Timeout);
+        httpClient.DefaultRequestHeaders.ExpectContinue = Options.Expect100Continue;
     }
 
     void ConfigureHttpMessageHandler(HttpClientHandler handler) {

--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -15,7 +15,6 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
-using RestSharp.Authenticators;
 using RestSharp.Extensions;
 
 // ReSharper disable VirtualMemberCallInConstructor
@@ -27,8 +26,6 @@ namespace RestSharp;
 /// Client to translate RestRequests into Http requests and process response result
 /// </summary>
 public partial class RestClient : IDisposable {
-    public CookieContainer CookieContainer { get; }
-
     /// <summary>
     /// Content types that will be sent in the Accept header. The list is populated from the known serializers.
     /// If you need to send something else by default, set this property to a different value.
@@ -51,7 +48,6 @@ public partial class RestClient : IDisposable {
         UseDefaultSerializers();
 
         Options            = options;
-        CookieContainer    = Options.CookieContainer ?? new CookieContainer();
         _disposeHttpClient = true;
 
         var handler = new HttpClientHandler();
@@ -69,25 +65,27 @@ public partial class RestClient : IDisposable {
     /// </summary>
     public RestClient() : this(new RestClientOptions()) { }
 
-    /// <inheritdoc />
     /// <summary>
-    /// Sets the BaseUrl property for requests made by this client instance
+    /// Creates an instance of RestClient using a specific BaseUrl for requests made by this client instance
     /// </summary>
-    /// <param name="baseUrl"></param>
+    /// <param name="baseUrl">Base URI for the new client</param>
     public RestClient(Uri baseUrl) : this(new RestClientOptions { BaseUrl = baseUrl }) { }
 
-    /// <inheritdoc />
     /// <summary>
-    /// Sets the BaseUrl property for requests made by this client instance
+    /// Creates an instance of RestClient using a specific BaseUrl for requests made by this client instance
     /// </summary>
-    /// <param name="baseUrl"></param>
+    /// <param name="baseUrl">Base URI for this new client as a string</param>
     public RestClient(string baseUrl) : this(new Uri(Ensure.NotEmptyString(baseUrl, nameof(baseUrl)))) { }
 
+    /// <summary>
+    /// Creates an instance of RestClient using a shared HttpClient and does not allocate one internally.
+    /// </summary>
+    /// <param name="httpClient">HttpClient to use</param>
+    /// <param name="disposeHttpClient">True to dispose of the client, false to assume the caller does (defaults to false)</param>
     public RestClient(HttpClient httpClient, bool disposeHttpClient = false) {
         UseDefaultSerializers();
 
         HttpClient         = httpClient;
-        CookieContainer    = new CookieContainer();
         Options            = new RestClientOptions();
         _disposeHttpClient = disposeHttpClient;
 
@@ -96,15 +94,16 @@ public partial class RestClient : IDisposable {
         }
     }
 
+    /// <summary>
+    /// Creates an instance of RestClient using a shared HttpClient and specific RestClientOptions and does not allocate one internally.
+    /// </summary>
+    /// <param name="httpClient">HttpClient to use</param>
+    /// <param name="options">RestClient options to use</param>
+    /// <param name="disposeHttpClient">True to dispose of the client, false to assume the caller does (defaults to false)</param>
     public RestClient(HttpClient httpClient, RestClientOptions options, bool disposeHttpClient = false) {
-        if (options.CookieContainer != null) {
-            throw new ArgumentException("Custom cookie container cannot be added to the HttpClient instance", nameof(options.CookieContainer));
-        }
-
         UseDefaultSerializers();
 
         HttpClient         = httpClient;
-        CookieContainer    = new CookieContainer();
         Options            = options;
         _disposeHttpClient = disposeHttpClient;
 
@@ -123,15 +122,25 @@ public partial class RestClient : IDisposable {
     /// <param name="disposeHandler">Dispose the handler when disposing RestClient, true by default</param>
     public RestClient(HttpMessageHandler handler, bool disposeHandler = true) : this(new HttpClient(handler, disposeHandler), true) { }
 
+    /// <summary>
+    /// Returns the currently configured BaseUrl for this RestClient instance
+    /// </summary>
+    public Uri BaseUrl => Options.BaseUrl!;
+
+    /// <summary>
+    /// Returns the currently configured BaseHost for this RestClient instance
+    /// </summary>
+    public string BaseHost => Options.BaseHost!;
+
     void ConfigureHttpClient(HttpClient httpClient) {
         if (Options.Timeout > 0) httpClient.Timeout = TimeSpan.FromMilliseconds(Options.Timeout);
         httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(Options.UserAgent);
     }
 
     void ConfigureHttpMessageHandler(HttpClientHandler handler) {
+        handler.UseCookies             = false;
         handler.Credentials            = Options.Credentials;
         handler.UseDefaultCredentials  = Options.UseDefaultCredentials;
-        handler.CookieContainer        = CookieContainer;
         handler.AutomaticDecompression = Options.AutomaticDecompression;
         handler.PreAuthenticate        = Options.PreAuthenticate;
         handler.AllowAutoRedirect      = Options.FollowRedirects;
@@ -152,11 +161,6 @@ public partial class RestClient : IDisposable {
     internal Func<string, string> Encode { get; set; } = s => s.UrlEncode();
 
     internal Func<string, Encoding, string> EncodeQuery { get; set; } = (s, encoding) => s.UrlEncode(encoding)!;
-
-    /// <summary>
-    /// Authenticator that will be used to populate request with necessary authentication data
-    /// </summary>
-    public IAuthenticator? Authenticator { get; set; }
 
     public ParametersCollection DefaultParameters { get; } = new();
 

--- a/src/RestSharp/RestClientExtensions.Config.cs
+++ b/src/RestSharp/RestClientExtensions.Config.cs
@@ -13,9 +13,7 @@
 // limitations under the License.
 // 
 
-using System.Net;
 using System.Text;
-using RestSharp.Authenticators;
 using RestSharp.Extensions;
 
 namespace RestSharp;
@@ -42,24 +40,4 @@ public static partial class RestClientExtensions {
     /// <returns></returns>
     public static RestClient UseQueryEncoder(this RestClient client, Func<string, Encoding, string> queryEncoder)
         => client.With(x => x.EncodeQuery = queryEncoder);
-
-    /// <summary>
-    /// Adds cookie to the <seealso cref="HttpClient"/> cookie container.
-    /// </summary>
-    /// <param name="client"></param>
-    /// <param name="name">Cookie name</param>
-    /// <param name="value">Cookie value</param>
-    /// <param name="path">Cookie path</param>
-    /// <param name="domain">Cookie domain, must not be an empty string</param>
-    /// <returns></returns>
-    public static RestClient AddCookie(this RestClient client, string name, string value, string path, string domain) {
-        lock (client.CookieContainer) {
-            client.CookieContainer.Add(new Cookie(name, value, path, domain));
-        }
-
-        return client;
-    }
-
-    public static RestClient UseAuthenticator(this RestClient client, IAuthenticator authenticator)
-        => client.With(x => x.Authenticator = authenticator);
 }

--- a/src/RestSharp/RestClientExtensions.Json.cs
+++ b/src/RestSharp/RestClientExtensions.Json.cs
@@ -14,6 +14,7 @@
 // 
 
 using System.Net;
+using RestSharp.Authenticators;
 using RestSharp.Extensions;
 
 namespace RestSharp;
@@ -25,21 +26,42 @@ public static partial class RestClientExtensions {
     /// <param name="client">RestClient instance</param>
     /// <param name="resource">Resource URL</param>
     /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
     /// <typeparam name="TResponse">Response object type</typeparam>
-    /// <returns></returns>
-    public static Task<TResponse?> GetJsonAsync<TResponse>(this RestClient client, string resource, CancellationToken cancellationToken = default) {
-        var request = new RestRequest(resource);
+    /// <returns>Deserialized response object</returns>
+    public static Task<TResponse?> GetJsonAsync<TResponse>(
+        this RestClient   client,
+        string            resource,
+        CancellationToken cancellationToken = default,
+        IAuthenticator?   authenticator     = null
+    ) {
+        var request = new RestRequest(resource) {
+            Authenticator = authenticator
+        };
         return client.GetAsync<TResponse>(request, cancellationToken);
     }
 
+    /// <summary>
+    /// Calls the URL specified in the <code>resource</code> parameter, expecting a JSON response back. Deserializes and returns the response.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="resource">Resource URL</param>
+    /// <param name="parameters">Parameters to pass to the request</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
+    /// <typeparam name="TResponse">Response object type</typeparam>
+    /// <returns>Deserialized response object</returns>
     public static Task<TResponse?> GetJsonAsync<TResponse>(
         this RestClient   client,
         string            resource,
         object            parameters,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken = default,
+        IAuthenticator?   authenticator = null
     ) {
         var props = parameters.GetProperties();
-        var request = new RestRequest(resource);
+        var request = new RestRequest(resource) {
+            Authenticator = authenticator
+        };
 
         foreach (var (name, value) in props) {
             Parameter parameter = resource.Contains($"{name}") ? new UrlSegmentParameter(name, value!) : new QueryParameter(name, value);
@@ -57,6 +79,7 @@ public static partial class RestClientExtensions {
     /// <param name="resource">Resource URL</param>
     /// <param name="request">Request object, must be serializable to JSON</param>
     /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
     /// <typeparam name="TRequest">Request object type</typeparam>
     /// <typeparam name="TResponse">Response object type</typeparam>
     /// <returns>Deserialized response object</returns>
@@ -64,9 +87,12 @@ public static partial class RestClientExtensions {
         this RestClient   client,
         string            resource,
         TRequest          request,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken = default,
+        IAuthenticator?   authenticator     = null
     ) where TRequest : class {
-        var restRequest = new RestRequest(resource).AddJsonBody(request);
+        var restRequest = new RestRequest(resource) {
+            Authenticator = authenticator
+        }.AddJsonBody(request);
         return client.PostAsync<TResponse>(restRequest, cancellationToken);
     }
 
@@ -78,15 +104,19 @@ public static partial class RestClientExtensions {
     /// <param name="resource">Resource URL</param>
     /// <param name="request">Request object, must be serializable to JSON</param>
     /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
     /// <typeparam name="TRequest">Request object type</typeparam>
     /// <returns>Response status code</returns>
     public static async Task<HttpStatusCode> PostJsonAsync<TRequest>(
         this RestClient   client,
         string            resource,
         TRequest          request,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken = default,
+        IAuthenticator?   authenticator     = null
     ) where TRequest : class {
-        var restRequest = new RestRequest(resource).AddJsonBody(request);
+        var restRequest = new RestRequest(resource) {
+            Authenticator = authenticator
+        }.AddJsonBody(request);
         var response    = await client.PostAsync(restRequest, cancellationToken).ConfigureAwait(false);
         return response.StatusCode;
     }
@@ -99,6 +129,7 @@ public static partial class RestClientExtensions {
     /// <param name="resource">Resource URL</param>
     /// <param name="request">Request object, must be serializable to JSON</param>
     /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
     /// <typeparam name="TRequest">Request object type</typeparam>
     /// <typeparam name="TResponse">Response object type</typeparam>
     /// <returns>Deserialized response object</returns>
@@ -106,9 +137,12 @@ public static partial class RestClientExtensions {
         this RestClient   client,
         string            resource,
         TRequest          request,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken = default,
+        IAuthenticator?   authenticator     = null
     ) where TRequest : class {
-        var restRequest = new RestRequest(resource).AddJsonBody(request);
+        var restRequest = new RestRequest(resource) {
+            Authenticator = authenticator
+        }.AddJsonBody(request);
         return client.PutAsync<TResponse>(restRequest, cancellationToken);
     }
 
@@ -120,15 +154,19 @@ public static partial class RestClientExtensions {
     /// <param name="resource">Resource URL</param>
     /// <param name="request">Request object, must be serializable to JSON</param>
     /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
     /// <typeparam name="TRequest">Request object type</typeparam>
     /// <returns>Response status code</returns>
     public static async Task<HttpStatusCode> PutJsonAsync<TRequest>(
         this RestClient   client,
         string            resource,
         TRequest          request,
-        CancellationToken cancellationToken = default
+        CancellationToken cancellationToken = default,
+        IAuthenticator?   authenticator     = null
     ) where TRequest : class {
-        var restRequest = new RestRequest(resource).AddJsonBody(request);
+        var restRequest = new RestRequest(resource) {
+            Authenticator = authenticator
+        }.AddJsonBody(request);
         var response    = await client.PutAsync(restRequest, cancellationToken).ConfigureAwait(false);
         return response.StatusCode;
     }

--- a/src/RestSharp/RestClientExtensions.Json.cs
+++ b/src/RestSharp/RestClientExtensions.Json.cs
@@ -25,6 +25,20 @@ public static partial class RestClientExtensions {
     /// </summary>
     /// <param name="client">RestClient instance</param>
     /// <param name="resource">Resource URL</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
+    /// <typeparam name="TResponse">Response object type</typeparam>
+    /// <returns>Deserialized response object</returns>
+    public static TResponse? GetJson<TResponse>(
+        this RestClient   client,
+        string            resource,
+        IAuthenticator?   authenticator = null)
+        => AsyncHelpers.RunSync(() => client.GetJsonAsync<TResponse>(resource, authenticator: authenticator));
+
+    /// <summary>
+    /// Calls the URL specified in the <code>resource</code> parameter, expecting a JSON response back. Deserializes and returns the response.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="resource">Resource URL</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <param name="authenticator">Optional authenticator to use for the request</param>
     /// <typeparam name="TResponse">Response object type</typeparam>
@@ -40,6 +54,22 @@ public static partial class RestClientExtensions {
         };
         return client.GetAsync<TResponse>(request, cancellationToken);
     }
+
+    /// <summary>
+    /// Calls the URL specified in the <code>resource</code> parameter, expecting a JSON response back. Deserializes and returns the response.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="resource">Resource URL</param>
+    /// <param name="parameters">Parameters to pass to the request</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
+    /// <typeparam name="TResponse">Response object type</typeparam>
+    /// <returns>Deserialized response object</returns>
+    public static TResponse? GetJson<TResponse>(
+        this RestClient   client,
+        string            resource,
+        object            parameters,
+        IAuthenticator?   authenticator = null)
+        => AsyncHelpers.RunSync(() => client.GetJsonAsync<TResponse>(resource, parameters, authenticator: authenticator));
 
     /// <summary>
     /// Calls the URL specified in the <code>resource</code> parameter, expecting a JSON response back. Deserializes and returns the response.
@@ -78,6 +108,25 @@ public static partial class RestClientExtensions {
     /// <param name="client">RestClient instance</param>
     /// <param name="resource">Resource URL</param>
     /// <param name="request">Request object, must be serializable to JSON</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
+    /// <typeparam name="TRequest">Request object type</typeparam>
+    /// <typeparam name="TResponse">Response object type</typeparam>
+    /// <returns>Deserialized response object</returns>
+    public static TResponse? PostJson<TRequest, TResponse>(
+        this RestClient   client,
+        string            resource,
+        TRequest          request,
+        IAuthenticator?   authenticator     = null
+    ) where TRequest : class
+        => AsyncHelpers.RunSync(() => client.PostJsonAsync<TRequest, TResponse>(resource, request, authenticator: authenticator));
+
+    /// <summary>
+    /// Serializes the <code>request</code> object to JSON and makes a POST call to the resource specified in the <code>resource</code> parameter.
+    /// Expects a JSON response back, deserializes it to <code>TResponse</code> type and returns it.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="resource">Resource URL</param>
+    /// <param name="request">Request object, must be serializable to JSON</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <param name="authenticator">Optional authenticator to use for the request</param>
     /// <typeparam name="TRequest">Request object type</typeparam>
@@ -95,6 +144,24 @@ public static partial class RestClientExtensions {
         }.AddJsonBody(request);
         return client.PostAsync<TResponse>(restRequest, cancellationToken);
     }
+
+    /// <summary>
+    /// Serializes the <code>request</code> object to JSON and makes a POST call to the resource specified in the <code>resource</code> parameter.
+    /// Expects no response back, just the status code.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="resource">Resource URL</param>
+    /// <param name="request">Request object, must be serializable to JSON</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
+    /// <typeparam name="TRequest">Request object type</typeparam>
+    /// <returns>Response status code</returns>
+    public static HttpStatusCode PostJson<TRequest>(
+        this RestClient client,
+        string          resource,
+        TRequest        request,
+        IAuthenticator? authenticator = null
+    ) where TRequest : class
+        => AsyncHelpers.RunSync(() => client.PostJsonAsync(resource, request, authenticator: authenticator));
 
     /// <summary>
     /// Serializes the <code>request</code> object to JSON and makes a POST call to the resource specified in the <code>resource</code> parameter.
@@ -128,6 +195,25 @@ public static partial class RestClientExtensions {
     /// <param name="client">RestClient instance</param>
     /// <param name="resource">Resource URL</param>
     /// <param name="request">Request object, must be serializable to JSON</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
+    /// <typeparam name="TRequest">Request object type</typeparam>
+    /// <typeparam name="TResponse">Response object type</typeparam>
+    /// <returns>Deserialized response object</returns>
+    public static TResponse? PutJson<TRequest, TResponse>(
+        this RestClient   client,
+        string            resource,
+        TRequest          request,
+        IAuthenticator?   authenticator     = null
+    ) where TRequest : class
+        => AsyncHelpers.RunSync(() => client.PutJsonAsync<TRequest, TResponse>(resource, request, authenticator: authenticator));
+
+    /// <summary>
+    /// Serializes the <code>request</code> object to JSON and makes a PUT call to the resource specified in the <code>resource</code> parameter.
+    /// Expects a JSON response back, deserializes it to <code>TResponse</code> type and returns it.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="resource">Resource URL</param>
+    /// <param name="request">Request object, must be serializable to JSON</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <param name="authenticator">Optional authenticator to use for the request</param>
     /// <typeparam name="TRequest">Request object type</typeparam>
@@ -145,6 +231,24 @@ public static partial class RestClientExtensions {
         }.AddJsonBody(request);
         return client.PutAsync<TResponse>(restRequest, cancellationToken);
     }
+
+    /// <summary>
+    /// Serializes the <code>request</code> object to JSON and makes a PUT call to the resource specified in the <code>resource</code> parameter.
+    /// Expects no response back, just the status code.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="resource">Resource URL</param>
+    /// <param name="request">Request object, must be serializable to JSON</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
+    /// <typeparam name="TRequest">Request object type</typeparam>
+    /// <returns>Response status code</returns>
+    public static HttpStatusCode PutJson<TRequest>(
+        this RestClient client,
+        string          resource,
+        TRequest        request,
+        IAuthenticator? authenticator = null
+    ) where TRequest : class
+        => AsyncHelpers.RunSync(() => client.PutJsonAsync(resource, request, authenticator: authenticator));
 
     /// <summary>
     /// Serializes the <code>request</code> object to JSON and makes a PUT call to the resource specified in the <code>resource</code> parameter.

--- a/src/RestSharp/RestClientExtensions.cs
+++ b/src/RestSharp/RestClientExtensions.cs
@@ -13,6 +13,7 @@
 //   limitations under the License. 
 
 using System.Runtime.CompilerServices;
+using RestSharp.Authenticators;
 using RestSharp.Extensions;
 
 namespace RestSharp;
@@ -316,18 +317,23 @@ public static partial class RestClientExtensions {
     /// Reads a stream returned by the specified endpoint, deserializes each line to JSON and returns each object asynchronously.
     /// It is required for each JSON object to be returned in a single line.
     /// </summary>
-    /// <param name="client"></param>
-    /// <param name="resource"></param>
-    /// <param name="cancellationToken"></param>
+    /// <param name="client">Rest client</param>
+    /// <param name="resource">Resource URL</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="authenticator">Optional authenticator to use for the request</param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
     [PublicAPI]
     public static async IAsyncEnumerable<T> StreamJsonAsync<T>(
         this RestClient                            client,
         string                                     resource,
-        [EnumeratorCancellation] CancellationToken cancellationToken
+        [EnumeratorCancellation] CancellationToken cancellationToken,
+        IAuthenticator?                            authenticator = null
     ) {
-        var request = new RestRequest(resource) { CompletionOption = HttpCompletionOption.ResponseHeadersRead };
+        var request = new RestRequest(resource) {
+            CompletionOption = HttpCompletionOption.ResponseHeadersRead,
+            Authenticator = authenticator
+        };
 
 #if NETSTANDARD
         using var stream = await client.DownloadStreamAsync(request, cancellationToken).ConfigureAwait(false);

--- a/src/RestSharp/RestClientExtensions.cs
+++ b/src/RestSharp/RestClientExtensions.cs
@@ -21,6 +21,17 @@ namespace RestSharp;
 [PublicAPI]
 public static partial class RestClientExtensions {
     /// <summary>
+    /// Executes a GET-style request synchronously, authenticating if needed.
+    /// The response content then gets deserialized to T.
+    /// </summary>
+    /// <typeparam name="T">Target deserialization type</typeparam>
+    /// <param name="client"></param>
+    /// <param name="request">Request to be executed</param>
+    /// <returns>Deserialized response content</returns>
+    public static RestResponse<T> ExecuteGet<T>(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.ExecuteAsync<T>(request, Method.Get));
+
+    /// <summary>
     /// Executes a GET-style request asynchronously, authenticating if needed.
     /// The response content then gets deserialized to T.
     /// </summary>
@@ -33,6 +44,14 @@ public static partial class RestClientExtensions {
         => client.ExecuteAsync<T>(request, Method.Get, cancellationToken);
 
     /// <summary>
+    /// Executes a GET-style synchronously, authenticating if needed
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="request">Request to be executed</param>
+    public static RestResponse ExecuteGet(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.ExecuteAsync(request, Method.Get));
+
+    /// <summary>
     /// Executes a GET-style asynchronously, authenticating if needed
     /// </summary>
     /// <param name="client"></param>
@@ -40,6 +59,20 @@ public static partial class RestClientExtensions {
     /// <param name="cancellationToken">Cancellation token</param>
     public static Task<RestResponse> ExecuteGetAsync(this RestClient client, RestRequest request, CancellationToken cancellationToken = default)
         => client.ExecuteAsync(request, Method.Get, cancellationToken);
+
+    /// <summary>
+    /// Executes a POST-style request synchronously, authenticating if needed.
+    /// The response content then gets deserialized to T.
+    /// </summary>
+    /// <typeparam name="T">Target deserialization type</typeparam>
+    /// <param name="client"></param>
+    /// <param name="request">Request to be executed</param>
+    /// <returns>Deserialized response content</returns>
+    public static RestResponse<T> ExecutePost<T>(
+        this RestClient   client,
+        RestRequest       request
+    )
+        => AsyncHelpers.RunSync(() => client.ExecuteAsync<T>(request, Method.Post));
 
     /// <summary>
     /// Executes a POST-style request asynchronously, authenticating if needed.
@@ -58,6 +91,14 @@ public static partial class RestClientExtensions {
         => client.ExecuteAsync<T>(request, Method.Post, cancellationToken);
 
     /// <summary>
+    /// Executes a POST-style synchronously, authenticating if needed
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="request">Request to be executed</param>
+    public static RestResponse ExecutePost(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.ExecuteAsync(request, Method.Post));
+
+    /// <summary>
     /// Executes a POST-style asynchronously, authenticating if needed
     /// </summary>
     /// <param name="client"></param>
@@ -65,6 +106,20 @@ public static partial class RestClientExtensions {
     /// <param name="cancellationToken">Cancellation token</param>
     public static Task<RestResponse> ExecutePostAsync(this RestClient client, RestRequest request, CancellationToken cancellationToken = default)
         => client.ExecuteAsync(request, Method.Post, cancellationToken);
+
+    /// <summary>
+    /// Executes a PUT-style request synchronously, authenticating if needed.
+    /// The response content then gets deserialized to T.
+    /// </summary>
+    /// <typeparam name="T">Target deserialization type</typeparam>
+    /// <param name="client"></param>
+    /// <param name="request">Request to be executed</param>
+    /// <returns>Deserialized response content</returns>
+    public static RestResponse<T> ExecutePut<T>(
+        this RestClient   client,
+        RestRequest       request
+    )
+        => AsyncHelpers.RunSync(() => client.ExecuteAsync<T>(request, Method.Put));
 
     /// <summary>
     /// Executes a PUT-style request asynchronously, authenticating if needed.
@@ -83,6 +138,14 @@ public static partial class RestClientExtensions {
         => client.ExecuteAsync<T>(request, Method.Put, cancellationToken);
 
     /// <summary>
+    /// Executes a PUP-style synchronously, authenticating if needed
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="request">Request to be executed</param>
+    public static RestResponse ExecutePut(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.ExecuteAsync(request, Method.Put));
+
+    /// <summary>
     /// Executes a PUP-style asynchronously, authenticating if needed
     /// </summary>
     /// <param name="client"></param>
@@ -90,6 +153,18 @@ public static partial class RestClientExtensions {
     /// <param name="cancellationToken">Cancellation token</param>
     public static Task<RestResponse> ExecutePutAsync(this RestClient client, RestRequest request, CancellationToken cancellationToken = default)
         => client.ExecuteAsync(request, Method.Put, cancellationToken);
+
+    /// <summary>
+    /// Executes the request synchronously, authenticating if needed
+    /// </summary>
+    /// <typeparam name="T">Target deserialization type</typeparam>
+    /// <param name="client"></param>
+    /// <param name="request">Request to be executed</param>
+    public static RestResponse<T> Execute<T>(
+        this RestClient client,
+        RestRequest     request
+    )
+        => AsyncHelpers.RunSync(() => client.ExecuteAsync<T>(request));
 
     /// <summary>
     /// Executes the request asynchronously, authenticating if needed
@@ -111,6 +186,19 @@ public static partial class RestClientExtensions {
     }
 
     /// <summary>
+    /// Executes the request synchronously, authenticating if needed
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="request">Request to be executed</param>
+    /// <param name="httpMethod">Override the request method</param>
+    public static RestResponse Execute(
+        this RestClient   client,
+        RestRequest       request,
+        Method            httpMethod
+    )
+        => AsyncHelpers.RunSync(() => client.ExecuteAsync(request, httpMethod));
+
+    /// <summary>
     /// Executes the request asynchronously, authenticating if needed
     /// </summary>
     /// <param name="client"></param>
@@ -128,6 +216,20 @@ public static partial class RestClientExtensions {
         request.Method = httpMethod;
         return client.ExecuteAsync(request, cancellationToken);
     }
+
+    /// <summary>
+    /// Executes the request synchronously, authenticating if needed
+    /// </summary>
+    /// <typeparam name="T">Target deserialization type</typeparam>
+    /// <param name="client"></param>
+    /// <param name="request">Request to be executed</param>
+    /// <param name="httpMethod">Override the request method</param>
+    public static RestResponse<T> Execute<T>(
+        this RestClient   client,
+        RestRequest       request,
+        Method            httpMethod
+    )
+        => AsyncHelpers.RunSync(() => client.ExecuteAsync<T>(request, httpMethod));
 
     /// <summary>
     /// Executes the request asynchronously, authenticating if needed
@@ -155,6 +257,17 @@ public static partial class RestClientExtensions {
     /// </summary>
     /// <param name="client">RestClient instance</param>
     /// <param name="request">The request</param>
+    /// <typeparam name="T">Expected result type</typeparam>
+    /// <returns></returns>
+    public static T? Get<T>(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.GetAsync<T>(request));
+
+    /// <summary>
+    /// Execute the request using GET HTTP method. Exception will be thrown if the request does not succeed.
+    /// The response data is deserialized to the Data property of the returned response object.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="request">The request</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <typeparam name="T">Expected result type</typeparam>
     /// <returns></returns>
@@ -164,11 +277,25 @@ public static partial class RestClientExtensions {
         return response.Data;
     }
 
+    public static RestResponse Get(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.GetAsync(request));
+
     public static async Task<RestResponse> GetAsync(this RestClient client, RestRequest request, CancellationToken cancellationToken = default) {
         var response = await client.ExecuteGetAsync(request, cancellationToken).ConfigureAwait(false);
         RestClient.ThrowIfError(response);
         return response;
     }
+
+    /// <summary>
+    /// Execute the request using POST HTTP method. Exception will be thrown if the request does not succeed.
+    /// The response data is deserialized to the Data property of the returned response object.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="request">The request</param>
+    /// <typeparam name="T">Expected result type</typeparam>
+    /// <returns></returns>
+    public static T? Post<T>(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.PostAsync<T>(request));
 
     /// <summary>
     /// Execute the request using POST HTTP method. Exception will be thrown if the request does not succeed.
@@ -185,11 +312,25 @@ public static partial class RestClientExtensions {
         return response.Data;
     }
 
+    public static RestResponse Post(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.PostAsync(request));
+
     public static async Task<RestResponse> PostAsync(this RestClient client, RestRequest request, CancellationToken cancellationToken = default) {
         var response = await client.ExecutePostAsync(request, cancellationToken).ConfigureAwait(false);
         RestClient.ThrowIfError(response);
         return response;
     }
+
+    /// <summary>
+    /// Execute the request using PUT HTTP method. Exception will be thrown if the request does not succeed.
+    /// The response data is deserialized to the Data property of the returned response object.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="request">The request</param>
+    /// <typeparam name="T">Expected result type</typeparam>
+    /// <returns></returns>
+    public static T? Put<T>(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.PutAsync<T>(request));
 
     /// <summary>
     /// Execute the request using PUT HTTP method. Exception will be thrown if the request does not succeed.
@@ -206,11 +347,25 @@ public static partial class RestClientExtensions {
         return response.Data;
     }
 
+    public static RestResponse Put(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.PutAsync(request));
+
     public static async Task<RestResponse> PutAsync(this RestClient client, RestRequest request, CancellationToken cancellationToken = default) {
         var response = await client.ExecuteAsync(request, Method.Put, cancellationToken).ConfigureAwait(false);
         RestClient.ThrowIfError(response);
         return response;
     }
+
+    /// <summary>
+    /// Execute the request using HEAD HTTP method. Exception will be thrown if the request does not succeed.
+    /// The response data is deserialized to the Data property of the returned response object.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="request">The request</param>
+    /// <typeparam name="T">Expected result type</typeparam>
+    /// <returns></returns>
+    public static T? Head<T>(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.HeadAsync<T>(request));
 
     /// <summary>
     /// Execute the request using HEAD HTTP method. Exception will be thrown if the request does not succeed.
@@ -227,11 +382,25 @@ public static partial class RestClientExtensions {
         return response.Data;
     }
 
+    public static RestResponse Head(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.HeadAsync(request));
+
     public static async Task<RestResponse> HeadAsync(this RestClient client, RestRequest request, CancellationToken cancellationToken = default) {
         var response = await client.ExecuteAsync(request, Method.Head, cancellationToken).ConfigureAwait(false);
         RestClient.ThrowIfError(response);
         return response;
     }
+
+    /// <summary>
+    /// Execute the request using OPTIONS HTTP method. Exception will be thrown if the request does not succeed.
+    /// The response data is deserialized to the Data property of the returned response object.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="request">The request</param>
+    /// <typeparam name="T">Expected result type</typeparam>
+    /// <returns></returns>
+    public static T? Options<T>(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.OptionsAsync<T>(request));
 
     /// <summary>
     /// Execute the request using OPTIONS HTTP method. Exception will be thrown if the request does not succeed.
@@ -248,11 +417,25 @@ public static partial class RestClientExtensions {
         return response.Data;
     }
 
+    public static RestResponse Options(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.OptionsAsync(request));
+
     public static async Task<RestResponse> OptionsAsync(this RestClient client, RestRequest request, CancellationToken cancellationToken = default) {
         var response = await client.ExecuteAsync(request, Method.Options, cancellationToken).ConfigureAwait(false);
         RestClient.ThrowIfError(response);
         return response;
     }
+
+    /// <summary>
+    /// Execute the request using PATCH HTTP method. Exception will be thrown if the request does not succeed.
+    /// The response data is deserialized to the Data property of the returned response object.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="request">The request</param>
+    /// <typeparam name="T">Expected result type</typeparam>
+    /// <returns></returns>
+    public static T? Patch<T>(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.PatchAsync<T>(request));
 
     /// <summary>
     /// Execute the request using PATCH HTTP method. Exception will be thrown if the request does not succeed.
@@ -269,11 +452,25 @@ public static partial class RestClientExtensions {
         return response.Data;
     }
 
+    public static RestResponse Patch(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.PatchAsync(request));
+
     public static async Task<RestResponse> PatchAsync(this RestClient client, RestRequest request, CancellationToken cancellationToken = default) {
         var response = await client.ExecuteAsync(request, Method.Patch, cancellationToken).ConfigureAwait(false);
         RestClient.ThrowIfError(response);
         return response;
     }
+
+    /// <summary>
+    /// Execute the request using DELETE HTTP method. Exception will be thrown if the request does not succeed.
+    /// The response data is deserialized to the Data property of the returned response object.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="request">The request</param>
+    /// <typeparam name="T">Expected result type</typeparam>
+    /// <returns></returns>
+    public static T? Delete<T>(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.DeleteAsync<T>(request));
 
     /// <summary>
     /// Execute the request using DELETE HTTP method. Exception will be thrown if the request does not succeed.
@@ -290,11 +487,24 @@ public static partial class RestClientExtensions {
         return response.Data;
     }
 
+    public static RestResponse Delete(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.DeleteAsync(request));
+
     public static async Task<RestResponse> DeleteAsync(this RestClient client, RestRequest request, CancellationToken cancellationToken = default) {
         var response = await client.ExecuteAsync(request, Method.Delete, cancellationToken).ConfigureAwait(false);
         RestClient.ThrowIfError(response);
         return response;
     }
+
+    /// <summary>
+    /// A specialized method to download files.
+    /// </summary>
+    /// <param name="client">RestClient instance</param>
+    /// <param name="request">Pre-configured request instance.</param>
+    /// <returns>The downloaded file.</returns>
+    [PublicAPI]
+    public static byte[]? DownloadData(this RestClient client, RestRequest request)
+        => AsyncHelpers.RunSync(() => client.DownloadDataAsync(request));
 
     /// <summary>
     /// A specialized method to download files.
@@ -327,7 +537,7 @@ public static partial class RestClientExtensions {
     public static async IAsyncEnumerable<T> StreamJsonAsync<T>(
         this RestClient                            client,
         string                                     resource,
-        [EnumeratorCancellation] CancellationToken cancellationToken,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default,
         IAuthenticator?                            authenticator = null
     ) {
         var request = new RestRequest(resource) {

--- a/src/RestSharp/RestClientOptions.cs
+++ b/src/RestSharp/RestClientOptions.cs
@@ -71,7 +71,6 @@ public class RestClientOptions {
     public X509CertificateCollection? ClientCertificates { get; set; }
 
     public IWebProxy?               Proxy           { get; set; }
-    public CacheControlHeaderValue? CachePolicy     { get; set; }
     public bool                     FollowRedirects { get; set; } = true;
     public string                   UserAgent       { get; set; } = DefaultUserAgent;
     public int                      Timeout         { get; set; }
@@ -107,12 +106,6 @@ public class RestClientOptions {
     /// overriding certificate errors in the scope of a request.
     /// </summary>
     public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; set; }
-
-    /// <summary>
-    /// Explicit Host header value to use in requests independent from the request URI.
-    /// If null, default host value extracted from BaseUrl is used.
-    /// </summary>
-    public string? BaseHost { get; set; }
 
     /// <summary>
     /// By default, RestSharp doesn't allow multiple parameters to have the same name.

--- a/src/RestSharp/RestClientOptions.cs
+++ b/src/RestSharp/RestClientOptions.cs
@@ -73,7 +73,6 @@ public class RestClientOptions {
     public IWebProxy?               Proxy           { get; set; }
     public CacheControlHeaderValue? CachePolicy     { get; set; }
     public bool                     FollowRedirects { get; set; } = true;
-    public CookieContainer?         CookieContainer { get; set; }
     public string                   UserAgent       { get; set; } = DefaultUserAgent;
     public int                      Timeout         { get; set; }
     public Encoding                 Encoding        { get; set; } = Encoding.UTF8;

--- a/src/RestSharp/RestClientOptions.cs
+++ b/src/RestSharp/RestClientOptions.cs
@@ -15,16 +15,12 @@
 
 using System.Net;
 using System.Net.Security;
-using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
 namespace RestSharp;
 
 public class RestClientOptions {
-    static readonly Version Version = new AssemblyName(typeof(RestClientOptions).Assembly.FullName!).Version!;
-    static readonly string DefaultUserAgent = $"RestSharp/{Version}";
-
     /// <summary>
     /// Default constructor for default RestClientOptions
     /// </summary>
@@ -100,13 +96,8 @@ public class RestClientOptions {
     public bool FollowRedirects { get; set; } = true;
 
     /// <summary>
-    /// Sets the user agent string to be used for all requests from this client. Defaults to a RestSharp string if not provided.
-    /// </summary>
-    public string UserAgent { get; set; } = DefaultUserAgent;
-
-    /// <summary>
     /// Sets the timeout in milliseconds for all requests using this client. You can also set a timeout value on a per
-    /// request basis, but beard in mind the shorter of the two values is what will end up being used. So if you need long
+    /// request basis, but bear in mind the shorter of the two values is what will end up being used. So if you need long
     /// timeouts at the request level, you will want to set this to a larger value than the maximum you need per request.
     /// </summary>
     public int Timeout { get; set; }

--- a/src/RestSharp/RestClientOptions.cs
+++ b/src/RestSharp/RestClientOptions.cs
@@ -34,10 +34,10 @@ public class RestClientOptions {
     public RestClientOptions(string baseUrl) : this(new Uri(Ensure.NotEmptyString(baseUrl, nameof(baseUrl)))) { }
 
     /// <summary>
-    /// Explicit Host header value to use in requests independent from the request URI.
-    /// If null, default host value extracted from URI is used.
+    /// Base URI for all requests base with the RestClient. This cannot be changed after the client has been
+    /// constructed.
     /// </summary>
-    public Uri? BaseUrl { get; set; }
+    public Uri? BaseUrl { get; internal set; }
     
     public Func<HttpMessageHandler, HttpMessageHandler>? ConfigureMessageHandler { get; set; }
     
@@ -109,6 +109,10 @@ public class RestClientOptions {
     /// </summary>
     public RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get; set; }
 
+    /// <summary>
+    /// Explicit Host header value to use in requests independent from the request URI.
+    /// If null, default host value extracted from BaseUrl is used.
+    /// </summary>
     public string? BaseHost { get; set; }
 
     /// <summary>

--- a/src/RestSharp/RestClientOptions.cs
+++ b/src/RestSharp/RestClientOptions.cs
@@ -96,9 +96,16 @@ public class RestClientOptions {
     public bool FollowRedirects { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a Boolean value that determines whether 100-Continue behavior is used. Default is true.
+    /// </summary>
+    public bool Expect100Continue { get; set; } = true;
+
+    /// <summary>
     /// Sets the timeout in milliseconds for all requests using this client. You can also set a timeout value on a per
     /// request basis, but bear in mind the shorter of the two values is what will end up being used. So if you need long
     /// timeouts at the request level, you will want to set this to a larger value than the maximum you need per request.
+    ///
+    /// If this value is left at the default of 0, the build in default HttpClient timeout of 100 seconds is used.
     /// </summary>
     public int Timeout { get; set; }
 

--- a/src/RestSharp/RestClientOptions.cs
+++ b/src/RestSharp/RestClientOptions.cs
@@ -14,7 +14,6 @@
 // 
 
 using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
@@ -24,13 +23,23 @@ namespace RestSharp;
 
 public class RestClientOptions {
     static readonly Version Version = new AssemblyName(typeof(RestClientOptions).Assembly.FullName!).Version!;
-
     static readonly string DefaultUserAgent = $"RestSharp/{Version}";
 
+    /// <summary>
+    /// Default constructor for default RestClientOptions
+    /// </summary>
     public RestClientOptions() { }
 
+    /// <summary>
+    /// Constructor for RestClientOptions using a specific base URL pass in the Uri format.
+    /// </summary>
+    /// <param name="baseUrl">Base URL to use in Uri format</param>
     public RestClientOptions(Uri baseUrl) => BaseUrl = baseUrl;
 
+    /// <summary>
+    /// Constructor for RestClientOptions using a specific base URL pass as a string.
+    /// </summary>
+    /// <param name="baseUrl">Base URL to use in string format</param>
     public RestClientOptions(string baseUrl) : this(new Uri(Ensure.NotEmptyString(baseUrl, nameof(baseUrl)))) { }
 
     /// <summary>
@@ -38,7 +47,10 @@ public class RestClientOptions {
     /// constructed.
     /// </summary>
     public Uri? BaseUrl { get; internal set; }
-    
+
+    /// <summary>
+    /// Optional callback to allow you to configure the underlying HttpMessageHandler for this client when it is created.
+    /// </summary>
     public Func<HttpMessageHandler, HttpMessageHandler>? ConfigureMessageHandler { get; set; }
     
     /// <summary>
@@ -57,12 +69,19 @@ public class RestClientOptions {
     /// </summary>
     public bool DisableCharset { get; set; }
 
+    /// <summary>
+    /// Option to enable automatic decompression of responses. Defaults to GZip or higher where possible.
+    /// </summary>
 #if NETSTANDARD
     public DecompressionMethods AutomaticDecompression { get; set; } = DecompressionMethods.GZip;
 #else
     public DecompressionMethods AutomaticDecompression { get; set; } = DecompressionMethods.All;
 #endif
 
+    /// <summary>
+    /// Option to control the maximum number of redirects the client will follow before giving up. If not
+    /// provided the HttpClient default value of 50 is used.
+    /// </summary>
     public int? MaxRedirects { get; set; }
 
     /// <summary>
@@ -70,11 +89,32 @@ public class RestClientOptions {
     /// </summary>
     public X509CertificateCollection? ClientCertificates { get; set; }
 
-    public IWebProxy?               Proxy           { get; set; }
-    public bool                     FollowRedirects { get; set; } = true;
-    public string                   UserAgent       { get; set; } = DefaultUserAgent;
-    public int                      Timeout         { get; set; }
-    public Encoding                 Encoding        { get; set; } = Encoding.UTF8;
+    /// <summary>
+    /// Define the optional web proxy to use for all requests via this client instance
+    /// </summary>
+    public IWebProxy? Proxy { get; set; }
+
+    /// <summary>
+    /// Indicates whether the client will follow redirects or not. Defaults to true.
+    /// </summary>
+    public bool FollowRedirects { get; set; } = true;
+
+    /// <summary>
+    /// Sets the user agent string to be used for all requests from this client. Defaults to a RestSharp string if not provided.
+    /// </summary>
+    public string UserAgent { get; set; } = DefaultUserAgent;
+
+    /// <summary>
+    /// Sets the timeout in milliseconds for all requests using this client. You can also set a timeout value on a per
+    /// request basis, but beard in mind the shorter of the two values is what will end up being used. So if you need long
+    /// timeouts at the request level, you will want to set this to a larger value than the maximum you need per request.
+    /// </summary>
+    public int Timeout { get; set; }
+
+    /// <summary>
+    /// Set the encoding to use for encoding encoding query strings. By default it uses UTF8.
+    /// </summary>
+    public Encoding Encoding { get; set; } = Encoding.UTF8;
 
     /// <summary>
     /// Flag to send authorisation header with the HttpWebRequest

--- a/test/RestSharp.InteractiveTests/AuthenticationTests.cs
+++ b/test/RestSharp.InteractiveTests/AuthenticationTests.cs
@@ -15,14 +15,13 @@ public class AuthenticationTests {
 
         var baseUrl = new Uri("https://api.twitter.com");
 
-        var client = new RestClient(baseUrl) {
+        var client = new RestClient(baseUrl);
+        var request  = new RestRequest("oauth/request_token") {
             Authenticator = OAuth1Authenticator.ForRequestToken(
                 twitterKeys.ConsumerKey!,
                 twitterKeys.ConsumerSecret,
-                "https://restsharp.dev"
-            )
+                "https://restsharp.dev")
         };
-        var request  = new RestRequest("oauth/request_token");
         var response = await client.ExecuteAsync(request);
 
         Assert.NotNull(response);
@@ -44,15 +43,15 @@ public class AuthenticationTests {
         Console.Write("Enter the verifier: ");
         var verifier = Console.ReadLine();
 
-        request = new RestRequest("oauth/access_token");
+        request = new RestRequest("oauth/access_token") {
+            Authenticator = OAuth1Authenticator.ForAccessToken(
+                twitterKeys.ConsumerKey!,
+                twitterKeys.ConsumerSecret,
+                oauthToken!,
+                oauthTokenSecret!,
+                verifier!)
+        };
 
-        client.Authenticator = OAuth1Authenticator.ForAccessToken(
-            twitterKeys.ConsumerKey!,
-            twitterKeys.ConsumerSecret,
-            oauthToken!,
-            oauthTokenSecret!,
-            verifier!
-        );
         response = await client.ExecuteAsync(request);
 
         Assert.NotNull(response);
@@ -65,14 +64,14 @@ public class AuthenticationTests {
         Assert.NotNull(oauthToken);
         Assert.NotNull(oauthTokenSecret);
 
-        request = new RestRequest("1.1/account/verify_credentials.json");
+        request = new RestRequest("1.1/account/verify_credentials.json") {
+            Authenticator = OAuth1Authenticator.ForProtectedResource(
+                twitterKeys.ConsumerKey!,
+                twitterKeys.ConsumerSecret,
+                oauthToken!,
+                oauthTokenSecret!)
+        };
 
-        client.Authenticator = OAuth1Authenticator.ForProtectedResource(
-            twitterKeys.ConsumerKey!,
-            twitterKeys.ConsumerSecret,
-            oauthToken!,
-            oauthTokenSecret!
-        );
         response = await client.ExecuteAsync(request);
 
         Console.WriteLine($"Code: {response.StatusCode}, response: {response.Content}");

--- a/test/RestSharp.InteractiveTests/TwitterClient.cs
+++ b/test/RestSharp.InteractiveTests/TwitterClient.cs
@@ -24,20 +24,21 @@ public interface ITwitterClient {
 }
 
 public class TwitterClient : ITwitterClient, IDisposable {
-    readonly RestClient _client;
+    readonly RestClient     _client;
+    readonly IAuthenticator _authenticator;
 
     public TwitterClient(string apiKey, string apiKeySecret) {
         var options = new RestClientOptions("https://api.twitter.com/2");
 
-        _client = new RestClient(options) {
-            Authenticator = new TwitterAuthenticator("https://api.twitter.com", apiKey, apiKeySecret)
-        };
+        _client        = new RestClient(options);
+        _authenticator = new TwitterAuthenticator("https://api.twitter.com", apiKey, apiKeySecret);
     }
 
     public async Task<TwitterUser> GetUser(string user) {
         var response = await _client.GetJsonAsync<TwitterSingleObject<TwitterUser>>(
             "users/by/username/{user}",
-            new { user }
+            new { user },
+            authenticator: _authenticator
         );
         return response!.Data;
     }
@@ -45,18 +46,24 @@ public class TwitterClient : ITwitterClient, IDisposable {
     public async Task<SearchRulesResponse[]> AddSearchRules(params AddStreamSearchRule[] rules) {
         var response = await _client.PostJsonAsync<AddSearchRulesRequest, TwitterCollectionObject<SearchRulesResponse>>(
             "tweets/search/stream/rules",
-            new AddSearchRulesRequest(rules)
+            new AddSearchRulesRequest(rules),
+            authenticator: _authenticator
         );
         return response?.Data;
     }
 
     public async Task<SearchRulesResponse[]> GetSearchRules() {
-        var response = await _client.GetJsonAsync<TwitterCollectionObject<SearchRulesResponse>>("tweets/search/stream/rules");
+        var response = await _client.GetJsonAsync<TwitterCollectionObject<SearchRulesResponse>>(
+            "tweets/search/stream/rules",
+            authenticator: _authenticator);
         return response?.Data;
     }
 
     public async IAsyncEnumerable<SearchResponse> SearchStream([EnumeratorCancellation] CancellationToken cancellationToken = default) {
-        var response = _client.StreamJsonAsync<TwitterSingleObject<SearchResponse>>("tweets/search/stream", cancellationToken);
+        var response = _client.StreamJsonAsync<TwitterSingleObject<SearchResponse>>(
+            "tweets/search/stream",
+            cancellationToken,
+            _authenticator);
 
         await foreach (var item in response.WithCancellation(cancellationToken)) {
             yield return item.Data;
@@ -94,12 +101,11 @@ class TwitterAuthenticator : AuthenticatorBase {
     async Task<string> GetToken() {
         var options = new RestClientOptions(_baseUrl);
 
-        using var client = new RestClient(options) {
-            Authenticator = new HttpBasicAuthenticator(_clientId, _clientSecret),
-        };
+        using var client = new RestClient(options);
 
-        var request = new RestRequest("oauth2/token")
-            .AddParameter("grant_type", "client_credentials");
+        var request = new RestRequest("oauth2/token") {
+            Authenticator = new HttpBasicAuthenticator(_clientId, _clientSecret),
+        }.AddParameter("grant_type", "client_credentials");
         var response = await client.PostAsync<TokenResponse>(request);
         return $"{response!.TokenType} {response!.AccessToken}";
     }

--- a/test/RestSharp.Tests.Integrated/Authentication/AuthenticationTests.cs
+++ b/test/RestSharp.Tests.Integrated/Authentication/AuthenticationTests.cs
@@ -21,10 +21,10 @@ public class AuthenticationTests {
         const string userName = "testuser";
         const string password = "testpassword";
 
-        var client = new RestClient(_fixture.Server.Url) {
+        var client = new RestClient(_fixture.Server.Url);
+        var request  = new RestRequest("headers") {
             Authenticator = new HttpBasicAuthenticator(userName, password)
         };
-        var request  = new RestRequest("headers");
         var response = await client.GetAsync<TestServerResponse[]>(request);
 
         var header = response!.First(x => x.Name == KnownHeaders.Authorization);

--- a/test/RestSharp.Tests.Integrated/Authentication/OAuth2Tests.cs
+++ b/test/RestSharp.Tests.Integrated/Authentication/OAuth2Tests.cs
@@ -1,5 +1,4 @@
 using RestSharp.Authenticators.OAuth2;
-using RestSharp.Tests.Integrated.Fixtures;
 using RestSharp.Tests.Integrated.Server;
 
 namespace RestSharp.Tests.Integrated.Authentication; 
@@ -14,9 +13,8 @@ public class OAuth2Tests {
     public async Task ShouldHaveProperHeader() {
         var client = new RestClient(_fixture.Server.Url);
         var auth   = new OAuth2AuthorizationRequestHeaderAuthenticator("token", "Bearer");
-        client.Authenticator = auth;
 
-        var response   = await client.GetJsonAsync<TestServerResponse[]>("headers");
+        var response   = await client.GetJsonAsync<TestServerResponse[]>("headers", authenticator: auth);
         var authHeader = response!.FirstOrDefault(x => x.Name == KnownHeaders.Authorization);
 
         authHeader.Should().NotBeNull();

--- a/test/RestSharp.Tests.Integrated/OAuth1Tests.cs
+++ b/test/RestSharp.Tests.Integrated/OAuth1Tests.cs
@@ -33,10 +33,10 @@ public class OAuth1Tests {
 
         var baseUrl = new Uri("http://api.netflix.com");
 
-        var client = new RestClient(baseUrl) {
+        var client = new RestClient(baseUrl);
+        var request  = new RestRequest("oauth/request_token") {
             Authenticator = OAuth1Authenticator.ForRequestToken(consumerKey, consumerSecret)
         };
-        var request  = new RestRequest("oauth/request_token");
         var response = await client.ExecuteAsync(request);
 
         Assert.NotNull(response);
@@ -66,7 +66,7 @@ public class OAuth1Tests {
 
         request = new RestRequest("oauth/access_token"); // <-- Breakpoint here, login to netflix
 
-        client.Authenticator = OAuth1Authenticator.ForAccessToken(
+        request.Authenticator = OAuth1Authenticator.ForAccessToken(
             consumerKey,
             consumerSecret,
             oauthToken,
@@ -87,7 +87,7 @@ public class OAuth1Tests {
         Assert.NotNull(oauthTokenSecret);
         Assert.NotNull(userId);
 
-        client.Authenticator = OAuth1Authenticator.ForProtectedResource(
+        request.Authenticator = OAuth1Authenticator.ForProtectedResource(
             consumerKey,
             consumerSecret,
             oauthToken,
@@ -111,14 +111,14 @@ public class OAuth1Tests {
         const string consumerSecret = "TODO_CONSUMER_SECRET_HERE";
 
         // request token
-        var client = new RestClient("https://api.linkedin.com/uas/oauth") {
+        var client = new RestClient("https://api.linkedin.com/uas/oauth");
+        var requestTokenRequest  = new RestRequest("requestToken") {
             Authenticator = OAuth1Authenticator.ForRequestToken(
                 consumerKey,
                 consumerSecret,
                 "http://localhost"
             )
-        };
-        var requestTokenRequest  = new RestRequest("requestToken");
+        };;
         var requestTokenResponse = await client.ExecuteAsync(requestTokenRequest);
 
         Assert.NotNull(requestTokenResponse);
@@ -150,15 +150,15 @@ public class OAuth1Tests {
         var requestTokenQueryParameters = new Uri(requestUrl).ParseQuery();
         var requestVerifier             = requestTokenQueryParameters["oauth_verifier"];
 
-        client.Authenticator = OAuth1Authenticator.ForAccessToken(
-            consumerKey,
-            consumerSecret,
-            requestToken,
-            requestSecret,
-            requestVerifier
-        );
-
-        var requestAccessTokenRequest  = new RestRequest("accessToken");
+        var requestAccessTokenRequest  = new RestRequest("accessToken") {
+            Authenticator = OAuth1Authenticator.ForAccessToken(
+                consumerKey,
+                consumerSecret,
+                requestToken,
+                requestSecret,
+                requestVerifier
+            )
+        };
         var requestActionTokenResponse = await client.ExecuteAsync(requestAccessTokenRequest);
 
         Assert.NotNull(requestActionTokenResponse);
@@ -208,7 +208,9 @@ public class OAuth1Tests {
             AccessSecret   = ""
         };
 
-        var client = new RestClient("https://api.twitter.com/1.1") {
+        var client = new RestClient("https://api.twitter.com/1.1");
+
+        var request = new RestRequest("account/verify_credentials.json") {
             Authenticator = OAuth1Authenticator.ForProtectedResource(
                 config.ConsumerKey,
                 config.ConsumerSecret,
@@ -216,8 +218,6 @@ public class OAuth1Tests {
                 config.AccessSecret
             )
         };
-
-        var request = new RestRequest("account/verify_credentials.json");
 
         request.AddParameter("include_entities", "true", ParameterType.QueryString);
 
@@ -234,10 +234,10 @@ public class OAuth1Tests {
 
         var baseUrl = new Uri("https://api.twitter.com");
 
-        var client = new RestClient(baseUrl) {
+        var client = new RestClient(baseUrl);
+        var request  = new RestRequest("oauth/request_token", Method.Post) {
             Authenticator = OAuth1Authenticator.ForRequestToken(consumerKey, consumerSecret)
         };
-        var request  = new RestRequest("oauth/request_token", Method.Post);
         var response = await client.ExecuteAsync(request);
 
         Assert.NotNull(response);
@@ -261,7 +261,7 @@ public class OAuth1Tests {
 
         request = new RestRequest("oauth/access_token", Method.Post);
 
-        client.Authenticator = OAuth1Authenticator.ForAccessToken(
+        request.Authenticator = OAuth1Authenticator.ForAccessToken(
             consumerKey,
             consumerSecret,
             oauthToken,
@@ -282,7 +282,7 @@ public class OAuth1Tests {
 
         request = new RestRequest("/1.1/account/verify_credentials.json");
 
-        client.Authenticator = OAuth1Authenticator.ForProtectedResource(
+        request.Authenticator = OAuth1Authenticator.ForProtectedResource(
             consumerKey,
             consumerSecret,
             oauthToken,
@@ -301,10 +301,10 @@ public class OAuth1Tests {
         const string consumerSecret = "TODO_CONSUMER_SECRET_HERE";
 
         // arrange
-        var client = new RestClient("http://vimeo.com/api/rest/v2") {
+        var client = new RestClient("http://vimeo.com/api/rest/v2");
+        var request = new RestRequest() {
             Authenticator = OAuth1Authenticator.ForRequestToken(consumerKey, consumerSecret)
         };
-        var request = new RestRequest();
 
         request.AddParameter("format", "json");
         request.AddParameter("method", "vimeo.videos.search");
@@ -332,7 +332,8 @@ public class OAuth1Tests {
         const string accessSecret   = "TODO_ACCES_SECRET_HERE";
 
         // arrange
-        var client = new RestClient("http://api.linkedin.com/v1") {
+        var client = new RestClient("http://api.linkedin.com/v1");
+        var request = new RestRequest("people/~:(id,first-name,last-name)") {
             Authenticator = OAuth1Authenticator.ForProtectedResource(
                 consumerKey,
                 consumerSecret,
@@ -340,7 +341,6 @@ public class OAuth1Tests {
                 accessSecret
             )
         };
-        var request = new RestRequest("people/~:(id,first-name,last-name)");
 
         // act
         var response = await client.ExecuteAsync<LinkedInMemberProfile>(request);

--- a/test/RestSharp.Tests.Integrated/RequestTests.cs
+++ b/test/RestSharp.Tests.Integrated/RequestTests.cs
@@ -52,6 +52,63 @@ public class AsyncTests {
     }
 
     [Fact]
+    public async Task Can_Perform_GET_Async_With_Request_Cookies() {
+        var request = new RestRequest("get-cookies") {
+            CookieContainer = new CookieContainer()
+        };
+        request.CookieContainer.Add(new Cookie("cookie", "value", null, _client.BaseUrl.Host));
+        request.CookieContainer.Add(new Cookie("cookie2", "value2", null, _client.BaseUrl.Host));
+        var response = await _client.ExecuteAsync(request);
+        response.Content.Should().Be("[\"cookie=value\",\"cookie2=value2\"]");
+    }
+
+    [Fact]
+    public async Task Can_Perform_GET_Async_With_Response_Cookies() {
+        var request = new RestRequest("set-cookies");
+        var response = await _client.ExecuteAsync(request);
+        response.Content.Should().Be("success");
+
+        // Check we got all our cookies
+        var domain = _client.BaseUrl.Host;
+        var cookie = response.Cookies!.First(p => p.Name == "cookie1");
+        Assert.Equal("value1", cookie.Value);
+        Assert.Equal("/", cookie.Path);
+        Assert.Equal(domain, cookie.Domain);
+        Assert.Equal(DateTime.MinValue, cookie.Expires);
+        Assert.False(cookie.HttpOnly);
+
+        // Cookie 2 should vanish as the path will not match
+        cookie = response.Cookies!.FirstOrDefault(p => p.Name == "cookie2");
+        Assert.Null(cookie);
+
+        // Check cookie3 has a valid expiration
+        cookie = response.Cookies!.First(p => p.Name == "cookie3");
+        Assert.Equal("value3", cookie.Value);
+        Assert.Equal("/", cookie.Path);
+        Assert.Equal(domain, cookie.Domain);
+        Assert.True(cookie.Expires > DateTime.Now);
+
+        // Check cookie4 has a valid expiration
+        cookie = response.Cookies!.First(p => p.Name == "cookie4");
+        Assert.Equal("value4", cookie.Value);
+        Assert.Equal("/", cookie.Path);
+        Assert.Equal(domain, cookie.Domain);
+        Assert.True(cookie.Expires > DateTime.Now);
+
+        // Cookie 5 should vanish as the request is not SSL
+        cookie = response.Cookies!.FirstOrDefault(p => p.Name == "cookie5");
+        Assert.Null(cookie);
+
+        // Check cookie6 should be http only
+        cookie = response.Cookies!.First(p => p.Name == "cookie6");
+        Assert.Equal("value6", cookie.Value);
+        Assert.Equal("/", cookie.Path);
+        Assert.Equal(domain, cookie.Domain);
+        Assert.Equal(DateTime.MinValue, cookie.Expires);
+        Assert.True(cookie.HttpOnly);
+    }
+
+    [Fact]
     public async Task Can_Timeout_GET_Async() {
         var request = new RestRequest("timeout").AddBody("Body_Content");
 

--- a/test/RestSharp.Tests.Integrated/Server/TestServer.cs
+++ b/test/RestSharp.Tests.Integrated/Server/TestServer.cs
@@ -37,6 +37,10 @@ public sealed class HttpServer {
         _app.MapGet("request-echo", async context => await context.Request.BodyReader.AsStream().CopyToAsync(context.Response.BodyWriter.AsStream()));
         _app.MapDelete("delete", () => new TestResponse { Message = "Works!" });
 
+        // Cookies
+        _app.MapGet("get-cookies", HandleCookies);
+        _app.MapGet("set-cookies", HandleSetCookies);
+
         // PUT
         _app.MapPut(
             ContentResource,
@@ -57,6 +61,34 @@ public sealed class HttpServer {
         IResult HandleHeaders(HttpContext ctx) {
             var response = ctx.Request.Headers.Select(x => new TestServerResponse(x.Key, x.Value));
             return Results.Ok(response);
+        }
+
+        IResult HandleCookies(HttpContext ctx) {
+            var results = new List<string>();
+            foreach (var (key, value) in ctx.Request.Cookies) {
+                results.Add($"{key}={value}");
+            }
+            return Results.Ok(results);
+        }
+
+        IResult HandleSetCookies(HttpContext ctx) {
+            ctx.Response.Cookies.Append("cookie1", "value1");
+            ctx.Response.Cookies.Append("cookie2", "value2", new CookieOptions {
+                Path = "/path_extra"
+            });
+            ctx.Response.Cookies.Append("cookie3", "value3", new CookieOptions {
+                Expires = DateTimeOffset.Now.AddDays(2)
+            });
+            ctx.Response.Cookies.Append("cookie4", "value4", new CookieOptions {
+                MaxAge = TimeSpan.FromSeconds(100)
+            });
+            ctx.Response.Cookies.Append("cookie5", "value5", new CookieOptions {
+                Secure = true
+            });
+            ctx.Response.Cookies.Append("cookie6", "value6", new CookieOptions {
+                HttpOnly = true
+            });
+            return Results.Content("success");
         }
 
         async Task<IResult> HandleUpload(HttpRequest req) {

--- a/test/RestSharp.Tests/JwtAuthTests.cs
+++ b/test/RestSharp.Tests/JwtAuthTests.cs
@@ -23,11 +23,11 @@ public class JwtAuthTests {
 
     [Fact]
     public async Task Can_Set_ValidFormat_Auth_Header() {
-        var client  = new RestClient { Authenticator = new JwtAuthenticator(_testJwt) };
-        var request = new RestRequest();
+        var client  = new RestClient();
+        var request = new RestRequest { Authenticator = new JwtAuthenticator(_testJwt) };
 
         //In real case client.Execute(request) will invoke Authenticate method
-        await client.Authenticator.Authenticate(client, request);
+        await request.Authenticator.Authenticate(client, request);
 
         var authParam = request.Parameters.Single(p => p.Name.Equals(KnownHeaders.Authorization, StringComparison.OrdinalIgnoreCase));
 
@@ -37,14 +37,14 @@ public class JwtAuthTests {
 
     [Fact]
     public async Task Check_Only_Header_Authorization() {
-        var client  = new RestClient { Authenticator = new JwtAuthenticator(_testJwt) };
-        var request = new RestRequest();
+        var client  = new RestClient();
+        var request = new RestRequest { Authenticator = new JwtAuthenticator(_testJwt) };
 
         // Paranoid server needs "two-factor authentication": jwt header and query param key for example
         request.AddParameter(KnownHeaders.Authorization, "manualAuth", ParameterType.QueryString);
 
         // In real case client.Execute(request) will invoke Authenticate method
-        await client.Authenticator.Authenticate(client, request);
+        await request.Authenticator.Authenticate(client, request);
 
         var paramList = request.Parameters.Where(p => p.Name.Equals(KnownHeaders.Authorization)).ToList();
 
@@ -64,10 +64,10 @@ public class JwtAuthTests {
 
         request.AddHeader(KnownHeaders.Authorization, "second_header_auth_token");
 
-        client.Authenticator = new JwtAuthenticator(_testJwt);
+        request.Authenticator = new JwtAuthenticator(_testJwt);
 
         //In real case client.Execute(...) will invoke Authenticate method
-        await client.Authenticator.Authenticate(client, request);
+        await request.Authenticator.Authenticate(client, request);
 
         var paramList = request.Parameters.Where(p => p.Name.Equals(KnownHeaders.Authorization)).ToList();
 
@@ -85,13 +85,11 @@ public class JwtAuthTests {
         var client  = new RestClient();
         var request = new RestRequest();
 
-        var authenticator = new JwtAuthenticator(_expectedAuthHeaderContent);
+        request.Authenticator = new JwtAuthenticator(_expectedAuthHeaderContent);;
+        await request.Authenticator.Authenticate(client, request);
 
-        client.Authenticator = authenticator;
-        await client.Authenticator.Authenticate(client, request);
-
-        authenticator.SetBearerToken("second_header_auth_token");
-        await client.Authenticator.Authenticate(client, request);
+        request.Authenticator = new JwtAuthenticator("second_header_auth_token");
+        await request.Authenticator.Authenticate(client, request);
 
         var paramList = request.Parameters.Where(p => p.Name.Equals(KnownHeaders.Authorization)).ToList();
 

--- a/test/RestSharp.Tests/RestClientTests.cs
+++ b/test/RestSharp.Tests/RestClientTests.cs
@@ -37,15 +37,6 @@ public class RestClientTests {
     }
 
     [Fact]
-    public void BaseHost_Returns_Host_From_Options() {
-        var options = new RestClientOptions {
-            BaseHost = "baseHost"
-        };
-        var client  = new RestClient(options);
-        Assert.Equal(options.BaseHost, client.BaseHost);
-    }
-
-    [Fact]
     public void BuildUri_should_build_with_passing_link_as_Uri() {
         // arrange
         var relative    = new Uri("/foo/bar/baz", UriKind.Relative);

--- a/test/RestSharp.Tests/RestClientTests.cs
+++ b/test/RestSharp.Tests/RestClientTests.cs
@@ -30,6 +30,22 @@ public class RestClientTests {
     }
 
     [Fact]
+    public void BaseUrl_Returns_Url_From_Options() {
+        var options = new RestClientOptions(BaseUrl);
+        var client  = new RestClient(options);
+        Assert.Equal(options.BaseUrl, client.BaseUrl);
+    }
+
+    [Fact]
+    public void BaseHost_Returns_Host_From_Options() {
+        var options = new RestClientOptions {
+            BaseHost = "baseHost"
+        };
+        var client  = new RestClient(options);
+        Assert.Equal(options.BaseHost, client.BaseHost);
+    }
+
+    [Fact]
     public void BuildUri_should_build_with_passing_link_as_Uri() {
         // arrange
         var relative    = new Uri("/foo/bar/baz", UriKind.Relative);


### PR DESCRIPTION
## Description

Implements the following changes:
- BaseUrl needs to be internal so it cannot be changed after the client is constructed by the user.
- ResponseWriter and AdvancedResponseWriter are back to regular property setters (no longer init)
- Moved handling of Cookies out of HttpClient and into RestSharp, so they will not cross pollinate requests.
- Make the CookieContainer a property on the request, not the client.
- Move Authenticator from the client into the request, since it's request specific.
- Add tests for cookie handling.
- Add back all non-sync functions to RestClient and extensions

## Purpose
Fix issues referenced about thread safety with single instance and improve the API to help developers avoid causing those problems.

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
