### PR TITLE
Fix spelling in docs sidebar

### DIFF
--- a/docs/docs/usage/_category_.json
+++ b/docs/docs/usage/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Using ReshSharp",
+  "label": "Using RestSharp",
   "position": 3,
   "link": {
     "type": "generated-index"


### PR DESCRIPTION
## Description

Fixes the spelling of RestSharp on the intro page at https://restsharp.dev/docs/intro
<img width="315" alt="image" src="https://github.com/restsharp/RestSharp/assets/3185998/8c9be89a-5b53-4d3a-a01d-1c77a63346ed">


## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
