### PR TITLE
.Net 8.0 Compliance Followup

### DIFF
--- a/src/RestSharp.Serializers.CsvHelper/RestSharp.Serializers.CsvHelper.csproj
+++ b/src/RestSharp.Serializers.CsvHelper/RestSharp.Serializers.CsvHelper.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+      <TargetFrameworks>netstandard2.0;net471;net6.0;net7.0;net8.0</TargetFrameworks>
+    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="CsvHelper" Version="30.0.1" />
     </ItemGroup>

--- a/src/RestSharp.Serializers.NewtonsoftJson/RestSharp.Serializers.NewtonsoftJson.csproj
+++ b/src/RestSharp.Serializers.NewtonsoftJson/RestSharp.Serializers.NewtonsoftJson.csproj
@@ -1,4 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+      <TargetFrameworks>netstandard2.0;net471;net6.0;net7.0;net8.0</TargetFrameworks>
+    </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     </ItemGroup>

--- a/src/RestSharp.Serializers.Xml/RestSharp.Serializers.Xml.csproj
+++ b/src/RestSharp.Serializers.Xml/RestSharp.Serializers.Xml.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <RootNamespace>RestSharp.Serializers.Xml</RootNamespace>
+        <TargetFrameworks>netstandard2.0;net471;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\RestSharp\RestSharp.csproj"/>

--- a/src/RestSharp/RestSharp.csproj
+++ b/src/RestSharp/RestSharp.csproj
@@ -5,18 +5,15 @@
     </PropertyGroup>
     <ItemGroup>
         <None Remove="RestSharp.csproj.DotSettings" />
+        <PackageReference Include="System.Text.Json" Version="8.0.3" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net471'">
         <Reference Include="System.Net.Http" />
         <Reference Include="System.Web" />
-        <PackageReference Include="System.Text.Json" Version="7.0.3" />
         <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' != 'net471'">
-        <PackageReference Include="System.Text.Json" Version="8.0.2" />
     </ItemGroup>
     <ItemGroup>
         <Compile Update="RestClient.Extensions.Params.cs">

--- a/src/RestSharp/RestSharp.csproj
+++ b/src/RestSharp/RestSharp.csproj
@@ -1,20 +1,22 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <TargetFrameworks>netstandard2.0;net471;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="7.0.3" />
-    </ItemGroup>
     <ItemGroup>
         <None Remove="RestSharp.csproj.DotSettings" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net471'">
         <Reference Include="System.Net.Http" />
         <Reference Include="System.Web" />
+        <PackageReference Include="System.Text.Json" Version="7.0.3" />
         <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' != 'net471'">
+        <PackageReference Include="System.Text.Json" Version="8.0.2" />
     </ItemGroup>
     <ItemGroup>
         <Compile Update="RestClient.Extensions.Params.cs">

--- a/test/RestSharp.InteractiveTests/RestSharp.InteractiveTests.csproj
+++ b/test/RestSharp.InteractiveTests/RestSharp.InteractiveTests.csproj
@@ -1,11 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <IsTestProject>false</IsTestProject>
         <TargetFramework>net6</TargetFramework>
+        <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="$(RepoRoot)\src\RestSharp\RestSharp.csproj" />
         <ProjectReference Include="..\RestSharp.Tests.Shared\RestSharp.Tests.Shared.csproj" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+      <Reference Include="System.Web">
+        <HintPath>..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.7.2\System.Web.dll</HintPath>
+      </Reference>
     </ItemGroup>
 </Project>

--- a/test/RestSharp.Tests.Integrated/NonProtocolExceptionHandlingTests.cs
+++ b/test/RestSharp.Tests.Integrated/NonProtocolExceptionHandlingTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Net.Sockets;
 using RestSharp.Tests.Shared.Fixtures;
 
 namespace RestSharp.Tests.Integrated;
@@ -77,9 +78,9 @@ public sealed class NonProtocolExceptionHandlingTests : IDisposable {
             Method        = Method.Get
         };
         var response = await client.ExecuteAsync<StupidClass>(request);
-
         response.ErrorException.Should().BeOfType<HttpRequestException>();
-        response.ErrorException!.Message.Should().Contain("known");
+        response.ErrorException!.InnerException.Should().BeOfType<SocketException>();
+        (response.ErrorException!.InnerException as SocketException)!.SocketErrorCode.Should().Be(SocketError.HostNotFound);
         response.ResponseStatus.Should().Be(ResponseStatus.Error);
     }
 }

--- a/test/RestSharp.Tests.Integrated/RestSharp.Tests.Integrated.csproj
+++ b/test/RestSharp.Tests.Integrated/RestSharp.Tests.Integrated.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="$(RepoRoot)\src\RestSharp.Serializers.Xml\RestSharp.Serializers.Xml.csproj" />

--- a/test/RestSharp.Tests.Serializers.Csv/RestSharp.Tests.Serializers.Csv.csproj
+++ b/test/RestSharp.Tests.Serializers.Csv/RestSharp.Tests.Serializers.Csv.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+      <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
+    </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="$(RepoRoot)\src\RestSharp.Serializers.CsvHelper\RestSharp.Serializers.CsvHelper.csproj"/>
         <ProjectReference Include="..\RestSharp.Tests.Shared\RestSharp.Tests.Shared.csproj"/>

--- a/test/RestSharp.Tests.Serializers.Json/RestSharp.Tests.Serializers.Json.csproj
+++ b/test/RestSharp.Tests.Serializers.Json/RestSharp.Tests.Serializers.Json.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+      <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
+    </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="$(RepoRoot)\src\RestSharp.Serializers.NewtonsoftJson\RestSharp.Serializers.NewtonsoftJson.csproj" />
         <ProjectReference Include="$(RepoRoot)\src\RestSharp\RestSharp.csproj" />
@@ -12,6 +15,10 @@
         <Compile Include="NewtonsoftJson\IntegratedTests.cs" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+        <PackageReference Include="rest-mock-core" Version="0.7.12" />
+        <Compile Include="NewtonsoftJson\IntegratedTests.cs" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="rest-mock-core" Version="0.7.12" />
         <Compile Include="NewtonsoftJson\IntegratedTests.cs" />
     </ItemGroup>

--- a/test/RestSharp.Tests.Serializers.Xml/RestSharp.Tests.Serializers.Xml.csproj
+++ b/test/RestSharp.Tests.Serializers.Xml/RestSharp.Tests.Serializers.Xml.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Nullable>disable</Nullable>
+        <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="$(RepoRoot)\src\RestSharp.Serializers.Xml\RestSharp.Serializers.Xml.csproj" />

--- a/test/RestSharp.Tests.Shared/RestSharp.Tests.Shared.csproj
+++ b/test/RestSharp.Tests.Shared/RestSharp.Tests.Shared.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <IsTestProject>false</IsTestProject>
+        <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 </Project>

--- a/test/RestSharp.Tests/ObjectParameterTests.cs
+++ b/test/RestSharp.Tests/ObjectParameterTests.cs
@@ -446,11 +446,7 @@ public partial class ObjectParameterTests {
             .ContainSingle()
             .Which
             .Should()
-#if NET472
-            .BeEquivalentTo(new GetOrPostParameter("CustomName", "Hello world,Guid[]-matrix"));
-#else
             .BeEquivalentTo(new GetOrPostParameter("CustomName", "Hello world,Guid[] Array"));
-#endif
     }
 
     [Fact]

--- a/test/RestSharp.Tests/ObjectParameterTests.cs
+++ b/test/RestSharp.Tests/ObjectParameterTests.cs
@@ -446,7 +446,11 @@ public partial class ObjectParameterTests {
             .ContainSingle()
             .Which
             .Should()
+#if NET472
+            .BeEquivalentTo(new GetOrPostParameter("CustomName", "Hello world,Guid[]-matrix"));
+#else
             .BeEquivalentTo(new GetOrPostParameter("CustomName", "Hello world,Guid[] Array"));
+#endif
     }
 
     [Fact]

--- a/test/RestSharp.Tests/RestSharp.Tests.csproj
+++ b/test/RestSharp.Tests/RestSharp.Tests.csproj
@@ -1,8 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.20.2" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-    <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\RestSharp\RestSharp.csproj" />

--- a/test/RestSharp.Tests/RestSharp.Tests.csproj
+++ b/test/RestSharp.Tests/RestSharp.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Moq" Version="4.20.2" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.2" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\RestSharp\RestSharp.csproj" />


### PR DESCRIPTION
## Purpose
To add full .Net 8.0 compliance and and fix #2169 

## Description
In one of the commits here, I changed one of the tests to take into account, that `Array.Empty<Guid>()`  gave a different output. It turns out this was due to **System.Text.Json** being v7.0.3 for net4.7.2 - this appears to be related to the issue #2169 - so, changing all frameworks to use v8.0.3 appear to be eliminating this issue, thus all tests could be completed accordingly.

_Note_: Another test was also changed, since it renders a **false negative** due to me using culture specific system (da-DK). Details is enclosed within the commit.

Finally, when using this version, I advice to **CLEAN** your solution or the #2169 issue may remain.