### PR TITLE
Fixes OAuth1 signature with special characters (#2126, #1945)

### DIFF
--- a/src/RestSharp/Authenticators/OAuth/OAuthTools.cs
+++ b/src/RestSharp/Authenticators/OAuth/OAuthTools.cs
@@ -142,7 +142,7 @@ static class OAuthTools {
     internal static IEnumerable<string> SortParametersExcludingSignature(WebPairCollection parameters)
         => parameters
             .Where(x => !x.Name.EqualsIgnoreCase("oauth_signature"))
-            .Select(x => new WebPair(UrlEncodeStrict(x.Name), UrlEncodeStrict(x.Value)))
+            .Select(x => new WebPair(UrlEncodeStrict(x.Name), UrlEncodeRelaxed(x.Value)))
             .OrderBy(x => x, WebPair.Comparer)
             .Select(x => x.GetQueryParameter(false));
 

--- a/test/RestSharp.Tests.Integrated/OAuth1Tests.cs
+++ b/test/RestSharp.Tests.Integrated/OAuth1Tests.cs
@@ -51,16 +51,28 @@ public class OAuth1Tests {
         actual.Should().BeEquivalentTo(expected);
     }
 
-    [Fact]
-    public void Properly_Encodes_Parameter_Names() {
-        var postData = new WebPairCollection {
-            { "name[first]", "Chuck" },
-            { "name[last]", "Testa" }
-        };
+    [Theory]
+    [MemberData(nameof(EncodeParametersTestData))]
+    public void Properly_Encodes_Parameter_Names(IList<(string, string)> parameters, string expected) {
+        var postData = new WebPairCollection();
+        postData.AddRange(parameters.Select(x => new WebPair(x.Item1, x.Item2)));
         var sortedParams = OAuthTools.SortParametersExcludingSignature(postData);
 
-        sortedParams.First().Should().Be("name%5Bfirst%5D=Chuck");
+        sortedParams.First().Should().Be(expected);
     }
+
+    public static IEnumerable<object[]> EncodeParametersTestData =>
+        new List<object[]>
+        {
+            new object[] {
+                new List<(string, string)> { ("name[first]", "Chuck"), ("name[last]", "Testa") },
+                "name%5Bfirst%5D=Chuck"
+            },
+            new object[] {
+                new List<(string, string)> { ("country", "España") },
+                "country=Espa%C3%B1a"
+            }
+        };
 
     [Fact]
     public void Use_RFC_3986_Encoding_For_Auth_Signature_Base() {


### PR DESCRIPTION
## Description
Fixes OAuth1 signature which is generated wrong when containing special characters
#2126 , #1945 

## Purpose
This pull request is a:

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
