### PR TITLE
Allow setting parameter content type

### DIFF
--- a/docs/docs/usage/request.md
+++ b/docs/docs/usage/request.md
@@ -71,9 +71,28 @@ request.AddParameter("name", "Væ üé", false); // don't encode the value
 If you have files, RestSharp will send a `multipart/form-data` request. Your parameters will be part of this request in the form:
 
 ```
+Content-Type: text/plain; charset=utf-8
 Content-Disposition: form-data; name="parameterName"
 
 ParameterValue
+```
+
+Sometimes, you need to override the default content type for the parameter when making a multipart form call. It's possible to do by setting the `ContentType` property of the parameter object. As an example, the code below will create a POST parameter with JSON value, and set the appropriate content type:
+
+```csharp
+var parameter = new GetOrPostParameter("someJson", "{\"attributeFormat\":\"pdf\"}") {
+    ContentType = "application/json"
+};
+request.AddParameter(parameter);
+```
+
+When the request is set to use multipart content, the parameter will be sent as part of the request with the specified content type:
+
+```
+Content-Type: application/json; charset=utf-8
+Content-Disposition: form-data; name="someJson"
+
+{"attributeFormat":"pdf"}
 ```
 
 You can also add `GetOrPost` parameter as a default parameter to the client. This will add the parameter to every request made by the client.

--- a/src/RestSharp/Parameters/Parameter.cs
+++ b/src/RestSharp/Parameters/Parameter.cs
@@ -32,13 +32,29 @@ public abstract record Parameter {
     }
 
     /// <summary>
-    /// MIME content type of the parameter
+    /// Content type of the parameter. Normally applies to the body parameter, or POST parameter in multipart requests.
     /// </summary>
-    public ContentType ContentType { get; protected init; } = ContentType.Undefined;
-    public string?       Name   { get; }
-    public object?       Value  { get; }
-    public ParameterType Type   { get; }
-    public bool          Encode { get; }
+    public ContentType ContentType { get; set; } = ContentType.Undefined;
+
+    /// <summary>
+    /// Parameter name
+    /// </summary>
+    public string? Name { get; }
+
+    /// <summary>
+    /// Parameter value
+    /// </summary>
+    public object? Value { get; }
+
+    /// <summary>
+    /// Parameter type
+    /// </summary>
+    public ParameterType Type { get; }
+
+    /// <summary>
+    /// Indicates if the parameter value should be encoded or not.
+    /// </summary>
+    public bool Encode { get; }
 
     /// <summary>
     /// Return a human-readable representation of this parameter
@@ -48,6 +64,15 @@ public abstract record Parameter {
 
     protected virtual string ValueString => Value?.ToString() ?? "null";
 
+    /// <summary>
+    /// Creates a parameter object of based on the type
+    /// </summary>
+    /// <param name="name">Parameter name</param>
+    /// <param name="value">Parameter value</param>
+    /// <param name="type">Parameter type</param>
+    /// <param name="encode">Indicates if the parameter value should be encoded</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
     public static Parameter CreateParameter(string? name, object? value, ParameterType type, bool encode = true)
         // ReSharper disable once SwitchExpressionHandlesSomeKnownEnumValuesWithExceptionInDefault
         => type switch {


### PR DESCRIPTION
## Description

POST parameters support content type when being used in multipart forms, but there's no way to set the content type property of the parameter today. This PR fixes it.

## Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


