### PR TITLE
Fix file upload with non-ancii characters in a filename

### DIFF
--- a/src/RestSharp/Request/RequestContent.cs
+++ b/src/RestSharp/Request/RequestContent.cs
@@ -59,10 +59,7 @@ class RequestContent : IDisposable {
             if (file.ContentType != null)
                 fileContent.Headers.ContentType = MediaTypeHeaderValue.Parse(file.ContentType);
 
-            fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data") {
-                Name     = $"\"{file.Name}\"",
-                FileName = $"\"{file.FileName}\""
-            };
+            fileContent.Headers.TryAddWithoutValidation(ContentDisposition, $"form-data; name=\"{file.Name}\"; filename=\"{file.FileName}\";");
             mpContent.Add(fileContent, file.Name, file.FileName);
         }
 


### PR DESCRIPTION
## Description
This is a fix for file upload with non-ASCII characters in a filename eg. ÄÖäö.jpg.
Before it was converting the ContentDisposition.FileName to smth like "=?utf-8?B?BDFSDFasdfasdc==?="
Initially, it's an issue with ContentDispositionHeaderValue (microsoft/referencesource#140), but I don't know how to fix it there
<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
