### PR TITLE
Support constructing JwtAuthenticator with token includes Bearer prefix

### DIFF
--- a/src/RestSharp/Authenticators/JwtAuthenticator.cs
+++ b/src/RestSharp/Authenticators/JwtAuthenticator.cs
@@ -28,7 +28,7 @@ public class JwtAuthenticator : AuthenticatorBase {
     [PublicAPI]
     public void SetBearerToken(string accessToken) => Token = GetToken(accessToken);
 
-    static string GetToken(string accessToken) => $"Bearer {Ensure.NotEmpty(accessToken, nameof(accessToken))}";
+    static string GetToken(string accessToken) => Ensure.NotEmpty(accessToken, nameof(accessToken)).StartsWith("Bearer ") ? accessToken : $"Bearer {accessToken}";
 
     protected override ValueTask<Parameter> GetAuthenticationParameter(string accessToken)
         => new(new HeaderParameter(KnownHeaders.Authorization, accessToken));

--- a/test/RestSharp.Tests/JwtAuthTests.cs
+++ b/test/RestSharp.Tests/JwtAuthTests.cs
@@ -34,6 +34,20 @@ public class JwtAuthTests {
         Assert.True(authParam.Type == ParameterType.HttpHeader);
         Assert.Equal(_expectedAuthHeaderContent, authParam.Value);
     }
+    
+    [Fact]
+    public async Task Can_Set_ValidFormat_Auth_Header_With_Bearer_Prefix() {
+        var client  = new RestClient { Authenticator = new JwtAuthenticator($"Bearer {_testJwt}") };
+        var request = new RestRequest();
+
+        //In real case client.Execute(request) will invoke Authenticate method
+        await client.Authenticator.Authenticate(client, request);
+
+        var authParam = request.Parameters.Single(p => p.Name.Equals(KnownHeaders.Authorization, StringComparison.OrdinalIgnoreCase));
+
+        Assert.True(authParam.Type == ParameterType.HttpHeader);
+        Assert.Equal(_expectedAuthHeaderContent, authParam.Value);
+    }
 
     [Fact]
     public async Task Check_Only_Header_Authorization() {


### PR DESCRIPTION
Support constructing JwtAuthenticator with token includes Bearer prefix

## Description

This pull request have made to handle scenario of constructing the JwtAuthenticator with token string which includes the Bearer Prefix. For example, Sending http request from one web service to another which use the same jwt secret. In this scenario it is likable to use the Authorization header value from the original request (to the first service). This value includes the Bearer prefix.

Current Behavior: When Passing the value of the existing Authorization attribute to the JwtAuthenticator constructor the result value of the Authorization attribute of the new request will be "Bearer Bearer <TOKEN>"

Expected Behavior: The Authorization header value of the new request will be "Bearer <TOKEN>"

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
