### PR TITLE
Updated access modifier on RestRequest.AddFile to match documentation…

### DIFF
--- a/src/RestSharp/Request/RestRequest.cs
+++ b/src/RestSharp/Request/RestRequest.cs
@@ -198,5 +198,5 @@ public class RestRequest {
         return this;
     }
 
-    internal RestRequest AddFile(FileParameter file) => this.With(x => x._files.Add(file));
+    public RestRequest AddFile(FileParameter file) => this.With(x => x._files.Add(file));
 }


### PR DESCRIPTION
… specification.

## Description
This PR aims to fix issue #1882 in which the official RestSharp documentation claims that files may be attached to a request by calling the `RestRequest.AddFile` method, which accepts a `FileParameter` as its only input. However, the internal modifier prevents this usage and instead forces the user to call any of three `AddFile` overloads in `RestSharp.RestRequestExtensions`. Each of these overloaded extension methods creates a `FileParameter` and calls the original `internal` `AddFile` method.
<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
