### PR TITLE
We also need to control the Expect100Continue functionality at the client level

### DIFF
--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -126,6 +126,7 @@ public partial class RestClient : IDisposable {
     void ConfigureHttpClient(HttpClient httpClient) {
         if (Options.Timeout > 0) httpClient.Timeout = TimeSpan.FromMilliseconds(Options.Timeout);
         httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(Options.UserAgent);
+        httpClient.DefaultRequestHeaders.ExpectContinue = Options.Expect100Continue;
     }
 
     void ConfigureHttpMessageHandler(HttpClientHandler handler) {

--- a/src/RestSharp/RestClientOptions.cs
+++ b/src/RestSharp/RestClientOptions.cs
@@ -73,6 +73,7 @@ public class RestClientOptions {
     public IWebProxy?               Proxy           { get; set; }
     public CacheControlHeaderValue? CachePolicy     { get; set; }
     public bool                     FollowRedirects { get; set; } = true;
+    public bool?                    Expect100Continue { get; set; } = null;
     public CookieContainer?         CookieContainer { get; set; }
     public string                   UserAgent       { get; set; } = DefaultUserAgent;
     public int                      Timeout         { get; set; }


### PR DESCRIPTION
## Description

We also need to control the Expect100Continue functionality at the client level. If you need this, doing it at the client level is much better than doing it globally at the ServicePoint level so it does not affect any other requests but those from your client.

## Purpose
This pull request is a:

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have added necessary documentation (if appropriate)

Not entirely sure how to best test this
