### PR TITLE
Authenticator should persist Token for future calls

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,8 +48,8 @@ public class TwitterAuthenticator : AuthenticatorBase {
     }
 
     protected override async ValueTask<Parameter> GetAuthenticationParameter(string accessToken) {
-        var token = string.IsNullOrEmpty(Token) ? await GetToken() : Token;
-        return new HeaderParameter(KnownHeaders.Authorization, token);
+        Token = string.IsNullOrEmpty(Token) ? await GetToken() : Token;
+        return new HeaderParameter(KnownHeaders.Authorization, Token);
     }
 }
 ```


### PR DESCRIPTION
The previous code works, except each authentication would get a new token rather than re-using the previous token

## Description

This is a change to the documentation example, The previous example code works, except each authentication would get a new token rather than re-using the previous token.
Also note: the documented example does not account for token expiry.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
