### PR TITLE
Move Cookie handling out of HttpClient so we do not cross pollinate requests

### DIFF
--- a/src/RestSharp/KnownHeaders.cs
+++ b/src/RestSharp/KnownHeaders.cs
@@ -30,6 +30,7 @@ public static class KnownHeaders {
     public const string ContentLocation    = "Content-Location";
     public const string ContentRange       = "Content-Range";
     public const string ContentType        = "Content-Type";
+    public const string Cookie             = "Cookie";
     public const string LastModified       = "Last-Modified";
     public const string ContentMD5         = "Content-MD5";
     public const string Host               = "Host";

--- a/src/RestSharp/Request/RequestHeaders.cs
+++ b/src/RestSharp/Request/RequestHeaders.cs
@@ -14,7 +14,10 @@
 // 
 
 // ReSharper disable InvertIf
-namespace RestSharp; 
+
+using System.Net;
+
+namespace RestSharp;
 
 class RequestHeaders {
     public ParametersCollection Parameters { get; } = new();
@@ -31,6 +34,15 @@ class RequestHeaders {
             Parameters.AddParameter(new HeaderParameter(KnownHeaders.Accept, accepts));
         }
 
+        return this;
+    }
+
+    // Add Cookie header from the cookie container
+    public RequestHeaders AddCookieHeaders(CookieContainer cookieContainer, Uri uri) {
+        var cookies = cookieContainer.GetCookieHeader(uri);
+        if (cookies.Length > 0) {
+            Parameters.AddParameter(new HeaderParameter(KnownHeaders.Cookie, cookies));
+        }
         return this;
     }
 }

--- a/src/RestSharp/Request/RestRequest.cs
+++ b/src/RestSharp/Request/RestRequest.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net;
 using RestSharp.Extensions;
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 
@@ -29,6 +30,11 @@ public class RestRequest {
     /// </summary>
     public RestRequest() => Method = Method.Get;
 
+    /// <summary>
+    /// Constructor for a rest request to a relative resource URL and optional method
+    /// </summary>
+    /// <param name="resource">Resource to use</param>
+    /// <param name="method">Method to use (defaults to Method.Get></param>
     public RestRequest(string? resource, Method method = Method.Get) : this() {
         Resource = resource ?? "";
         Method   = method;
@@ -58,6 +64,11 @@ public class RestRequest {
                 );
     }
 
+    /// <summary>
+    /// Constructor for a rest request to a specific resource Uri and optional method
+    /// </summary>
+    /// <param name="resource">Resource Uri to use</param>
+    /// <param name="method">Method to use (defaults to Method.Get></param>
     public RestRequest(Uri resource, Method method = Method.Get)
         : this(resource.IsAbsoluteUri ? resource.AbsoluteUri : resource.OriginalString, method) { }
 
@@ -82,6 +93,11 @@ public class RestRequest {
     /// See AddParameter() for explanation of the types of parameters that can be passed
     /// </summary>
     public ParametersCollection Parameters { get; } = new();
+
+    /// <summary>
+    /// Optional cookie container to use for the request. If not set, cookies are not passed.
+    /// </summary>
+    public CookieContainer? CookieContainer { get; set; }
 
     /// <summary>
     /// Container of all the files to be uploaded with the request.

--- a/src/RestSharp/Request/RestRequestExtensions.cs
+++ b/src/RestSharp/Request/RestRequestExtensions.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net;
 using System.Text.RegularExpressions;
 using RestSharp.Extensions;
 using RestSharp.Serializers;
@@ -442,6 +443,21 @@ public static class RestRequestExtensions {
             request.AddParameter(name, value);
         }
 
+        return request;
+    }
+
+    /// <summary>
+    /// Adds cookie to the <seealso cref="HttpClient"/> cookie container.
+    /// </summary>
+    /// <param name="request">RestRequest to add the cookies to</param>
+    /// <param name="name">Cookie name</param>
+    /// <param name="value">Cookie value</param>
+    /// <param name="path">Cookie path</param>
+    /// <param name="domain">Cookie domain, must not be an empty string</param>
+    /// <returns></returns>
+    public static RestRequest AddCookie(this RestRequest request, string name, string value, string path, string domain) {
+        request.CookieContainer ??= new CookieContainer();
+        request.CookieContainer.Add(new Cookie(name, value, path, domain));
         return request;
     }
 

--- a/src/RestSharp/Response/RestResponse.cs
+++ b/src/RestSharp/Response/RestResponse.cs
@@ -64,7 +64,7 @@ public class RestResponse : RestResponseBase {
         HttpResponseMessage     httpResponse,
         RestRequest             request,
         Encoding                encoding,
-        CookieCollection        cookieCollection,
+        CookieCollection?       cookieCollection,
         CalculateResponseStatus calculateResponseStatus,
         CancellationToken       cancellationToken
     ) {

--- a/src/RestSharp/RestClient.Async.cs
+++ b/src/RestSharp/RestClient.Async.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net;
 using RestSharp.Extensions;
 
 namespace RestSharp;
@@ -32,7 +33,7 @@ public partial class RestClient {
                     internalResponse.ResponseMessage!,
                     request,
                     Options.Encoding,
-                    CookieContainer.GetCookies(internalResponse.Url),
+                    request.CookieContainer!.GetCookies(internalResponse.Url),
                     CalculateResponseStatus,
                     cancellationToken
                 )
@@ -64,15 +65,25 @@ public partial class RestClient {
         var ct = cts.Token;
 
         try {
+            // Make sure we have a cookie container if not provided in the request
+            var cookieContainer = request.CookieContainer ??= new CookieContainer();
             var headers = new RequestHeaders()
                 .AddHeaders(request.Parameters)
                 .AddHeaders(DefaultParameters)
-                .AddAcceptHeader(AcceptedContentTypes);
+                .AddAcceptHeader(AcceptedContentTypes)
+                .AddCookieHeaders(cookieContainer, url);
             message.AddHeaders(headers);
 
             if (request.OnBeforeRequest != null) await request.OnBeforeRequest(message).ConfigureAwait(false);
 
             var responseMessage = await HttpClient.SendAsync(message, request.CompletionOption, ct).ConfigureAwait(false);
+
+            // Parse all the cookies from the response and update the cookie jar with cookies
+            if (responseMessage.Headers.TryGetValues("Set-Cookie", out var cookiesHeader)) {
+                foreach (var header in cookiesHeader) {
+                    cookieContainer.SetCookies(url, header);
+                }
+            }
 
             if (request.OnAfterRequest != null) await request.OnAfterRequest(responseMessage).ConfigureAwait(false);
 

--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -27,8 +27,6 @@ namespace RestSharp;
 /// Client to translate RestRequests into Http requests and process response result
 /// </summary>
 public partial class RestClient : IDisposable {
-    public CookieContainer CookieContainer { get; }
-
     /// <summary>
     /// Content types that will be sent in the Accept header. The list is populated from the known serializers.
     /// If you need to send something else by default, set this property to a different value.
@@ -51,7 +49,6 @@ public partial class RestClient : IDisposable {
         UseDefaultSerializers();
 
         Options            = options;
-        CookieContainer    = Options.CookieContainer ?? new CookieContainer();
         _disposeHttpClient = true;
 
         var handler = new HttpClientHandler();
@@ -71,23 +68,27 @@ public partial class RestClient : IDisposable {
 
     /// <inheritdoc />
     /// <summary>
-    /// Sets the BaseUrl property for requests made by this client instance
+    /// Creates an instance of RestClient using a specific BaseUrl for requests made by this client instance
     /// </summary>
-    /// <param name="baseUrl"></param>
+    /// <param name="baseUrl">Base URI for the new client</param>
     public RestClient(Uri baseUrl) : this(new RestClientOptions { BaseUrl = baseUrl }) { }
 
     /// <inheritdoc />
     /// <summary>
-    /// Sets the BaseUrl property for requests made by this client instance
+    /// Creates an instance of RestClient using a specific BaseUrl for requests made by this client instance
     /// </summary>
-    /// <param name="baseUrl"></param>
+    /// <param name="baseUrl">Base URI for this new client as a string</param>
     public RestClient(string baseUrl) : this(new Uri(Ensure.NotEmptyString(baseUrl, nameof(baseUrl)))) { }
 
+    /// <summary>
+    /// Creates an instance of RestClient using a shared HttpClient and does not allocate one internally.
+    /// </summary>
+    /// <param name="httpClient">HttpClient to use</param>
+    /// <param name="disposeHttpClient">True to dispose of the client, false to assume the caller does (defaults to false)</param>
     public RestClient(HttpClient httpClient, bool disposeHttpClient = false) {
         UseDefaultSerializers();
 
         HttpClient         = httpClient;
-        CookieContainer    = new CookieContainer();
         Options            = new RestClientOptions();
         _disposeHttpClient = disposeHttpClient;
 
@@ -96,15 +97,16 @@ public partial class RestClient : IDisposable {
         }
     }
 
+    /// <summary>
+    /// Creates an instance of RestClient using a shared HttpClient and specific RestClientOptions and does not allocate one internally.
+    /// </summary>
+    /// <param name="httpClient">HttpClient to use</param>
+    /// <param name="options">RestClient options to use</param>
+    /// <param name="disposeHttpClient">True to dispose of the client, false to assume the caller does (defaults to false)</param>
     public RestClient(HttpClient httpClient, RestClientOptions options, bool disposeHttpClient = false) {
-        if (options.CookieContainer != null) {
-            throw new ArgumentException("Custom cookie container cannot be added to the HttpClient instance", nameof(options.CookieContainer));
-        }
-
         UseDefaultSerializers();
 
         HttpClient         = httpClient;
-        CookieContainer    = new CookieContainer();
         Options            = options;
         _disposeHttpClient = disposeHttpClient;
 
@@ -134,9 +136,9 @@ public partial class RestClient : IDisposable {
     }
 
     void ConfigureHttpMessageHandler(HttpClientHandler handler) {
+        handler.UseCookies             = false;
         handler.Credentials            = Options.Credentials;
         handler.UseDefaultCredentials  = Options.UseDefaultCredentials;
-        handler.CookieContainer        = CookieContainer;
         handler.AutomaticDecompression = Options.AutomaticDecompression;
         handler.PreAuthenticate        = Options.PreAuthenticate;
         handler.AllowAutoRedirect      = Options.FollowRedirects;

--- a/src/RestSharp/RestClientExtensions.Config.cs
+++ b/src/RestSharp/RestClientExtensions.Config.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 // 
 
-using System.Net;
 using System.Text;
 using RestSharp.Authenticators;
 using RestSharp.Extensions;
@@ -42,23 +41,6 @@ public static partial class RestClientExtensions {
     /// <returns></returns>
     public static RestClient UseQueryEncoder(this RestClient client, Func<string, Encoding, string> queryEncoder)
         => client.With(x => x.EncodeQuery = queryEncoder);
-
-    /// <summary>
-    /// Adds cookie to the <seealso cref="HttpClient"/> cookie container.
-    /// </summary>
-    /// <param name="client"></param>
-    /// <param name="name">Cookie name</param>
-    /// <param name="value">Cookie value</param>
-    /// <param name="path">Cookie path</param>
-    /// <param name="domain">Cookie domain, must not be an empty string</param>
-    /// <returns></returns>
-    public static RestClient AddCookie(this RestClient client, string name, string value, string path, string domain) {
-        lock (client.CookieContainer) {
-            client.CookieContainer.Add(new Cookie(name, value, path, domain));
-        }
-
-        return client;
-    }
 
     public static RestClient UseAuthenticator(this RestClient client, IAuthenticator authenticator)
         => client.With(x => x.Authenticator = authenticator);

--- a/src/RestSharp/RestClientOptions.cs
+++ b/src/RestSharp/RestClientOptions.cs
@@ -74,7 +74,6 @@ public class RestClientOptions {
     public CacheControlHeaderValue? CachePolicy       { get; set; }
     public bool                     FollowRedirects   { get; set; } = true;
     public bool?                    Expect100Continue { get; set; } = null;
-    public CookieContainer?         CookieContainer   { get; set; }
     public string?                  UserAgent         { get; set; } = DefaultUserAgent;
 
     /// <summary>


### PR DESCRIPTION
## Description

Implements the following:

- Move handling of Cookies out of HttpClient and into RestSharp, so they will not cross pollinate requests.
- Make the CookieContainer a property on the request, not the client.
- Add tests for cookie handling.

## Purpose
This pull request is a:

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

although the breakage is only against stuff that was not released other than in alpha anyway (making Options internal again).

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
