### PR TITLE
Optionally disable encoding for request properties

### DIFF
--- a/src/RestSharp/Request/RestRequestExtensions.cs
+++ b/src/RestSharp/Request/RestRequestExtensions.cs
@@ -438,8 +438,8 @@ public static class RestRequestExtensions {
     public static RestRequest AddObject<T>(this RestRequest request, T obj, params string[] includedProperties) where T : class {
         var props = obj.GetProperties(includedProperties);
 
-        foreach (var (name, value) in props) {
-            request.AddParameter(name, value);
+        foreach (var prop in props) {
+            request.AddParameter(prop.Name, prop.Value, prop.Encode);
         }
 
         return request;

--- a/src/RestSharp/RestClientExtensions.Json.cs
+++ b/src/RestSharp/RestClientExtensions.Json.cs
@@ -47,11 +47,13 @@ public static partial class RestClientExtensions {
         object            parameters,
         CancellationToken cancellationToken = default
     ) {
-        var props = parameters.GetProperties();
+        var props   = parameters.GetProperties();
         var request = new RestRequest(resource);
 
-        foreach (var (name, value) in props) {
-            Parameter parameter = resource.Contains($"{name}") ? new UrlSegmentParameter(name, value!) : new QueryParameter(name, value);
+        foreach (var prop in props) {
+            Parameter parameter = resource.Contains($"{prop.Name}")
+                ? new UrlSegmentParameter(prop.Name, prop.Value!, prop.Encode)
+                : new QueryParameter(prop.Name, prop.Value, prop.Encode);
             request.AddParameter(parameter);
         }
 


### PR DESCRIPTION
Add the `Encode` property to `RequestPropery` attribute, set it to `true` by default.
I would allow disabling the parameter encoding for each of the object properties when using `AddObject` and `GetJsonAsync`.