### PR TITLE
Set UserAgent as a default header parameter

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -594,7 +594,7 @@ One way of doing it is to use `RestClient` constructors that accept an instance 
 
 - `BaseAddress` will be used to set the base address of the `HttpClient` instance if base address is not set there already.
 - `MaxTimeout`
-- `UserAgent` will be set if the `User-Agent` header is not set on the `HttpClient` instance already.
+- `UserAgent` will be added to the `RestClient.DefaultParameters` list as a HTTP header. This will be added to each request made by the `RestClient`, and the `HttpClient` instance will not be modified. This is to allow the `HttpClient` instance to be reused for scenarios where different `User-Agent` headers are required.
 - `Expect100Continue`
 
 Another option is to use a simple HTTP client factory as described [above](#simple-factory). 

--- a/test/RestSharp.Tests/RestClientTests.cs
+++ b/test/RestSharp.Tests/RestClientTests.cs
@@ -118,20 +118,41 @@ public class RestClientTests {
     }
 
     [Fact]
-    public void ConfigureHttpClient_does_not_duplicate_user_agent_for_same_client() {
+    public void ConfigureDefaultParameters_sets_user_agent_new_httpClient_instance() {
+        // arrange
+        var clientOptions = new RestClientOptions();
+
+        // act
+        var restClient = new RestClient(clientOptions);
+
+        //assert
+        Assert.Single(
+            restClient.DefaultParameters,
+            parameter => parameter.Type == ParameterType.HttpHeader &&
+                parameter.Name == KnownHeaders.UserAgent &&
+                parameter.Value is string valueAsString &&
+                valueAsString == clientOptions.UserAgent);
+
+        Assert.Empty(restClient.HttpClient.DefaultRequestHeaders.UserAgent);
+    }
+
+    [Fact]
+    public void ConfigureDefaultParameters_sets_user_agent_given_httpClient_instance() {
         // arrange
         var httpClient    = new HttpClient();
         var clientOptions = new RestClientOptions();
 
         // act
-        var unused = new RestClient(httpClient, clientOptions);
-        var dummy  = new RestClient(httpClient, clientOptions);
+        var restClient = new RestClient(httpClient, clientOptions);
 
-        // assert
-        Assert.Contains(
-            httpClient.DefaultRequestHeaders.UserAgent,
-            agent => $"{agent.Product.Name}/{agent.Product.Version}" == clientOptions.UserAgent
-        );
-        Assert.Single(httpClient.DefaultRequestHeaders.UserAgent);
+        //assert
+        Assert.Single(
+            restClient.DefaultParameters,
+            parameter => parameter.Type == ParameterType.HttpHeader &&
+                parameter.Name == KnownHeaders.UserAgent &&
+                parameter.Value is string valueAsString &&
+                valueAsString == clientOptions.UserAgent);
+
+        Assert.Empty(httpClient.DefaultRequestHeaders.UserAgent);
     }
 }


### PR DESCRIPTION
## Description
When a UserAgent is set in the RestClientOptions passed to the RestClient constructor, the UserAgent is now set as a HTTP header in the DefaultParameters property rather than modifying the HttpClient instance. This is so that the HttpClient instance can be re-used for APIs etc that require different UserAgent headers.

The ConfigureHttpClient method still sets the max timeout as that's set on the client instance itself, not a HTTP header.

I did not modify the "ExpectContinue" behaviour as it seems to have complex logic around parsing values rather than just directly setting them. If this is something you'd like to be in the DefaultParameters property too I can consider that.

<!-- If your pull request solves an issue, please reference it here -->

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
