### PR TITLE
Wrapping up interceptors, fixing typos, removing Moq

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,8 +20,17 @@ jobs:
           dotnet-version: '7.0'
       -  
         name: Run tests
-        run: dotnet test -c Release
-        
+        run: dotnet test
+      -
+        name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            test-results/**/*.xml
+            test-results/**/*.trx
+            test-results/**/*.json
+
   docs:
     runs-on: ubuntu-latest
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,37 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <PropertyGroup Label="Package versions for .NET 6" Condition="$(TargetFramework) == 'net6.0'">
+    <MicrosoftTestHostVer>[6.0.22,7)</MicrosoftTestHostVer>
+  </PropertyGroup>
+  <PropertyGroup Label="Package versions for .NET 7" Condition="$(TargetFramework) == 'net7.0'">
+    <MicrosoftTestHostVer>7.0.11</MicrosoftTestHostVer>
+  </PropertyGroup>
+  <PropertyGroup Label="Package versions for .NET 8" Condition="$(TargetFramework) == 'net8.0'">
+    <MicrosoftTestHostVer>8.0.0-rc.1.23421.29</MicrosoftTestHostVer>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="HttpTracer" Version="2.1.1" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftTestHostVer)" />
+    <PackageVersion Include="Polly" Version="7.2.4" />
+    <PackageVersion Include="Xunit.Extensions.Logging" Version="1.1.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" PrivateAssets="All" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="AutoFixture" Version="4.18.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="MinVer" Version="4.3.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2023.2.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="CsvHelper" Version="30.0.1" />
+    <PackageVersion Include="Nullable" Version="1.3.1" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.3" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.8" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
+  </ItemGroup>
+</Project>

--- a/benchmarks/RestSharp.Benchmarks/RestSharp.Benchmarks.csproj
+++ b/benchmarks/RestSharp.Benchmarks/RestSharp.Benchmarks.csproj
@@ -1,24 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <LangVersion>10</LangVersion>
+        <LangVersion>preview</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
+        <RepoRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'RestSharp.sln'))</RepoRoot>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="4.18.0" />
-        <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+        <PackageReference Include="AutoFixture"/>
+        <PackageReference Include="BenchmarkDotNet"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\..\src\RestSharp.Serializers.NewtonsoftJson\RestSharp.Serializers.NewtonsoftJson.csproj" />
-        <ProjectReference Include="..\..\test\RestSharp.Tests.Shared\RestSharp.Tests.Shared.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\RestSharp.Serializers.NewtonsoftJson\RestSharp.Serializers.NewtonsoftJson.csproj"/>
+        <ProjectReference Include="$(RepoRoot)\test\RestSharp.Tests.Shared\RestSharp.Tests.Shared.csproj"/>
     </ItemGroup>
     <ItemGroup>
-        <Compile Remove="BenchmarkDotNet.Artifacts\**" />
-        <EmbeddedResource Remove="BenchmarkDotNet.Artifacts\**" />
-        <None Remove="BenchmarkDotNet.Artifacts\**" />
+        <Compile Remove="BenchmarkDotNet.Artifacts\**"/>
+        <EmbeddedResource Remove="BenchmarkDotNet.Artifacts\**"/>
+        <None Remove="BenchmarkDotNet.Artifacts\**"/>
     </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "7.0.0",
-    "rollForward": "latestMajor",
-    "allowPrerelease": false
-  }
-}

--- a/props/Common.props
+++ b/props/Common.props
@@ -3,7 +3,7 @@
         <RepoRoot>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory)).Parent.FullName)</RepoRoot>
         <AssemblyOriginatorKeyFile>$(RepoRoot)\RestSharp.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>
-        <LangVersion>10</LangVersion>
+        <LangVersion>preview</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'RestSharp.sln'))\props\Common.props"/>
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net471;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net471;net6.0;net7.0;net8.0</TargetFrameworks>
         <PackageIcon>restsharp.png</PackageIcon>
         <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
         <PackageProjectUrl>https://restsharp.dev</PackageProjectUrl>
@@ -15,13 +15,12 @@
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
-        <LangVersion>11</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
+        <PackageReference Include="MinVer" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <None Include="$(RepoRoot)\restsharp.png" Pack="true" PackagePath="\"/>

--- a/src/RestSharp.Serializers.CsvHelper/RestSharp.Serializers.CsvHelper.csproj
+++ b/src/RestSharp.Serializers.CsvHelper/RestSharp.Serializers.CsvHelper.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
-        <PackageReference Include="CsvHelper" Version="30.0.1" />
+        <PackageReference Include="CsvHelper"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\RestSharp\RestSharp.csproj"/>

--- a/src/RestSharp.Serializers.NewtonsoftJson/RestSharp.Serializers.NewtonsoftJson.csproj
+++ b/src/RestSharp.Serializers.NewtonsoftJson/RestSharp.Serializers.NewtonsoftJson.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageReference Include="Newtonsoft.Json"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\RestSharp\RestSharp.csproj"/>

--- a/src/RestSharp/Extensions/GenerateImmutableAttribute.cs
+++ b/src/RestSharp/Extensions/GenerateImmutableAttribute.cs
@@ -16,4 +16,7 @@
 namespace RestSharp.Extensions;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class GenerateImmutableAttribute : Attribute { }
+class GenerateImmutableAttribute : Attribute { }
+
+[AttributeUsage(AttributeTargets.Property)]
+class Exclude : Attribute { }

--- a/src/RestSharp/Interceptors/Interceptor.cs
+++ b/src/RestSharp/Interceptors/Interceptor.cs
@@ -13,45 +13,54 @@
 // limitations under the License.
 // 
 
-namespace RestSharp.Interceptors; 
+namespace RestSharp.Interceptors;
 
 /// <summary>
 /// Base Interceptor
 /// </summary>
 public abstract class Interceptor {
+    static readonly ValueTask Completed = 
+#if NET
+        ValueTask.CompletedTask;
+#else
+        new ();
+#endif
     /// <summary>
-    /// Intercepts the request before serialization
+    /// Intercepts the request before composing the request message
     /// </summary>
-    /// <param name="request">RestRequest before serialization</param>
+    /// <param name="request">RestRequest before composing the request message</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Value Tags</returns>
-    public virtual ValueTask InterceptBeforeSerialization(RestRequest request) {
-        return new();
-    }
+    public virtual ValueTask BeforeRequest(RestRequest request, CancellationToken cancellationToken) => Completed;
 
     /// <summary>
     /// Intercepts the request before being sent
     /// </summary>
-    /// <param name="req">HttpRequestMessage before being sent</param>
+    /// <param name="requestMessage">HttpRequestMessage before being sent</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Value Tags</returns>
-    public virtual ValueTask InterceptBeforeRequest(HttpRequestMessage req) {
-        return new();
-    }
+    public virtual ValueTask BeforeHttpRequest(HttpRequestMessage requestMessage, CancellationToken cancellationToken) => Completed;
 
     /// <summary>
     /// Intercepts the request before being sent
     /// </summary>
-    /// <param name="responseMessage">HttpResponseMessage as received from Server</param>
+    /// <param name="responseMessage">HttpResponseMessage as received from the remote server</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Value Tags</returns>
-    public virtual ValueTask InterceptAfterRequest(HttpResponseMessage responseMessage) {
-        return new();
-    }
+    public virtual ValueTask AfterHttpRequest(HttpResponseMessage responseMessage, CancellationToken cancellationToken) => Completed;
 
     /// <summary>
-    /// Intercepts the request before deserialization
+    /// Intercepts the request after it's created from HttpResponseMessage
     /// </summary>
-    /// <param name="response">HttpResponseMessage as received from Server</param>
+    /// <param name="response">HttpResponseMessage as received from the remote server</param>
+    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Value Tags</returns>
-    public virtual ValueTask InterceptBeforeDeserialize(RestResponse response) {
-        return new();
-    }
+    public virtual ValueTask AfterRequest(RestResponse response, CancellationToken cancellationToken) => Completed;
+    
+    /// <summary>
+    /// Intercepts the request before deserialization, won't be called if using non-generic ExecuteAsync
+    /// </summary>
+    /// <param name="response">HttpResponseMessage as received from the remote server</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    public virtual ValueTask BeforeDeserialization(RestResponse response, CancellationToken cancellationToken) => Completed;
 }

--- a/src/RestSharp/Options/ReadOnlyRestClientOptions.cs
+++ b/src/RestSharp/Options/ReadOnlyRestClientOptions.cs
@@ -1,0 +1,32 @@
+//  Copyright (c) .NET Foundation and Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+using RestSharp.Interceptors;
+
+namespace RestSharp;
+
+public partial class ReadOnlyRestClientOptions {
+    public IReadOnlyCollection<Interceptor>? Interceptors { get; private set; }
+
+    // partial void CopyAdditionalProperties(RestClientOptions inner); 
+    partial void CopyAdditionalProperties(RestClientOptions inner) => Interceptors = GetInterceptors(inner);
+
+    static IReadOnlyCollection<Interceptor>? GetInterceptors(RestClientOptions? options) {
+        if (options == null || options.Interceptors.Count == 0) return null;
+
+        var interceptors = new List<Interceptor>(options.Interceptors);
+        return interceptors.AsReadOnly();
+    }
+}

--- a/src/RestSharp/Options/RestClientOptions.cs
+++ b/src/RestSharp/Options/RestClientOptions.cs
@@ -65,6 +65,10 @@ public class RestClientOptions {
     /// </summary>
     public IAuthenticator? Authenticator { get; set; }
 
+    /// <summary>
+    /// List of interceptors that will be executed before the request is sent
+    /// </summary>
+    [Exclude]
     public List<Interceptor> Interceptors { get; set; } = new();
 
     /// <summary>
@@ -114,6 +118,7 @@ public class RestClientOptions {
 #if NET
     [UnsupportedOSPlatform("browser")]
 #endif
+    [Exclude]
     public X509CertificateCollection? ClientCertificates { get; set; }
 
     /// <summary>

--- a/src/RestSharp/Parameters/DefaultParameters.cs
+++ b/src/RestSharp/Parameters/DefaultParameters.cs
@@ -13,12 +13,12 @@
 // limitations under the License.
 //
 
+using System.Runtime.CompilerServices;
+
 namespace RestSharp;
 
 public sealed class DefaultParameters : ParametersCollection {
     readonly ReadOnlyRestClientOptions _options;
-
-    readonly object _lock = new();
 
     public DefaultParameters(ReadOnlyRestClientOptions options) => _options = options;
 
@@ -29,21 +29,20 @@ public sealed class DefaultParameters : ParametersCollection {
     /// <returns></returns>
     /// <exception cref="NotSupportedException"></exception>
     /// <exception cref="ArgumentException"></exception>
+    [MethodImpl(MethodImplOptions.Synchronized)]
     public DefaultParameters AddParameter(Parameter parameter) {
-        lock (_lock) {
-            if (parameter.Type == ParameterType.RequestBody)
-                throw new NotSupportedException(
-                    "Cannot set request body using default parameters. Use Request.AddBody() instead."
-                );
+        if (parameter.Type == ParameterType.RequestBody)
+            throw new NotSupportedException(
+                "Cannot set request body using default parameters. Use Request.AddBody() instead."
+            );
 
-            if (!_options.AllowMultipleDefaultParametersWithSameName &&
-                !MultiParameterTypes.Contains(parameter.Type)        &&
-                this.Any(x => x.Name == parameter.Name)) {
-                throw new ArgumentException("A default parameters with the same name has already been added", nameof(parameter));
-            }
-
-            Parameters.Add(parameter);
+        if (!_options.AllowMultipleDefaultParametersWithSameName &&
+            !MultiParameterTypes.Contains(parameter.Type)        &&
+            this.Any(x => x.Name == parameter.Name)) {
+            throw new ArgumentException("A default parameters with the same name has already been added", nameof(parameter));
         }
+
+        Parameters.Add(parameter);
 
         return this;
     }
@@ -55,10 +54,9 @@ public sealed class DefaultParameters : ParametersCollection {
     /// <param name="type">Parameter type</param>
     /// <returns></returns>
     [PublicAPI]
+    [MethodImpl(MethodImplOptions.Synchronized)]
     public DefaultParameters RemoveParameter(string name, ParameterType type) {
-        lock (_lock) {
-            Parameters.RemoveAll(x => x.Name == name && x.Type == type);
-        }
+        Parameters.RemoveAll(x => x.Name == name && x.Type == type);
 
         return this;
     }

--- a/src/RestSharp/Request/RequestContent.cs
+++ b/src/RestSharp/Request/RequestContent.cs
@@ -83,7 +83,7 @@ class RequestContent : IDisposable {
         var dispositionHeader = fileParameter.Options.DisableFilenameEncoding
             ? ContentDispositionHeaderValue.Parse($"form-data; name=\"{fileParameter.Name}\"; filename=\"{fileParameter.FileName}\"")
             : new ContentDispositionHeaderValue("form-data") { Name = $"\"{fileParameter.Name}\"", FileName = $"\"{fileParameter.FileName}\"" };
-        if (!fileParameter.Options.DisableFileNameStar) dispositionHeader.FileNameStar = fileParameter.FileName;
+        if (!fileParameter.Options.DisableFilenameStar) dispositionHeader.FileNameStar = fileParameter.FileName;
         streamContent.Headers.ContentDisposition = dispositionHeader;
 
         return streamContent;

--- a/src/RestSharp/Request/RestRequest.cs
+++ b/src/RestSharp/Request/RestRequest.cs
@@ -16,6 +16,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using RestSharp.Authenticators;
 using RestSharp.Extensions;
+using RestSharp.Interceptors;
 
 // ReSharper disable ReplaceSubstringWithRangeIndexer
 // ReSharper disable UnusedAutoPropertyAccessor.Global
@@ -167,16 +168,19 @@ public class RestRequest {
     /// <summary>
     /// When supplied, the function will be called before calling the deserializer
     /// </summary>
+    [Obsolete("Use Interceptors instead")]
     public Action<RestResponse>? OnBeforeDeserialization { get; set; }
 
     /// <summary>
     /// When supplied, the function will be called before making a request
     /// </summary>
+    [Obsolete("Use Interceptors instead")]
     public Func<HttpRequestMessage, ValueTask>? OnBeforeRequest { get; set; }
 
     /// <summary>
     /// When supplied, the function will be called after the request is complete
     /// </summary>
+    [Obsolete("Use Interceptors instead")]
     public Func<HttpResponseMessage, ValueTask>? OnAfterRequest { get; set; }
 
     internal void IncreaseNumAttempts() => Attempts++;
@@ -226,6 +230,11 @@ public class RestRequest {
             _advancedResponseHandler = value;
         }
     }
+    
+    /// <summary>
+    /// Request-level interceptors. Will be combined with client-level interceptors if set.
+    /// </summary>
+    public List<Interceptor>? Interceptors { get; set; }
 
     /// <summary>
     /// Adds a parameter object to the request parameters

--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -14,7 +14,9 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
 using RestSharp.Authenticators;
+using RestSharp.Interceptors;
 using RestSharp.Serializers;
 
 // ReSharper disable VirtualMemberCallInConstructor
@@ -36,7 +38,11 @@ public partial class RestClient : IRestClient {
     /// Content types that will be sent in the Accept header. The list is populated from the known serializers.
     /// If you need to send something else by default, set this property to a different value.
     /// </summary>
-    public string[] AcceptedContentTypes { get; set; }
+    public string[] AcceptedContentTypes {
+        get;
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        set;
+    }
 
     internal HttpClient HttpClient { get; }
 
@@ -83,11 +89,12 @@ public partial class RestClient : IRestClient {
             HttpClient         = GetClient();
         }
 
-        DefaultParameters = new DefaultParameters(Options);
+        DefaultParameters    = new DefaultParameters(Options);
+        return;
 
         HttpClient GetClient() {
             var handler = new HttpClientHandler();
-            ConfigureHttpMessageHandler(handler, Options);
+            ConfigureHttpMessageHandler(handler, options);
             var finalHandler = options.ConfigureMessageHandler?.Invoke(handler) ?? handler;
 
             var httpClient = new HttpClient(finalHandler);
@@ -181,7 +188,9 @@ public partial class RestClient : IRestClient {
         Options           = new ReadOnlyRestClientOptions(opt);
         DefaultParameters = new DefaultParameters(Options);
 
-        if (options != null) ConfigureHttpClient(httpClient, options);
+        if (options != null) {
+            ConfigureHttpClient(httpClient, options);
+        }
     }
 
     /// <summary>
@@ -227,7 +236,7 @@ public partial class RestClient : IRestClient {
     }
 
     // ReSharper disable once CognitiveComplexity
-    static void ConfigureHttpMessageHandler(HttpClientHandler handler, ReadOnlyRestClientOptions options) {
+    static void ConfigureHttpMessageHandler(HttpClientHandler handler, RestClientOptions options) {
 #if NET
         if (!OperatingSystem.IsBrowser()) {
 #endif
@@ -271,8 +280,7 @@ public partial class RestClient : IRestClient {
     }
 
     readonly bool _disposeHttpClient;
-
-    bool _disposed;
+    bool          _disposed;
 
     protected virtual void Dispose(bool disposing) {
         if (disposing && !_disposed) {

--- a/src/RestSharp/RestSharp.csproj
+++ b/src/RestSharp/RestSharp.csproj
@@ -3,18 +3,20 @@
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="7.0.3" />
+        <None Remove="RestSharp.csproj.DotSettings"/>
     </ItemGroup>
-    <ItemGroup>
-        <None Remove="RestSharp.csproj.DotSettings" />
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+        <PackageReference Include="System.Text.Json"/>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net471'">
-        <Reference Include="System.Net.Http" />
-        <Reference Include="System.Web" />
-        <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
+        <Reference Include="System.Net.Http"/>
+        <Reference Include="System.Web"/>
+        <PackageReference Include="Nullable" PrivateAssets="All"/>
+        <PackageReference Include="System.Text.Json"/>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
+        <PackageReference Include="Nullable" PrivateAssets="All"/>
+        <PackageReference Include="System.Text.Json"/>
     </ItemGroup>
     <ItemGroup>
         <Compile Update="RestClient.Extensions.Params.cs">
@@ -24,34 +26,34 @@
             <DependentUpon>RestClient.cs</DependentUpon>
         </Compile>
         <Compile Update="Request\PropertyCache.Populator.cs">
-          <DependentUpon>PropertyCache.cs</DependentUpon>
+            <DependentUpon>PropertyCache.cs</DependentUpon>
         </Compile>
         <Compile Update="Request\PropertyCache.Populator.RequestProperty.cs">
-          <DependentUpon>PropertyCache.cs</DependentUpon>
+            <DependentUpon>PropertyCache.cs</DependentUpon>
         </Compile>
         <Compile Update="RestClient.Extensions.Get.cs">
-          <DependentUpon>RestClient.Extensions.cs</DependentUpon>
+            <DependentUpon>RestClient.Extensions.cs</DependentUpon>
         </Compile>
         <Compile Update="RestClient.Extensions.Post.cs">
-          <DependentUpon>RestClient.Extensions.cs</DependentUpon>
+            <DependentUpon>RestClient.Extensions.cs</DependentUpon>
         </Compile>
         <Compile Update="RestClient.Extensions.Put.cs">
-          <DependentUpon>RestClient.Extensions.cs</DependentUpon>
+            <DependentUpon>RestClient.Extensions.cs</DependentUpon>
         </Compile>
         <Compile Update="RestClient.Extensions.Patch.cs">
-          <DependentUpon>RestClient.Extensions.cs</DependentUpon>
+            <DependentUpon>RestClient.Extensions.cs</DependentUpon>
         </Compile>
         <Compile Update="RestClient.Extensions.Head.cs">
-          <DependentUpon>RestClient.Extensions.cs</DependentUpon>
+            <DependentUpon>RestClient.Extensions.cs</DependentUpon>
         </Compile>
         <Compile Update="RestClient.Extensions.Delete.cs">
-          <DependentUpon>RestClient.Extensions.cs</DependentUpon>
+            <DependentUpon>RestClient.Extensions.cs</DependentUpon>
         </Compile>
         <Compile Update="RestClient.Extensions.Options.cs">
-          <DependentUpon>RestClient.Extensions.cs</DependentUpon>
+            <DependentUpon>RestClient.Extensions.cs</DependentUpon>
         </Compile>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(RepoRoot)\gen\SourceGenerator\SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <ProjectReference Include="$(RepoRoot)\gen\SourceGenerator\SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
     </ItemGroup>
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,23 +3,25 @@
     <PropertyGroup>
         <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
-        <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
         <Nullable>disable</Nullable>
         <NoWarn>xUnit1033</NoWarn>
+        <VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).trx</VSTestLogger>
+        <VSTestResultsDirectory>$(RepoRoot)/test-results/$(TargetFramework)</VSTestResultsDirectory>
     </PropertyGroup>
 
     <ItemGroup Condition="$(IsTestProject) == 'true'">
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" PrivateAssets="All"/>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All"/>
+        <PackageReference Include="coverlet.collector" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="xunit" Version="2.5.0"/>
-        <PackageReference Include="AutoFixture" Version="4.18.0"/>
-        <PackageReference Include="FluentAssertions" Version="6.11.0"/>
+        <PackageReference Include="xunit" />
+        <PackageReference Include="AutoFixture" />
+        <PackageReference Include="FluentAssertions" />
     </ItemGroup>
     <ItemGroup Condition="$(TargetFramework) == 'net472'">
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" PrivateAssets="All"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/RestSharp.InteractiveTests/RestSharp.InteractiveTests.csproj
+++ b/test/RestSharp.InteractiveTests/RestSharp.InteractiveTests.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <IsTestProject>false</IsTestProject>
-        <TargetFramework>net6</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="$(RepoRoot)\src\RestSharp\RestSharp.csproj" />

--- a/test/RestSharp.Tests.Integrated/Interceptor/TestInterceptor.cs
+++ b/test/RestSharp.Tests.Integrated/Interceptor/TestInterceptor.cs
@@ -1,0 +1,45 @@
+namespace RestSharp.Tests.Integrated.Interceptor;
+
+class TestInterceptor : Interceptors.Interceptor {
+    internal bool BeforeRequestCalled         { get; private set; }
+    internal bool BeforeHttpRequestCalled     { get; private set; }
+    internal bool AfterHttpRequestCalled      { get; private set; }
+    internal bool AfterRequestCalled          { get; private set; }
+    internal bool BeforeDeserializationCalled { get; private set; }
+
+    internal Action<RestRequest>?         BeforeRequestAction         { get; set; }
+    internal Action<HttpRequestMessage>?  BeforeHttpRequestAction     { get; set; }
+    internal Action<HttpResponseMessage>? AfterHttpRequestAction      { get; set; }
+    internal Action<RestResponse>?        AfterRequestAction          { get; set; }
+    internal Action<RestResponse>?        BeforeDeserializationAction { get; set; }
+
+    public override ValueTask BeforeHttpRequest(HttpRequestMessage req, CancellationToken cancellationToken) {
+        BeforeHttpRequestCalled = true;
+        BeforeHttpRequestAction?.Invoke(req);
+        return base.BeforeHttpRequest(req, cancellationToken);
+    }
+
+    public override ValueTask AfterHttpRequest(HttpResponseMessage responseMessage, CancellationToken cancellationToken) {
+        AfterHttpRequestCalled = true;
+        AfterHttpRequestAction?.Invoke(responseMessage);
+        return base.AfterHttpRequest(responseMessage, cancellationToken);
+    }
+
+    public override ValueTask AfterRequest(RestResponse response, CancellationToken cancellationToken) {
+        AfterRequestCalled = true;
+        AfterRequestAction?.Invoke(response);
+        return base.AfterRequest(response, cancellationToken);
+    }
+
+    public override ValueTask BeforeRequest(RestRequest request, CancellationToken cancellationToken) {
+        BeforeRequestCalled = true;
+        BeforeRequestAction?.Invoke(request);
+        return base.BeforeRequest(request, cancellationToken);
+    }
+
+    public override ValueTask BeforeDeserialization(RestResponse response, CancellationToken cancellationToken) {
+        BeforeDeserializationCalled = true;
+        BeforeDeserializationAction?.Invoke(response);
+        return base.BeforeDeserialization(response, cancellationToken);
+    }
+}

--- a/test/RestSharp.Tests.Integrated/RestSharp.Tests.Integrated.csproj
+++ b/test/RestSharp.Tests.Integrated/RestSharp.Tests.Integrated.csproj
@@ -4,24 +4,23 @@
         <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
-        <ProjectReference Include="$(RepoRoot)\src\RestSharp.Serializers.Xml\RestSharp.Serializers.Xml.csproj" />
-        <ProjectReference Include="$(RepoRoot)\src\RestSharp\RestSharp.csproj" />
-        <ProjectReference Include="..\RestSharp.Tests.Shared\RestSharp.Tests.Shared.csproj" />
+        <ProjectReference Include="$(RepoRoot)\src\RestSharp.Serializers.Xml\RestSharp.Serializers.Xml.csproj"/>
+        <ProjectReference Include="$(RepoRoot)\src\RestSharp\RestSharp.csproj"/>
+        <ProjectReference Include="..\RestSharp.Tests.Shared\RestSharp.Tests.Shared.csproj"/>
     </ItemGroup>
     <ItemGroup>
-        <None Update="Assets\Koala.jpg" CopyToOutputDirectory="PreserveNewest" />
-        <None Update="Assets\TestFile.txt" CopyToOutputDirectory="PreserveNewest" />
-        <None Update="Assets\KoalaÄÖäö.jpg" CopyToOutputDirectory="PreserveNewest" />
-        <None Update="Assets\Teståæ.txt" CopyToOutputDirectory="PreserveNewest" />
+        <None Update="Assets\Koala.jpg" CopyToOutputDirectory="PreserveNewest"/>
+        <None Update="Assets\TestFile.txt" CopyToOutputDirectory="PreserveNewest"/>
+        <None Update="Assets\KoalaÄÖäö.jpg" CopyToOutputDirectory="PreserveNewest"/>
+        <None Update="Assets\Teståæ.txt" CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="HttpTracer" Version="2.1.1" />
-        <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.21" />
-        <PackageReference Include="Polly" Version="7.2.4" />
-        <PackageReference Include="Xunit.Extensions.Logging" Version="1.1.0" />
+        <PackageReference Include="HttpTracer"/>
+        <PackageReference Include="Microsoft.AspNetCore.TestHost"/>
+        <PackageReference Include="Polly"/>
+        <PackageReference Include="Xunit.Extensions.Logging"/>
     </ItemGroup>
     <ItemGroup>
-        <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+        <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
     </ItemGroup>
 </Project>

--- a/test/RestSharp.Tests.Serializers.Json/NewtonsoftJson/IntegratedSimpleTests.cs
+++ b/test/RestSharp.Tests.Serializers.Json/NewtonsoftJson/IntegratedSimpleTests.cs
@@ -65,7 +65,7 @@ public class IntegratedSimpleTests {
 
         var client = new RestClient(server.Url, configureSerialization: cfg => cfg.UseNewtonsoftJson());
 
-        var response = await client.ExecuteAsync<TestClass>(new RestRequest());
+        var response = await client.ExecuteAsync<TestClass>(new RestRequest(), default);
 
         response.IsSuccessStatusCode.Should().BeTrue();
         response.IsSuccessful.Should().BeFalse();
@@ -88,7 +88,7 @@ public class IntegratedSimpleTests {
 
         var client = new RestClient(server.Url, configureSerialization: cfg => cfg.UseNewtonsoftJson());
 
-        var response = await client.ExecuteAsync<TestClass>(new RestRequest());
+        var response = await client.ExecuteAsync<TestClass>(new RestRequest(), default);
 
         response.IsSuccessStatusCode.Should().BeTrue();
         response.IsSuccessful.Should().BeTrue();

--- a/test/RestSharp.Tests/RestSharp.Tests.csproj
+++ b/test/RestSharp.Tests/RestSharp.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.20.2" />
+    <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
   </ItemGroup>


### PR DESCRIPTION
- Make interceptors collection immutable in read-only options
- Adding interceptors to request level, making old callbacks obsolete
- Refactoring tests to not use Moq
- Moving `OnBeforeDerialization` to the right place
- Aligning interceptors:
  - Before request
  - Before HTTP request
  - After HTTP request
  - After request
  - Before deserialization