### PR TITLE
Allow forcing only a single custom serializer to be used

### DIFF
--- a/src/RestSharp/RestClientExtensions.cs
+++ b/src/RestSharp/RestClientExtensions.cs
@@ -14,6 +14,7 @@
 
 using System.Runtime.CompilerServices;
 using RestSharp.Extensions;
+using RestSharp.Serializers;
 
 namespace RestSharp;
 
@@ -352,8 +353,8 @@ public static partial class RestClientExtensions {
     /// <summary>
     /// Sets the <see cref="RestClient"/> to only use JSON
     /// </summary>
-    /// <param name="client">The client instance</param>
-    /// <returns></returns>
+    /// <param name="client">Client instance to work with</param>
+    /// <returns>Reference to the client instance</returns>
     public static RestClient UseJson(this RestClient client) {
         client.Serializers.Remove(DataFormat.Xml);
         client.AssignAcceptedContentTypes();
@@ -363,11 +364,23 @@ public static partial class RestClientExtensions {
     /// <summary>
     /// Sets the <see cref="RestClient"/> to only use XML
     /// </summary>
-    /// <param name="client"></param>
-    /// <returns></returns>
+    /// <param name="client">Client instance to work with</param>
+    /// <returns>Reference to the client instance</returns>
     public static RestClient UseXml(this RestClient client) {
         client.Serializers.Remove(DataFormat.Json);
         client.AssignAcceptedContentTypes();
+        return client;
+    }
+
+    /// <summary>
+    /// Sets the <see cref="RestClient"/> to only use the passed in custom serializer
+    /// </summary>
+    /// <param name="client">Client instance to work with</param>
+    /// <param name="serializerFactory">Function that returns the serializer instance</param>
+    /// <returns>Reference to the client instance</returns>
+    public static RestClient UseOnlySerializer(this RestClient client, Func<IRestSerializer> serializerFactory) {
+        client.Serializers.Clear();
+        client.UseSerializer(serializerFactory);
         return client;
     }
 }

--- a/test/RestSharp.Tests/RestClientTests.cs
+++ b/test/RestSharp.Tests/RestClientTests.cs
@@ -1,4 +1,6 @@
-namespace RestSharp.Tests; 
+using RestSharp.Serializers.Json;
+
+namespace RestSharp.Tests;
 
 public class RestClientTests {
     const string BaseUrl = "http://localhost:8888/";
@@ -57,5 +59,47 @@ public class RestClientTests {
 
         // assert
         new Uri(baseUrl, relative).Should().Be(builtUri);
+    }
+
+    [Fact]
+    public void UseJson_leaves_only_json_serializer() {
+        // arrange
+        var baseUrl  = new Uri(BaseUrl);
+
+        // act
+        var client   = new RestClient(baseUrl);
+        client.UseJson();
+
+        // assert
+        Assert.Single(client.Serializers);
+        Assert.True(client.Serializers.ContainsKey(DataFormat.Json));
+    }
+
+    [Fact]
+    public void UseXml_leaves_only_json_serializer() {
+        // arrange
+        var baseUrl = new Uri(BaseUrl);
+
+        // act
+        var client = new RestClient(baseUrl);
+        client.UseXml();
+
+        // assert
+        Assert.Single(client.Serializers);
+        Assert.True(client.Serializers.ContainsKey(DataFormat.Xml));
+    }
+
+    [Fact]
+    public void UseOnlySerializer_leaves_only_custom_serializer() {
+        // arrange
+        var baseUrl = new Uri(BaseUrl);
+
+        // act
+        var client = new RestClient(baseUrl);
+        client.UseOnlySerializer(() => new SystemTextJsonSerializer());
+
+        // assert
+        Assert.Single(client.Serializers);
+        Assert.True(client.Serializers.ContainsKey(DataFormat.Json));
     }
 }


### PR DESCRIPTION
## Description

Allow forcing only a single custom serializer to be used to clear out any others so the defaults can be changed like UseJson() and UseXml()

## Purpose
This pull request is a:

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
