### PR TITLE
Don't allow CRLF in headers

### DIFF
--- a/src/RestSharp/Parameters/HeaderParameter.cs
+++ b/src/RestSharp/Parameters/HeaderParameter.cs
@@ -13,22 +13,71 @@
 // limitations under the License.
 // 
 
+using System.Text;
+using System.Text.RegularExpressions;
+
 namespace RestSharp;
 
-public record HeaderParameter : Parameter {
+public partial record HeaderParameter : Parameter {
     /// <summary>
     /// Instantiates a header parameter
     /// </summary>
-    /// <param name="name">Parameter name</param>
-    /// <param name="value">Parameter value</param>
-    public HeaderParameter(string name, string value)
+    /// <param name="name">Header name</param>
+    /// <param name="value">Header value</param>
+    /// <param name="encode">Set to true to encode header value according to RFC 2047. Default is false.</param>
+    public HeaderParameter(string name, string value, bool encode = false)
         : base(
-            Ensure.NotEmptyString(name, nameof(name)),
-            Ensure.NotNull(value, nameof(value)),
+            EnsureValidHeaderString(Ensure.NotEmptyString(name, nameof(name)), "name"),
+            EnsureValidHeaderValue(name, value, encode),
             ParameterType.HttpHeader,
             false
         ) { }
 
     public new string Name  => base.Name!;
     public new string Value => (string)base.Value!;
+
+    static string EnsureValidHeaderValue(string name, string value, bool encode) {
+        CheckAndThrowsForInvalidHost(name, value);
+
+        return EnsureValidHeaderString(GetValue(Ensure.NotNull(value, nameof(value)), encode), "value");
+    }
+
+    static string EnsureValidHeaderString(string value, string type)
+        => !IsInvalidHeaderString(value) ? value : throw new ArgumentException($"Invalid character found in header {type}: {value}");
+
+    static string GetValue(string value, bool encode) => encode ? GetBase64EncodedHeaderValue(value) : value;
+
+    static string GetBase64EncodedHeaderValue(string value) => $"=?UTF-8?B?{Convert.ToBase64String(Encoding.UTF8.GetBytes(value))}?=";
+
+    static bool IsInvalidHeaderString(string stringValue) {
+        // ReSharper disable once ForCanBeConvertedToForeach
+        for (var i = 0; i < stringValue.Length; i++) {
+            switch (stringValue[i]) {
+                case '\t':
+                case '\r':
+                case '\n':
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    static readonly Regex PortSplitRegex = PartSplit();
+
+    static void CheckAndThrowsForInvalidHost(string name, string value) {
+        if (name == KnownHeaders.Host && InvalidHost(value))
+            throw new ArgumentException("The specified value is not a valid Host header string.", nameof(value));
+
+        return;
+
+        static bool InvalidHost(string host) => Uri.CheckHostName(PortSplitRegex.Split(host)[0]) == UriHostNameType.Unknown;
+    }
+
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(@":\d+")]
+    private static partial Regex PartSplit();
+#else
+    static Regex PartSplit() => new(@":\d+");
+#endif
 }

--- a/src/RestSharp/Request/RestRequestExtensions.Headers.cs
+++ b/src/RestSharp/Request/RestRequestExtensions.Headers.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Text.RegularExpressions;
-
 namespace RestSharp;
 
 public static partial class RestRequestExtensions {
@@ -39,10 +37,8 @@ public static partial class RestRequestExtensions {
     /// <param name="name">Header name</param>
     /// <param name="value">Header value</param>
     /// <returns></returns>
-    public static RestRequest AddHeader(this RestRequest request, string name, string value) {
-        CheckAndThrowsForInvalidHost(name, value);
-        return request.AddParameter(new HeaderParameter(name, value));
-    }
+    public static RestRequest AddHeader(this RestRequest request, string name, string value)
+        => request.AddParameter(new HeaderParameter(name, value));
 
     /// <summary>
     /// Adds a header to the request. RestSharp will try to separate request and content headers when calling the resource.
@@ -62,10 +58,8 @@ public static partial class RestRequestExtensions {
     /// <param name="name">Header name</param>
     /// <param name="value">Header value</param>
     /// <returns></returns>
-    public static RestRequest AddOrUpdateHeader(this RestRequest request, string name, string value) {
-        CheckAndThrowsForInvalidHost(name, value);
-        return request.AddOrUpdateParameter(new HeaderParameter(name, value));
-    }
+    public static RestRequest AddOrUpdateHeader(this RestRequest request, string name, string value)
+        => request.AddOrUpdateParameter(new HeaderParameter(name, value));
 
     /// <summary>
     /// Adds or updates the request header. RestSharp will try to separate request and content headers when calling the resource.
@@ -121,22 +115,4 @@ public static partial class RestRequestExtensions {
             throw new ArgumentException($"Duplicate header names exist: {string.Join(", ", duplicateKeys)}");
         }
     }
-
-    static readonly Regex PortSplitRegex = PartSplit();
-
-    static void CheckAndThrowsForInvalidHost(string name, string value) {
-        if (name == KnownHeaders.Host && InvalidHost(value))
-            throw new ArgumentException("The specified value is not a valid Host header string.", nameof(value));
-
-        return;
-
-        static bool InvalidHost(string host) => Uri.CheckHostName(PortSplitRegex.Split(host)[0]) == UriHostNameType.Unknown;
-    }
-
-#if NET7_0_OR_GREATER
-    [GeneratedRegex(@":\d+")]
-    private static partial Regex PartSplit();
-#else
-    static Regex PartSplit() => new(@":\d+");
-#endif
 }

--- a/test/RestSharp.Tests/RequestHeaderTests.cs
+++ b/test/RestSharp.Tests/RequestHeaderTests.cs
@@ -174,6 +174,12 @@ public class RequestHeaderTests {
         var request = new RestRequest();
         Assert.Throws<ArgumentException>("name", () => request.AddHeader("", "value"));
     }
+    
+    [Fact]
+    public void Should_not_allow_CRLF_in_header_value() {
+        var request = new RestRequest();
+        Assert.Throws<ArgumentException>(() => request.AddHeader("name", "test\r\nUser-Agent: injected header!\r\n\r\nGET /smuggled HTTP/1.1\r\nHost: insert.some.site.here"));
+    }
 
     static Parameter[] GetHeaders(RestRequest request) => request.Parameters.Where(x => x.Type == ParameterType.HttpHeader).ToArray();
 


### PR DESCRIPTION
## Description

Fixes potential exposure of applications that use RestSharp and allow users to provide header values to execute a request with CRLF in the header value possibly causing SSRF.

# Purpose
This pull request is a:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

It's breaking change since some users might be required to send invalid header values. Also, the new version is not binary-compatible with the previous version, so the fix will be released as a major version.
