### PR TITLE
Allow leaving encoded slash in UrlSegmentParameter value

### DIFF
--- a/src/RestSharp/Parameters/UrlSegmentParameter.cs
+++ b/src/RestSharp/Parameters/UrlSegmentParameter.cs
@@ -26,10 +26,11 @@ public partial record UrlSegmentParameter : NamedParameter {
     /// <param name="name">Parameter name</param>
     /// <param name="value">Parameter value</param>
     /// <param name="encode">Optional: encode the value, default is true</param>
-    public UrlSegmentParameter(string name, string value, bool encode = true)
+    /// <param name="replaceEncodedSlash">Optional: whether to replace all %2f and %2F in the parameter value with '/', default is true</param>
+    public UrlSegmentParameter(string name, string value, bool encode = true, bool replaceEncodedSlash = true)
         : base(
             name,
-            RegexPattern.Replace(Ensure.NotEmptyString(value, nameof(value)), "/"),
+            replaceEncodedSlash ? RegexPattern.Replace(Ensure.NotEmptyString(value, nameof(value)), "/") : value,
             ParameterType.UrlSegment,
             encode
         ) { }

--- a/test/RestSharp.Tests/ParametersTests.cs
+++ b/test/RestSharp.Tests/ParametersTests.cs
@@ -63,4 +63,28 @@ public class ParametersTests {
 
         expected.Should().BeEquivalentTo(actual);
     }
+
+    [Theory]
+    [InlineData("bar%2fBAR")]
+    [InlineData("bar%2FBAR")]
+    public void UrlSegmentParameter_WithValueWithEncodedSlash_WillReplaceEncodedSlashByDefault(string inputValue) {
+        var urlSegmentParameter = new UrlSegmentParameter("foo", inputValue);
+        urlSegmentParameter.Value.Should().BeEquivalentTo("bar/BAR");
+    }
+    
+    [Theory]
+    [InlineData("bar%2fBAR")]
+    [InlineData("bar%2FBAR")]
+    public void UrlSegmentParameter_WithValueWithEncodedSlash_CanReplaceEncodedSlash(string inputValue) {
+        var urlSegmentParameter = new UrlSegmentParameter("foo", inputValue, replaceEncodedSlash: true);
+        urlSegmentParameter.Value.Should().BeEquivalentTo("bar/BAR");
+    }
+    
+    [Theory]
+    [InlineData("bar%2fBAR")]
+    [InlineData("bar%2FBAR")]
+    public void UrlSegmentParameter_WithValueWithEncodedSlash_CanLeaveEncodedSlash(string inputValue) {
+        var urlSegmentParameter = new UrlSegmentParameter("foo", inputValue, replaceEncodedSlash: false);
+        urlSegmentParameter.Value.Should().BeEquivalentTo(inputValue);
+    }
 }


### PR DESCRIPTION
## Description

<!-- If your pull request solves an issue, please reference it here -->

We need to use path parameters which include the sequence of characters '%2F' or '%2f' in them. The constructor of UrlSegmentParameter replaces these sequences in the value with a '/' character. When using version 110.2.0 of RestSharp we would get around this by setting the Value property with the original string after the creation of the UrlSegmentParameter, but at 112.0.0 this is no longer possible as the Value property is now readonly after creation.

This pull request adds an optional parameter to the UrlSegmentParameter constructor to give control over whether the value is changed to replace '%2F' or not.

(we cannot create a new class with the desired behaviour since the UrlSegmentParameter type is used in this line https://github.com/restsharp/RestSharp/blob/dev/src/RestSharp/Request/UriExtensions.cs#L57)

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
