### PR TITLE
Bug fix. Response cookie with empty domain fails

### DIFF
--- a/src/RestSharp/RestClient.Async.cs
+++ b/src/RestSharp/RestClient.Async.cs
@@ -119,7 +119,12 @@ public partial class RestClient {
             // Parse all the cookies from the response and update the cookie jar with cookies
             if (responseMessage.Headers.TryGetValues(KnownHeaders.SetCookie, out var cookiesHeader)) {
                 foreach (var header in cookiesHeader) {
-                    cookieContainer.SetCookies(url, header);
+                    try {
+                        cookieContainer.SetCookies(url, header);
+                    }
+                    catch (CookieException) {
+                        // Do not fail request if we cannot parse a cookie
+                    }
                 }
             }
 

--- a/test/RestSharp.Tests.Integrated/CookieTests.cs
+++ b/test/RestSharp.Tests.Integrated/CookieTests.cs
@@ -48,4 +48,21 @@ public class CookieTests {
             c.HttpOnly.Should().Be(httpOnly);
         }
     }
+
+    [Fact]
+    public async Task GET_Async_With_Response_Cookies_Should_Not_Fail_With_Cookie_With_Empty_Domain() {
+        var request  = new RestRequest("set-cookies");
+        var response = await _client.ExecuteAsync(request);
+        response.Content.Should().Be("success");
+
+        Cookie? notFoundCookie = FindCookie("cookie_empty_domain");
+        notFoundCookie.Should().BeNull();
+
+        HeaderParameter? emptyDomainCookieHeader = response.Headers!
+            .SingleOrDefault(h => h.Name == KnownHeaders.SetCookie && ((string)h.Value!).StartsWith("cookie_empty_domain"));
+        emptyDomainCookieHeader.Should().NotBeNull();
+        ((string)emptyDomainCookieHeader!.Value!).Should().Contain("domain=;");
+        
+        Cookie? FindCookie(string name) => response!.Cookies!.FirstOrDefault(p => p.Name == name);
+    }
 }

--- a/test/RestSharp.Tests.Integrated/Server/Handlers/CookieHandlers.cs
+++ b/test/RestSharp.Tests.Integrated/Server/Handlers/CookieHandlers.cs
@@ -55,6 +55,16 @@ public static class CookieHandlers {
                 HttpOnly = true
             }
         );
+        
+        ctx.Response.Cookies.Append(
+            "cookie_empty_domain",
+            "value_empty_domain",
+            new CookieOptions {
+                HttpOnly = true,
+                Domain = string.Empty
+            }
+        );
+        
         return Results.Content("success");
     }
 }


### PR DESCRIPTION
## Description

Related to [issue 1792](https://github.com/restsharp/RestSharp/issues/1792)

When a response contains a Cookie header with an empty domain, the .NET library that parses the cookie throws an exception. This PR ignores cookie parsing exceptions so that the request does not fail due to malformed cookies. Instead, the cookie is ignored and the header is still accessible through the response headers. 

## Purpose
This pull request is a:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
