### PR TITLE
cleanup: Fix parameter naming case inconsistency in `RestRequestExtension.cs`

### DIFF
--- a/src/RestSharp/Request/RestRequestExtensions.cs
+++ b/src/RestSharp/Request/RestRequestExtensions.cs
@@ -277,10 +277,10 @@ public static class RestRequestExtensions {
         this RestRequest request,
         string           name,
         byte[]           bytes,
-        string           filename,
+        string           fileName,
         string?          contentType = null
     )
-        => request.AddFile(FileParameter.Create(name, bytes, filename, contentType));
+        => request.AddFile(FileParameter.Create(name, bytes, fileName, contentType));
 
     public static RestRequest AddFile(
         this RestRequest      request,
@@ -315,7 +315,7 @@ public static class RestRequestExtensions {
     /// <param name="request">Request instance</param>
     /// <param name="name">Parameter name</param>
     /// <param name="bytes">File content as bytes</param>
-    /// <param name="filename">File name</param>
+    /// <param name="fileName">File name</param>
     /// <param name="contentType">Optional: content type. Default is "application/octet-stream"</param>
     /// <param name="options">File parameter header options</param>
     /// <returns></returns>
@@ -323,11 +323,11 @@ public static class RestRequestExtensions {
         this RestRequest      request,
         string                name,
         byte[]                bytes,
-        string                filename,
+        string                fileName,
         string?               contentType,
         FileParameterOptions? options
     )
-        => request.AddFile(FileParameter.Create(name, bytes, filename, contentType, options));
+        => request.AddFile(FileParameter.Create(name, bytes, fileName, contentType, options));
 
     /// <summary>
     /// Adds a file attachment to the request, where the file content will be retrieved from a given stream 


### PR DESCRIPTION
## Description

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

_Might_ be breaking because we are changing a named argument. Existing call sites that uses [Named argument](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments#named-arguments) might fail to compile.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
