### PR TITLE
Add support for using models as parameter containers and add them to the parameters collection of a REST request

### DIFF
--- a/RestSharp.sln.DotSettings
+++ b/RestSharp.sln.DotSettings
@@ -82,6 +82,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=instagram/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Migrator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mongo/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Parameterizer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=repcodes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=upsert/@EntryIndexedValue">True</s:Boolean>

--- a/test/RestSharp.Tests/RestRequestExtensionsTests.cs
+++ b/test/RestSharp.Tests/RestRequestExtensionsTests.cs
@@ -1,0 +1,48 @@
+﻿//  Copyright © 2009-2020 John Sheehan, Andrew Young, Alexey Zimarev and RestSharp community
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+#nullable enable
+using System.ComponentModel;
+
+namespace RestSharp.Tests;
+
+public sealed class RestRequestExtensionsTests {
+    [Fact]
+    public void RestRequest_AddParameters_AddsParameters() {
+        var model = new User(Guid.Parse("27b7acdd-6184-4e21-9b64-cdaa2b2477bd"), "Joe", null, DateTime.Parse("2022-01-01T00:00:00Z"), 100, 100, 100);
+        var request = new RestRequest().AddParameters(model, ParameterType.QueryString);
+
+        string ConvertToInvariantString(object value) => TypeDescriptor.GetConverter(value.GetType()).ConvertToInvariantString(value);
+
+        var expectedParameters = new ParametersCollection(
+            new[] {
+                new QueryParameter(nameof(User.Id), ConvertToInvariantString(model.Id)),
+                new QueryParameter(nameof(User.FirstName), model.FirstName),
+                new QueryParameter(nameof(User.LastName), model.LastName),
+                new QueryParameter(nameof(User.LastLogin), ConvertToInvariantString(model.LastLogin)),
+                new QueryParameter(nameof(User.NameSpan), model.NameSpan.ToString()),
+                new QueryParameter(nameof(User.Score), ConvertToInvariantString(model.Score)),
+                new QueryParameter(nameof(User.Age), ConvertToInvariantString(model.Age)),
+                new QueryParameter(nameof(User.Special), ConvertToInvariantString(model.Special))
+            }
+        );
+
+        request.Parameters.Should().BeEquivalentTo(expectedParameters);
+    }
+
+    sealed record User(Guid Id, string FirstName, string? LastName, DateTime? LastLogin, int Score, uint Age, nint Special) {
+        public ReadOnlySpan<char> NameSpan => FirstName.AsSpan();
+    }
+}


### PR DESCRIPTION
## Description
This PR introduces a feature that allows us to wrap REST request parameters under any arbitrary model and add them to a `RestRequest` instance via an extension method.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
