### PR TITLE
Added extensions for getting content header values

### DIFF
--- a/src/RestSharp/Response/RestResponseExtensions.cs
+++ b/src/RestSharp/Response/RestResponseExtensions.cs
@@ -22,7 +22,7 @@ public static class RestResponseExtensions {
     /// <param name="headerName">Name of the header</param>
     /// <returns>Header value or null if the header is not found in the response</returns>
     public static string? GetHeaderValue(this RestResponse response, string headerName)
-        => response.Headers?.FirstOrDefault(x => NameIs(x.Name, headerName))?.Value?.ToString();
+        => response.Headers?.FirstOrDefault(x => NameIs(x.Name, headerName))?.Value.ToString();
 
     /// <summary>
     /// Gets all the values of the header with the specified name.
@@ -33,7 +33,29 @@ public static class RestResponseExtensions {
     public static string[] GetHeaderValues(this RestResponse response, string headerName)
         => response.Headers
                 ?.Where(x => NameIs(x.Name, headerName))
-                .Select(x => x.Value?.ToString() ?? "")
+                .Select(x => x.Value.ToString() ?? "")
+                .ToArray() ??
+            [];
+
+    /// <summary>
+    /// Gets the value of the content header with the specified name.
+    /// </summary>
+    /// <param name="response">Response object</param>
+    /// <param name="headerName">Name of the header</param>
+    /// <returns>Header value or null if the content header is not found in the response</returns>
+    public static string? GetContentHeaderValue(this RestResponse response, string headerName)
+        => response.ContentHeaders?.FirstOrDefault(x => NameIs(x.Name, headerName))?.Value.ToString();
+
+    /// <summary>
+    /// Gets all the values of the content header with the specified name.
+    /// </summary>
+    /// <param name="response">Response object</param>
+    /// <param name="headerName">Name of the header</param>
+    /// <returns>Array of header values or empty array if the content header is not found in the response</returns>
+    public static string[] GetContentHeaderValues(this RestResponse response, string headerName)
+        => response.ContentHeaders
+                ?.Where(x => NameIs(x.Name, headerName))
+                .Select(x => x.Value.ToString() ?? "")
                 .ToArray() ??
             [];
 


### PR DESCRIPTION
## Description

I liked the new extensions added in #2221, but immediately wished for the same extensions for the `ContentHeaders` collection. This PR adds `GetContentHeaderValue` and `GetContentHeaderValues` extension methods.

I also removed the `?` after `HeaderParameter.Value` properties in the extensions, as they are no longer needed after #2241.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
