### PR TITLE
Merge client- and request-level cookies in the header

### DIFF
--- a/src/RestSharp/Extensions/CookieContainerExtensions.cs
+++ b/src/RestSharp/Extensions/CookieContainerExtensions.cs
@@ -1,0 +1,31 @@
+//  Copyright (c) .NET Foundation and Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System.Net;
+
+namespace RestSharp.Extensions;
+
+static class CookieContainerExtensions {
+    public static void AddCookies(this CookieContainer cookieContainer, Uri uri, IEnumerable<string> cookiesHeader) {
+        foreach (var header in cookiesHeader) {
+            try {
+                cookieContainer.SetCookies(uri, header);
+            }
+            catch (CookieException) {
+                // Do not fail request if we cannot parse a cookie
+            }
+        }
+    }
+}

--- a/src/RestSharp/RestClient.Async.cs
+++ b/src/RestSharp/RestClient.Async.cs
@@ -20,7 +20,7 @@ namespace RestSharp;
 public partial class RestClient {
     /// <inheritdoc />
     public async Task<RestResponse> ExecuteAsync(RestRequest request, CancellationToken cancellationToken = default) {
-        var internalResponse = await ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false);
+        using var internalResponse = await ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
         var response = internalResponse.Exception == null
             ? await RestResponse.FromHttpResponse(
@@ -93,7 +93,8 @@ public partial class RestClient {
 
         var httpMethod = AsHttpMethod(request.Method);
         var url        = this.BuildUri(request);
-        var message    = new HttpRequestMessage(httpMethod, url) { Content = requestContent.BuildContent() };
+
+        using var message    = new HttpRequestMessage(httpMethod, url) { Content = requestContent.BuildContent() };
         message.Headers.Host         = Options.BaseHost;
         message.Headers.CacheControl = Options.CachePolicy;
 
@@ -110,11 +111,8 @@ public partial class RestClient {
                 .AddHeaders(request.Parameters)
                 .AddHeaders(DefaultParameters)
                 .AddAcceptHeader(AcceptedContentTypes)
-                .AddCookieHeaders(cookieContainer, url);
-
-            if (Options.CookieContainer != null) {
-                headers.AddCookieHeaders(Options.CookieContainer, url);
-            }
+                .AddCookieHeaders(url, cookieContainer)
+                .AddCookieHeaders(url, Options.CookieContainer);
 
             message.AddHeaders(headers);
 
@@ -124,14 +122,10 @@ public partial class RestClient {
 
             // Parse all the cookies from the response and update the cookie jar with cookies
             if (responseMessage.Headers.TryGetValues(KnownHeaders.SetCookie, out var cookiesHeader)) {
-                foreach (var header in cookiesHeader) {
-                    try {
-                        cookieContainer.SetCookies(url, header);
-                    }
-                    catch (CookieException) {
-                        // Do not fail request if we cannot parse a cookie
-                    }
-                }
+                // ReSharper disable once PossibleMultipleEnumeration
+                cookieContainer.AddCookies(url, cookiesHeader);
+                // ReSharper disable once PossibleMultipleEnumeration
+                Options.CookieContainer?.AddCookies(url, cookiesHeader);
             }
 
             if (request.OnAfterRequest != null) await request.OnAfterRequest(responseMessage).ConfigureAwait(false);
@@ -149,7 +143,9 @@ public partial class RestClient {
         CookieContainer?     CookieContainer,
         Exception?           Exception,
         CancellationToken    TimeoutToken
-    );
+    ) : IDisposable {
+        public void Dispose() => ResponseMessage?.Dispose();
+    }
 
     static HttpMethod AsHttpMethod(Method method)
         => method switch {

--- a/test/RestSharp.Tests.Integrated/CookieTests.cs
+++ b/test/RestSharp.Tests.Integrated/CookieTests.cs
@@ -9,7 +9,10 @@ public class CookieTests {
     readonly string     _host;
 
     public CookieTests(TestServerFixture fixture) {
-        _client = new RestClient(fixture.Server.Url);
+        var options = new RestClientOptions(fixture.Server.Url) {
+            CookieContainer = new CookieContainer()
+        };
+        _client = new RestClient(options);
         _host   = _client.Options.BaseUrl!.Host;
     }
 
@@ -25,6 +28,21 @@ public class CookieTests {
     }
 
     [Fact]
+    public async Task Can_Perform_GET_Async_With_Request_And_Client_Cookies() {
+        _client.Options.CookieContainer!.Add(new Cookie("clientCookie", "clientCookieValue", null, _host));
+
+        var request = new RestRequest("get-cookies") {
+            CookieContainer = new CookieContainer()
+        };
+        request.CookieContainer.Add(new Cookie("cookie", "value", null, _host));
+        request.CookieContainer.Add(new Cookie("cookie2", "value2", null, _host));
+        var response = await _client.ExecuteAsync<string[]>(request);
+
+        var expected = new[] { "cookie=value", "cookie2=value2", "clientCookie=clientCookieValue" };
+        response.Data.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
     public async Task Can_Perform_GET_Async_With_Response_Cookies() {
         var request  = new RestRequest("set-cookies");
         var response = await _client.ExecuteAsync(request);
@@ -37,7 +55,7 @@ public class CookieTests {
         FindCookie("cookie5").Should().BeNull("Cookie 5 should vanish as the request is not SSL");
         AssertCookie("cookie6", "value6", x => x == DateTime.MinValue, true);
 
-        Cookie? FindCookie(string name) =>response!.Cookies!.FirstOrDefault(p => p.Name == name);
+        Cookie? FindCookie(string name) => response.Cookies!.FirstOrDefault(p => p.Name == name);
 
         void AssertCookie(string name, string value, Func<DateTime, bool> checkExpiration, bool httpOnly = false) {
             var c = FindCookie(name)!;
@@ -62,7 +80,7 @@ public class CookieTests {
             .SingleOrDefault(h => h.Name == KnownHeaders.SetCookie && ((string)h.Value!).StartsWith("cookie_empty_domain"));
         emptyDomainCookieHeader.Should().NotBeNull();
         ((string)emptyDomainCookieHeader!.Value!).Should().Contain("domain=;");
-        
+
         Cookie? FindCookie(string name) => response!.Cookies!.FirstOrDefault(p => p.Name == name);
     }
 }


### PR DESCRIPTION
Fixes #2055

## Description

* Merge client- and request-level cookies in one header
* Also allows using a manually-set cookie header without overriding it
* Copies response cookies to the client-level container if it is set
* Dispose the response message if not downloading data, it might've been a memory leak. 

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
