### PR TITLE
Timeout as TimeSpan, Support custom request timeout

### DIFF
--- a/src/RestSharp/Options/RestClientOptions.cs
+++ b/src/RestSharp/Options/RestClientOptions.cs
@@ -172,10 +172,9 @@ public class RestClientOptions {
     public CookieContainer? CookieContainer { get; set; }
 
     /// <summary>
-    /// Maximum request duration in milliseconds. When the request timeout is specified using <seealso cref="RestRequest.Timeout"/>,
-    /// the lowest value between the client timeout and request timeout will be used.
+    /// Request duration. Used when the request timeout is not specified using <seealso cref="RestRequest.Timeout"/>,
     /// </summary>
-    public int MaxTimeout { get; set; }
+    public TimeSpan? Timeout { get; set; }
 
     /// <summary>
     /// Default encoding to use when no encoding is specified in the content type header.

--- a/src/RestSharp/Request/RestRequest.cs
+++ b/src/RestSharp/Request/RestRequest.cs
@@ -136,7 +136,7 @@ public class RestRequest {
     /// <summary>
     /// Custom request timeout
     /// </summary>
-    public int Timeout { get; set; }
+    public TimeSpan? Timeout { get; set; }
 
     /// <summary>
     /// The Resource URL to make the request against.

--- a/src/RestSharp/RestClient.Async.cs
+++ b/src/RestSharp/RestClient.Async.cs
@@ -18,6 +18,8 @@ using RestSharp.Extensions;
 namespace RestSharp;
 
 public partial class RestClient {
+    // Default HttpClient timeout 
+    public TimeSpan DefaultTimeout = TimeSpan.FromSeconds(100);
     /// <inheritdoc />
     public async Task<RestResponse> ExecuteAsync(RestRequest request, CancellationToken cancellationToken = default) {
         using var internalResponse = await ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false);
@@ -90,7 +92,7 @@ public partial class RestClient {
         message.Headers.Host         = Options.BaseHost;
         message.Headers.CacheControl = request.CachePolicy ?? Options.CachePolicy;
 
-        using var timeoutCts = new CancellationTokenSource(request.Timeout > 0 ? request.Timeout : int.MaxValue);
+        using var timeoutCts = new CancellationTokenSource(request.Timeout ?? Options.Timeout ?? DefaultTimeout);
         using var cts        = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
 
         var ct = cts.Token;

--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -216,7 +216,9 @@ public partial class RestClient : IRestClient {
         : this(new HttpClient(handler, disposeHandler), true, configureRestClient, configureSerialization) { }
 
     static void ConfigureHttpClient(HttpClient httpClient, RestClientOptions options) {
-        if (options.MaxTimeout > 0) httpClient.Timeout = TimeSpan.FromMilliseconds(options.MaxTimeout);
+        
+        // We will use Options.Timeout in ExecuteAsInternalAsync method
+        httpClient.Timeout = Timeout.InfiniteTimeSpan;
 
         if (options.UserAgent != null &&
             httpClient.DefaultRequestHeaders.UserAgent.All(x => $"{x.Product?.Name}/{x.Product?.Version}" != options.UserAgent)) {

--- a/test/RestSharp.Tests.Integrated/NonProtocolExceptionHandlingTests.cs
+++ b/test/RestSharp.Tests.Integrated/NonProtocolExceptionHandlingTests.cs
@@ -50,7 +50,7 @@ public sealed class NonProtocolExceptionHandlingTests : IDisposable {
     public async Task Handles_Server_Timeout_Error() {
         var client = new RestClient(_server.Url);
 
-        var request = new RestRequest("404") { Timeout = 500 };
+        var request  = new RestRequest("404") { Timeout = TimeSpan.FromMilliseconds(500) };
         var response = await client.ExecuteAsync(request);
 
         response.ErrorException.Should().BeOfType<TaskCanceledException>();
@@ -60,7 +60,7 @@ public sealed class NonProtocolExceptionHandlingTests : IDisposable {
     [Fact]
     public async Task Handles_Server_Timeout_Error_With_Deserializer() {
         var client   = new RestClient(_server.Url);
-        var request  = new RestRequest("404") { Timeout = 500 };
+        var request  = new RestRequest("404") { Timeout = TimeSpan.FromMilliseconds(500) };
         var response = await client.ExecuteAsync<TestResponse>(request);
 
         response.Data.Should().BeNull();

--- a/test/RestSharp.Tests.Integrated/PutTests.cs
+++ b/test/RestSharp.Tests.Integrated/PutTests.cs
@@ -40,7 +40,7 @@ public class PutTests {
         var request = new RestRequest(TimeoutResource, Method.Put).AddBody("Body_Content");
 
         // Half the value of ResponseHandler.Timeout
-        request.Timeout = 200;
+        request.Timeout = TimeSpan.FromMilliseconds(200);
 
         var response = await _client.ExecuteAsync(request);
 

--- a/test/RestSharp.Tests.Integrated/RequestTests.cs
+++ b/test/RestSharp.Tests.Integrated/RequestTests.cs
@@ -57,7 +57,7 @@ public class AsyncTests {
         var request = new RestRequest("timeout").AddBody("Body_Content");
 
         // Half the value of ResponseHandler.Timeout
-        request.Timeout = 200;
+        request.Timeout = TimeSpan.FromMilliseconds(200);
 
         var response = await _client.ExecuteAsync(request);
 


### PR DESCRIPTION
1. I think the current approach to use int for timeout is outdated and it generates a lot of errors when you need to remember that these are milliseconds, and you need translate it. Even HttpClient has timeout as TimeSpan.

2. The presence of "MaxTimeout" also confuses many users. If you want to set a custom timeout for the request, you need to remember which timeout is set for the rest client. Often, when you set a custom timeout for request, it's higher timeout than the default. These are requests for downloading and uploading files. It's rare case when the timeout is specially reduced for a particular request.