### PR TITLE
Use builtin methods to ConcurrentDictionary

### DIFF
--- a/src/RestSharp/SimpleClientFactory.cs
+++ b/src/RestSharp/SimpleClientFactory.cs
@@ -22,9 +22,6 @@ static class SimpleClientFactory {
 
     public static HttpClient GetClient(Uri baseUrl, Func<HttpClient> getClient) {
         var key = baseUrl.ToString();
-        if (CachedClients.TryGetValue(key, out var client)) return client;
-        client = getClient();
-        CachedClients.TryAdd(key, client);
-        return client;
+        return CachedClients.GetOrAdd(key, key => getClient());
     }
 }


### PR DESCRIPTION
## Description

Update SimpleClientFactory to use builtin methods to ConcurrentDictionary to avoid adding a key multiple times when run concurrently

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
  - As this resolves a concurrency issue, I find it hard to reliably reproduce in Unit Tests.
- [ ] I have added necessary documentation (if appropriate)
