### PR TITLE
fixed access to possible null object RequestMessage

### DIFF
--- a/src/RestSharp/Response/RestResponse.cs
+++ b/src/RestSharp/Response/RestResponse.cs
@@ -90,7 +90,7 @@ public class RestResponse : RestResponseBase {
                 ContentType         = httpResponse.Content.Headers.ContentType?.MediaType,
                 ResponseStatus      = calculateResponseStatus(httpResponse),
                 ErrorException      = httpResponse.MaybeException(),
-                ResponseUri         = httpResponse.RequestMessage!.RequestUri,
+                ResponseUri         = httpResponse.RequestMessage?.RequestUri,
                 Server              = httpResponse.Headers.Server.ToString(),
                 StatusCode          = httpResponse.StatusCode,
                 StatusDescription   = httpResponse.ReasonPhrase,


### PR DESCRIPTION
## Description
Avoid access to HttpResponseMessage.RequestHeader if the parameter is null.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
