### PR TITLE
ExecuteAsInternal and ExecuteAsInternalAsync methods for extended use

### DIFF
--- a/src/RestSharp/Sync/RestClient.Sync.cs
+++ b/src/RestSharp/Sync/RestClient.Sync.cs
@@ -25,6 +25,15 @@ public partial class RestClient {
         => AsyncHelpers.RunSync(() => ExecuteAsync(request, cancellationToken));
 
     /// <summary>
+    /// Executes the request synchronously, without processing to common model
+    /// </summary>
+    /// <param name="request"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public InternalResponse ExecuteAsInternal(RestRequest request, CancellationToken cancellationToken = default)
+        => AsyncHelpers.RunSync(() => ExecuteAsInternalAsync(request, cancellationToken));
+    
+    /// <summary>
     /// A specialized method to download files as streams.
     /// </summary>
     /// <param name="request">Pre-configured request instance.</param>


### PR DESCRIPTION
We now have a DownloadStreamAsync method. It's cool and very useful. But DownloadStreamAsync and ExecuteAsync have fundamentally different signatures, which is not convenient to use, especially in generators.

I propose to give access to just one internal method, so that those who need it can use it at their discretion