### PR TITLE
Re-instate old methods, but as obsolete

### DIFF
--- a/src/RestSharp/Options/RestClientOptions.cs
+++ b/src/RestSharp/Options/RestClientOptions.cs
@@ -182,6 +182,16 @@ public class RestClientOptions {
     public CookieContainer? CookieContainer { get; set; }
 
     /// <summary>
+    /// Maximum request duration in milliseconds. When the request timeout is specified using <seealso cref="RestRequest.Timeout"/>,
+    /// the lowest value between the client timeout and request timeout will be used.
+    /// </summary>
+    [Obsolete("Use Timeout instead.")]
+    public int MaxTimeout {
+        get => (int) (Timeout?.TotalMilliseconds ?? 0);
+        set => Timeout = TimeSpan.FromMilliseconds(value);
+    }
+
+    /// <summary>
     /// Request duration. Used when the request timeout is not specified using <seealso cref="RestRequest.Timeout"/>,
     /// </summary>
     public TimeSpan? Timeout { get; set; }

--- a/src/RestSharp/RestClient.Extensions.cs
+++ b/src/RestSharp/RestClient.Extensions.cs
@@ -20,7 +20,12 @@ namespace RestSharp;
 [PublicAPI]
 public static partial class RestClientExtensions {
     [PublicAPI]
-    public static ValueTask<RestResponse<T>> Deserialize<T>(this IRestClient client, RestResponse response, CancellationToken cancellationToken)
+    [Obsolete("Please use the async overload with a cancellation token")]
+    public static RestResponse<T> Deserialize<T>(this IRestClient client, RestResponse response)
+        => AsyncHelpers.RunSync(() => client.Serializers.Deserialize<T>(response.Request, response, client.Options, CancellationToken.None).AsTask());
+
+    [PublicAPI]
+    public static ValueTask<RestResponse<T>> Deserialize<T>(this IRestClient client, RestResponse response, CancellationToken cancellationToken)    
         => client.Serializers.Deserialize<T>(response.Request, response, client.Options, cancellationToken);
 
     /// <summary>


### PR DESCRIPTION
## Description

Release [111.0.0](https://github.com/restsharp/RestSharp/releases/tag/111.0.0) broke a few scenarios, with the changes in https://github.com/restsharp/RestSharp/pull/2078 and https://github.com/restsharp/RestSharp/pull/2141.

While both of these changes are valuable, they are breaking changes, and they break code generated by https://github.com/OpenAPITools/openapi-generator.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This PR adds overloads to these methods to re-instate the old behaviour, but flags them as `[Obsolete]`. 
(If projects that consume this library has `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` in the csproj, then this can be overridden via `<<NoWarn>618</NoWarn>`)

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
