### PR TITLE
Always stream just the headers for DownloadStreamAsync for best memory utilization

### DIFF
--- a/src/RestSharp/RestClient.Async.cs
+++ b/src/RestSharp/RestClient.Async.cs
@@ -95,6 +95,8 @@ public partial class RestClient {
     /// <returns>The downloaded stream.</returns>
     [PublicAPI]
     public async Task<Stream?> DownloadStreamAsync(RestRequest request, CancellationToken cancellationToken = default) {
+        // Make sure we only read the headers so we can stream the content body efficiently
+        request.CompletionOption = HttpCompletionOption.ResponseHeadersRead;
         var response = await ExecuteInternal(request, cancellationToken).ConfigureAwait(false);
 
         if (response.Exception != null) {

--- a/src/RestSharp/RestClientExtensions.cs
+++ b/src/RestSharp/RestClientExtensions.cs
@@ -331,7 +331,7 @@ public static partial class RestClientExtensions {
         string                                     resource,
         [EnumeratorCancellation] CancellationToken cancellationToken
     ) {
-        var request = new RestRequest(resource) { CompletionOption = HttpCompletionOption.ResponseHeadersRead };
+        var request = new RestRequest(resource);
 
 #if NETSTANDARD
         using var stream = await client.DownloadStreamAsync(request, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Description
Updates so this works out of the box:

https://github.com/restsharp/RestSharp/issues/1794

## Purpose
This pull request is a:

- [X] New feature (non-breaking change which adds functionality)