### PR TITLE
No value OAuth1 still need "=" to be valid

### DIFF
--- a/src/RestSharp/Authenticators/OAuth/WebPair.cs
+++ b/src/RestSharp/Authenticators/OAuth/WebPair.cs
@@ -10,7 +10,7 @@
 //   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
-//   limitations under the License. 
+//   limitations under the License.
 
 namespace RestSharp.Authenticators.OAuth;
 
@@ -27,7 +27,7 @@ class WebPair {
 
     public string  GetQueryParameter(bool web) {
         var value = web ? $"\"{WebValue}\"" : Value;
-        return value == null ? Name : $"{Name}={value}";
+        return $"{Name}={value}";
     }
 
     internal static WebPairComparer Comparer { get; } = new();


### PR DESCRIPTION
## Description

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

In 110.0.0 a fix for https://github.com/restsharp/RestSharp/issues/2022 was added.
While the request now being sent successfully the signature generated is invalid. This is as in OAuth1 [the name is separated from the corresponding value by an '=' character (ASCII code 61), even if the value is empty](https://oauth.net/core/1.0a/#anchor13)  
So this removes the new logic to add the "=" only if value in not null (only from the OAuth1 signature not for the URL construction)