### PR TITLE
Change RestClientOptions to MaxTimeout which is what it really is

### DIFF
--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -124,7 +124,7 @@ public partial class RestClient : IDisposable {
     public RestClient(HttpMessageHandler handler, bool disposeHandler = true) : this(new HttpClient(handler, disposeHandler), true) { }
 
     void ConfigureHttpClient(HttpClient httpClient) {
-        if (Options.Timeout > 0) httpClient.Timeout = TimeSpan.FromMilliseconds(Options.Timeout);
+        if (Options.MaxTimeout > 0) httpClient.Timeout = TimeSpan.FromMilliseconds(Options.MaxTimeout);
         httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(Options.UserAgent);
     }
 

--- a/src/RestSharp/RestClientOptions.cs
+++ b/src/RestSharp/RestClientOptions.cs
@@ -75,7 +75,7 @@ public class RestClientOptions {
     public bool                     FollowRedirects { get; set; } = true;
     public CookieContainer?         CookieContainer { get; set; }
     public string                   UserAgent       { get; set; } = DefaultUserAgent;
-    public int                      Timeout         { get; set; }
+    public int                      MaxTimeout      { get; set; }
     public Encoding                 Encoding        { get; set; } = Encoding.UTF8;
 
     /// <summary>


### PR DESCRIPTION
## Description

If you have a timeout on the client AND a timeout on the request, the resulting actual timeout is going to be the shorter of the two. By default HttpClient has a timeout of 100 seconds built in, so that means if someone is expecting to be able to send a request and have it wait longer than 100 seconds, it won't work unless the client is also changed.

So I propose we change the property in RestClientOptions which is then applied to HttpClient to be called MaxTimeout so it is a lot more clear what the connection is? You cannot have a longer timeout for any request unless you change this value.

It might also make sense to set this to a default value of something (maybe 100 seconds to make it clear) rather than leaving it null, so the user of the library will be more aware of how the client timeout and request timeout interact with each other?

The other option would be to always set the timeout in the client to infinite, and then always use a request timeout that is the Max() of either the client timeout or the request one if the request one was provided?

## Purpose
This pull request is a:

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
