### PR TITLE
Fix OAuth2 Example Code

### DIFF
--- a/docs/authenticators.md
+++ b/docs/authenticators.md
@@ -65,7 +65,7 @@ For example:
 
 ```csharp
 client.Authenticator = new OAuth2AuthorizationRequestHeaderAuthenticator(
-    "Bearer", token
+    token, "Bearer"
 );
 ```
 


### PR DESCRIPTION
The token and token type are backwards. When using the current code, it will set the Authorization Header to "[token] Bearer". Switching them around fixes the issue and sets the Authorization Header to "Bearer [token]".

## Description

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
