### PR TITLE
Throw exception on disposed RestClient

### DIFF
--- a/src/RestSharp/RestClient.Async.cs
+++ b/src/RestSharp/RestClient.Async.cs
@@ -48,6 +48,11 @@ public partial class RestClient {
     async Task<InternalResponse> ExecuteInternal(RestRequest request, CancellationToken cancellationToken) {
         Ensure.NotNull(request, nameof(request));
 
+        // Make sure we are not disposed of when someone tries to call us!
+        if (_disposed) {
+            throw new ObjectDisposedException(nameof(RestClient));
+        }
+
         using var requestContent = new RequestContent(this, request);
 
         if (Authenticator != null) await Authenticator.Authenticate(this, request).ConfigureAwait(false);


### PR DESCRIPTION
Throw exception on using a disposed RestClient instance. We should always throw this one as it is pretty fatal so you would not want this to silently show up in the Exception response value.

## Description
If you try to use a disposed instance right now, you get a silent exception buried inside HttpClient. With this change, it will throw immediately and cause the user code to fail as this is a pretty fatal problem.

## Purpose
This pull request is a:

- [X] New feature (non-breaking change which adds functionality)

## Checklist
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
