### PR TITLE
Update IAuthenticator? Authenticator in usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -107,11 +107,11 @@ public class TwitterClient : ITwitterClient, IDisposable {
     readonly RestClient _client;
 
     public TwitterClient(string apiKey, string apiKeySecret) {
-        var options = new RestClientOptions("https://api.twitter.com/2");
-
-        _client = new RestClient(options) {
+        var options = new RestClientOptions("https://api.twitter.com/2"){
             Authenticator = new TwitterAuthenticator("https://api.twitter.com", apiKey, apiKeySecret)
         };
+
+        _client = new RestClient(options);
     }
 
     public async Task<TwitterUser> GetUser(string user) {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,10 +60,10 @@ Now, we need to implement the `GetToken` function in the class:
 
 ```csharp
 async Task<string> GetToken() {
-    var options = new RestClientOptions(_baseUrl);
-    using var client = new RestClient(options) {
+    var options = new RestClientOptions(_baseUrl){
         Authenticator = new HttpBasicAuthenticator(_clientId, _clientSecret),
     };
+    using var client = new RestClient(options);
 
     var request = new RestRequest("oauth2/token")
         .AddParameter("grant_type", "client_credentials");


### PR DESCRIPTION
Remove `Authenticator` from `RestClient` init to `RestClientOptions` in [Usage][2] docs.

## Description

<!-- If your pull request solves an issue, please reference it here -->
Update the [Usage documentation][2] so that it conforms to the [latest RestSharp API][1] regarding where to set the `IAuthenticator? Authenticator`.

New deprecation in [`RestSharp/RestClient.cs`][1]:

```csharp
    [Obsolete("Use RestClientOptions.Authenticator instead")]
    public IAuthenticator? Authenticator => Options.Authenticator;
```

Deprecation warning `CS0618: 'RestClient.Authenticator' is obsolete: 'Use RestClientOptions.Authenticator instead'` in live:

![CS0618: 'RestClient.Authenticator' is obsolete: 'Use RestClientOptions.Authenticator instead'](https://github.com/restsharp/RestSharp/assets/5055400/8f59c73f-8a71-45dc-bf81-ce719386d40d)


## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

[1]: https://github.com/restsharp/RestSharp/blob/d0b4b1842859ff3c61c7a6151ba273f3a8577f95/src/RestSharp/RestClient.cs#L52C19-L52C19
[2]: https://restsharp.dev/usage.html#api-client