### PR TITLE
Move Cookie handling out of HttpClient so we do not cross pollinate requests

### DIFF
--- a/src/RestSharp/KnownHeaders.cs
+++ b/src/RestSharp/KnownHeaders.cs
@@ -30,6 +30,7 @@ public static class KnownHeaders {
     public const string ContentLocation    = "Content-Location";
     public const string ContentRange       = "Content-Range";
     public const string ContentType        = "Content-Type";
+    public const string Cookie             = "Cookie";
     public const string LastModified       = "Last-Modified";
     public const string ContentMD5         = "Content-MD5";
     public const string Host               = "Host";

--- a/src/RestSharp/Request/RequestHeaders.cs
+++ b/src/RestSharp/Request/RequestHeaders.cs
@@ -14,7 +14,10 @@
 // 
 
 // ReSharper disable InvertIf
-namespace RestSharp; 
+
+using System.Net;
+
+namespace RestSharp;
 
 class RequestHeaders {
     public ParametersCollection Parameters { get; } = new();
@@ -31,6 +34,15 @@ class RequestHeaders {
             Parameters.AddParameter(new HeaderParameter(KnownHeaders.Accept, accepts));
         }
 
+        return this;
+    }
+
+    // Add Cookie header from the cookie container
+    public RequestHeaders AddCookieHeaders(CookieContainer cookieContainer, Uri uri) {
+        var cookies = cookieContainer.GetCookieHeader(uri);
+        if (cookies.Length > 0) {
+            Parameters.AddParameter(new HeaderParameter(KnownHeaders.Cookie, cookies));
+        }
         return this;
     }
 }

--- a/src/RestSharp/Request/RestRequest.cs
+++ b/src/RestSharp/Request/RestRequest.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net;
+using RestSharp.Authenticators;
 using RestSharp.Extensions;
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 
@@ -29,6 +31,11 @@ public class RestRequest {
     /// </summary>
     public RestRequest() => Method = Method.Get;
 
+    /// <summary>
+    /// Constructor for a rest request to a relative resource URL and optional method
+    /// </summary>
+    /// <param name="resource">Resource to use</param>
+    /// <param name="method">Method to use (defaults to Method.Get></param>
     public RestRequest(string? resource, Method method = Method.Get) : this() {
         Resource = resource ?? "";
         Method   = method;
@@ -58,6 +65,11 @@ public class RestRequest {
                 );
     }
 
+    /// <summary>
+    /// Constructor for a rest request to a specific resource Uri and optional method
+    /// </summary>
+    /// <param name="resource">Resource Uri to use</param>
+    /// <param name="method">Method to use (defaults to Method.Get></param>
     public RestRequest(Uri resource, Method method = Method.Get)
         : this(resource.IsAbsoluteUri ? resource.AbsoluteUri : resource.OriginalString, method) { }
 
@@ -82,6 +94,11 @@ public class RestRequest {
     /// See AddParameter() for explanation of the types of parameters that can be passed
     /// </summary>
     public ParametersCollection Parameters { get; } = new();
+
+    /// <summary>
+    /// Optional cookie container to use for the request. If not set, cookies are not passed.
+    /// </summary>
+    public CookieContainer? CookieContainer { get; set; }
 
     /// <summary>
     /// Container of all the files to be uploaded with the request.

--- a/src/RestSharp/Request/RestRequestExtensions.cs
+++ b/src/RestSharp/Request/RestRequestExtensions.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net;
 using System.Text.RegularExpressions;
 using RestSharp.Extensions;
 using RestSharp.Serializers;
@@ -384,6 +385,21 @@ public static class RestRequestExtensions {
             request.AddParameter(name, value);
         }
 
+        return request;
+    }
+
+    /// <summary>
+    /// Adds cookie to the <seealso cref="HttpClient"/> cookie container.
+    /// </summary>
+    /// <param name="request">RestRequest to add the cookies to</param>
+    /// <param name="name">Cookie name</param>
+    /// <param name="value">Cookie value</param>
+    /// <param name="path">Cookie path</param>
+    /// <param name="domain">Cookie domain, must not be an empty string</param>
+    /// <returns></returns>
+    public static RestRequest AddCookie(this RestRequest request, string name, string value, string path, string domain) {
+        request.CookieContainer ??= new CookieContainer();
+        request.CookieContainer.Add(new Cookie(name, value, path, domain));
         return request;
     }
 

--- a/src/RestSharp/Response/RestResponse.cs
+++ b/src/RestSharp/Response/RestResponse.cs
@@ -64,7 +64,7 @@ public class RestResponse : RestResponseBase {
         HttpResponseMessage     httpResponse,
         RestRequest             request,
         Encoding                encoding,
-        CookieCollection        cookieCollection,
+        CookieCollection?       cookieCollection,
         CalculateResponseStatus calculateResponseStatus,
         CancellationToken       cancellationToken
     ) {

--- a/src/RestSharp/RestClient.Async.cs
+++ b/src/RestSharp/RestClient.Async.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net;
 using RestSharp.Extensions;
 
 namespace RestSharp;
@@ -32,7 +33,7 @@ public partial class RestClient {
                     internalResponse.ResponseMessage!,
                     request,
                     Options.Encoding,
-                    CookieContainer.GetCookies(internalResponse.Url),
+                    request.CookieContainer!.GetCookies(internalResponse.Url),
                     CalculateResponseStatus,
                     cancellationToken
                 )
@@ -64,16 +65,26 @@ public partial class RestClient {
         var       ct         = cts.Token;
 
         try {
+            // Make sure we have a cookie container if not provided in the request
+            var cookieContainer = request.CookieContainer ??= new CookieContainer();
             var headers = new RequestHeaders()
                 .AddHeaders(request.Parameters)
                 .AddHeaders(DefaultParameters)
-                .AddAcceptHeader(AcceptedContentTypes);
+                .AddAcceptHeader(AcceptedContentTypes)
+                .AddCookieHeaders(cookieContainer, url);
             message.AddHeaders(headers);
 
             if (request.OnBeforeRequest != null)
                 await request.OnBeforeRequest(message).ConfigureAwait(false);
 
             var responseMessage = await HttpClient.SendAsync(message, request.CompletionOption, ct).ConfigureAwait(false);
+
+            // Parse all the cookies from the response and update the cookie jar with cookies
+            if (responseMessage.Headers.TryGetValues("Set-Cookie", out var cookiesHeader)) {
+                foreach (var header in cookiesHeader) {
+                    cookieContainer.SetCookies(url, header);
+                }
+            }
 
             if (request.OnAfterRequest != null)
                 await request.OnAfterRequest(responseMessage).ConfigureAwait(false);

--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -27,8 +27,6 @@ namespace RestSharp;
 /// Client to translate RestRequests into Http requests and process response result
 /// </summary>
 public partial class RestClient : IDisposable {
-    public CookieContainer CookieContainer { get; }
-
     /// <summary>
     /// Content types that will be sent in the Accept header. The list is populated from the known serializers.
     /// If you need to send something else by default, set this property to a different value.
@@ -45,13 +43,12 @@ public partial class RestClient : IDisposable {
 
     HttpClient HttpClient { get; }
 
-    public RestClientOptions Options { get; }
+    internal RestClientOptions Options { get; }
 
     public RestClient(RestClientOptions options, Action<HttpRequestHeaders>? configureDefaultHeaders = null) {
         UseDefaultSerializers();
 
         Options            = options;
-        CookieContainer    = Options.CookieContainer ?? new CookieContainer();
         _disposeHttpClient = true;
 
         var handler = new HttpClientHandler();
@@ -69,25 +66,27 @@ public partial class RestClient : IDisposable {
     /// </summary>
     public RestClient() : this(new RestClientOptions()) { }
 
-    /// <inheritdoc />
     /// <summary>
-    /// Sets the BaseUrl property for requests made by this client instance
+    /// Creates an instance of RestClient using a specific BaseUrl for requests made by this client instance
     /// </summary>
-    /// <param name="baseUrl"></param>
+    /// <param name="baseUrl">Base URI for the new client</param>
     public RestClient(Uri baseUrl) : this(new RestClientOptions { BaseUrl = baseUrl }) { }
 
-    /// <inheritdoc />
     /// <summary>
-    /// Sets the BaseUrl property for requests made by this client instance
+    /// Creates an instance of RestClient using a specific BaseUrl for requests made by this client instance
     /// </summary>
-    /// <param name="baseUrl"></param>
+    /// <param name="baseUrl">Base URI for this new client as a string</param>
     public RestClient(string baseUrl) : this(new Uri(Ensure.NotEmptyString(baseUrl, nameof(baseUrl)))) { }
 
+    /// <summary>
+    /// Creates an instance of RestClient using a shared HttpClient and does not allocate one internally.
+    /// </summary>
+    /// <param name="httpClient">HttpClient to use</param>
+    /// <param name="disposeHttpClient">True to dispose of the client, false to assume the caller does (defaults to false)</param>
     public RestClient(HttpClient httpClient, bool disposeHttpClient = false) {
         UseDefaultSerializers();
 
         HttpClient         = httpClient;
-        CookieContainer    = new CookieContainer();
         Options            = new RestClientOptions();
         _disposeHttpClient = disposeHttpClient;
 
@@ -96,15 +95,16 @@ public partial class RestClient : IDisposable {
         }
     }
 
+    /// <summary>
+    /// Creates an instance of RestClient using a shared HttpClient and specific RestClientOptions and does not allocate one internally.
+    /// </summary>
+    /// <param name="httpClient">HttpClient to use</param>
+    /// <param name="options">RestClient options to use</param>
+    /// <param name="disposeHttpClient">True to dispose of the client, false to assume the caller does (defaults to false)</param>
     public RestClient(HttpClient httpClient, RestClientOptions options, bool disposeHttpClient = false) {
-        if (options.CookieContainer != null) {
-            throw new ArgumentException("Custom cookie container cannot be added to the HttpClient instance", nameof(options.CookieContainer));
-        }
-
         UseDefaultSerializers();
 
         HttpClient         = httpClient;
-        CookieContainer    = new CookieContainer();
         Options            = options;
         _disposeHttpClient = disposeHttpClient;
 
@@ -123,6 +123,16 @@ public partial class RestClient : IDisposable {
     /// <param name="disposeHandler">Dispose the handler when disposing RestClient, true by default</param>
     public RestClient(HttpMessageHandler handler, bool disposeHandler = true) : this(new HttpClient(handler, disposeHandler), true) { }
 
+    /// <summary>
+    /// Returns the currently configured BaseUrl for this RestClient instance
+    /// </summary>
+    public Uri? BaseUrl => Options.BaseUrl;
+
+    /// <summary>
+    /// Returns the currently configured BaseHost for this RestClient instance
+    /// </summary>
+    public string? BaseHost => Options.BaseHost;
+
     void ConfigureHttpClient(HttpClient httpClient) {
         if (Options.MaxTimeout > 0) httpClient.Timeout = TimeSpan.FromMilliseconds(Options.MaxTimeout);
         if (httpClient.DefaultRequestHeaders.UserAgent.All(x => x.Product.Name != "RestSharp")) {
@@ -133,9 +143,9 @@ public partial class RestClient : IDisposable {
     }
 
     void ConfigureHttpMessageHandler(HttpClientHandler handler) {
+        handler.UseCookies             = false;
         handler.Credentials            = Options.Credentials;
         handler.UseDefaultCredentials  = Options.UseDefaultCredentials;
-        handler.CookieContainer        = CookieContainer;
         handler.AutomaticDecompression = Options.AutomaticDecompression;
         handler.PreAuthenticate        = Options.PreAuthenticate;
         handler.AllowAutoRedirect      = Options.FollowRedirects;

--- a/src/RestSharp/RestClientExtensions.Config.cs
+++ b/src/RestSharp/RestClientExtensions.Config.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 // 
 
-using System.Net;
 using System.Text;
 using RestSharp.Authenticators;
 using RestSharp.Extensions;
@@ -42,23 +41,6 @@ public static partial class RestClientExtensions {
     /// <returns></returns>
     public static RestClient UseQueryEncoder(this RestClient client, Func<string, Encoding, string> queryEncoder)
         => client.With(x => x.EncodeQuery = queryEncoder);
-
-    /// <summary>
-    /// Adds cookie to the <seealso cref="HttpClient"/> cookie container.
-    /// </summary>
-    /// <param name="client"></param>
-    /// <param name="name">Cookie name</param>
-    /// <param name="value">Cookie value</param>
-    /// <param name="path">Cookie path</param>
-    /// <param name="domain">Cookie domain, must not be an empty string</param>
-    /// <returns></returns>
-    public static RestClient AddCookie(this RestClient client, string name, string value, string path, string domain) {
-        lock (client.CookieContainer) {
-            client.CookieContainer.Add(new Cookie(name, value, path, domain));
-        }
-
-        return client;
-    }
 
     public static RestClient UseAuthenticator(this RestClient client, IAuthenticator authenticator)
         => client.With(x => x.Authenticator = authenticator);

--- a/src/RestSharp/RestClientOptions.cs
+++ b/src/RestSharp/RestClientOptions.cs
@@ -74,7 +74,6 @@ public class RestClientOptions {
     public CacheControlHeaderValue? CachePolicy       { get; set; }
     public bool                     FollowRedirects   { get; set; } = true;
     public bool?                    Expect100Continue { get; set; } = null;
-    public CookieContainer?         CookieContainer   { get; set; }
     public string                   UserAgent         { get; set; } = DefaultUserAgent;
 
     /// <summary>

--- a/test/RestSharp.Tests.Integrated/RequestTests.cs
+++ b/test/RestSharp.Tests.Integrated/RequestTests.cs
@@ -52,6 +52,63 @@ public class AsyncTests {
     }
 
     [Fact]
+    public async Task Can_Perform_GET_Async_With_Request_Cookies() {
+        var request = new RestRequest("get-cookies") {
+            CookieContainer = new CookieContainer()
+        };
+        request.CookieContainer.Add(new Cookie("cookie", "value", null, _client.BaseUrl.Host));
+        request.CookieContainer.Add(new Cookie("cookie2", "value2", null, _client.BaseUrl.Host));
+        var response = await _client.ExecuteAsync(request);
+        response.Content.Should().Be("[\"cookie=value\",\"cookie2=value2\"]");
+    }
+
+    [Fact]
+    public async Task Can_Perform_GET_Async_With_Response_Cookies() {
+        var request = new RestRequest("set-cookies");
+        var response = await _client.ExecuteAsync(request);
+        response.Content.Should().Be("success");
+
+        // Check we got all our cookies
+        var domain = _client.BaseUrl.Host;
+        var cookie = response.Cookies!.First(p => p.Name == "cookie1");
+        Assert.Equal("value1", cookie.Value);
+        Assert.Equal("/", cookie.Path);
+        Assert.Equal(domain, cookie.Domain);
+        Assert.Equal(DateTime.MinValue, cookie.Expires);
+        Assert.False(cookie.HttpOnly);
+
+        // Cookie 2 should vanish as the path will not match
+        cookie = response.Cookies!.FirstOrDefault(p => p.Name == "cookie2");
+        Assert.Null(cookie);
+
+        // Check cookie3 has a valid expiration
+        cookie = response.Cookies!.First(p => p.Name == "cookie3");
+        Assert.Equal("value3", cookie.Value);
+        Assert.Equal("/", cookie.Path);
+        Assert.Equal(domain, cookie.Domain);
+        Assert.True(cookie.Expires > DateTime.Now);
+
+        // Check cookie4 has a valid expiration
+        cookie = response.Cookies!.First(p => p.Name == "cookie4");
+        Assert.Equal("value4", cookie.Value);
+        Assert.Equal("/", cookie.Path);
+        Assert.Equal(domain, cookie.Domain);
+        Assert.True(cookie.Expires > DateTime.Now);
+
+        // Cookie 5 should vanish as the request is not SSL
+        cookie = response.Cookies!.FirstOrDefault(p => p.Name == "cookie5");
+        Assert.Null(cookie);
+
+        // Check cookie6 should be http only
+        cookie = response.Cookies!.First(p => p.Name == "cookie6");
+        Assert.Equal("value6", cookie.Value);
+        Assert.Equal("/", cookie.Path);
+        Assert.Equal(domain, cookie.Domain);
+        Assert.Equal(DateTime.MinValue, cookie.Expires);
+        Assert.True(cookie.HttpOnly);
+    }
+
+    [Fact]
     public async Task Can_Timeout_GET_Async() {
         var request = new RestRequest("timeout").AddBody("Body_Content");
 

--- a/test/RestSharp.Tests.Integrated/Server/TestServer.cs
+++ b/test/RestSharp.Tests.Integrated/Server/TestServer.cs
@@ -37,6 +37,10 @@ public sealed class HttpServer {
         _app.MapGet("request-echo", async context => await context.Request.BodyReader.AsStream().CopyToAsync(context.Response.BodyWriter.AsStream()));
         _app.MapDelete("delete", () => new TestResponse { Message = "Works!" });
 
+        // Cookies
+        _app.MapGet("get-cookies", HandleCookies);
+        _app.MapGet("set-cookies", HandleSetCookies);
+
         // PUT
         _app.MapPut(
             ContentResource,
@@ -57,6 +61,34 @@ public sealed class HttpServer {
         IResult HandleHeaders(HttpContext ctx) {
             var response = ctx.Request.Headers.Select(x => new TestServerResponse(x.Key, x.Value));
             return Results.Ok(response);
+        }
+
+        IResult HandleCookies(HttpContext ctx) {
+            var results = new List<string>();
+            foreach (var (key, value) in ctx.Request.Cookies) {
+                results.Add($"{key}={value}");
+            }
+            return Results.Ok(results);
+        }
+
+        IResult HandleSetCookies(HttpContext ctx) {
+            ctx.Response.Cookies.Append("cookie1", "value1");
+            ctx.Response.Cookies.Append("cookie2", "value2", new CookieOptions {
+                Path = "/path_extra"
+            });
+            ctx.Response.Cookies.Append("cookie3", "value3", new CookieOptions {
+                Expires = DateTimeOffset.Now.AddDays(2)
+            });
+            ctx.Response.Cookies.Append("cookie4", "value4", new CookieOptions {
+                MaxAge = TimeSpan.FromSeconds(100)
+            });
+            ctx.Response.Cookies.Append("cookie5", "value5", new CookieOptions {
+                Secure = true
+            });
+            ctx.Response.Cookies.Append("cookie6", "value6", new CookieOptions {
+                HttpOnly = true
+            });
+            return Results.Content("success");
         }
 
         async Task<IResult> HandleUpload(HttpRequest req) {


### PR DESCRIPTION
## Description

Implements the following:

- Make RestClient.Options internal again and expose the BaseUrl and BaseHost as read only getters on the client.
- Move handling of Cookies out of HttpClient and into RestSharp, so they will not cross pollinate requests.
- Make the CookieContainer a property on the request, not the client.
- Add tests for cookie handling.

## Purpose
This pull request is a:

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

although the breakage is only against stuff that was not released other than in alpha anyway (making Options internal again).

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
