### PR TITLE
Remove note that `404` response code means succes

### DIFF
--- a/docs/docs/usage/response.md
+++ b/docs/docs/usage/response.md
@@ -7,27 +7,27 @@ All `Execute{Method}Async` functions return an instance of `RestResponse`. Simil
 
 Response object contains the following properties:
 
-| Property                 | Type                                                | Description                                                                                                                  |
-|--------------------------|-----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
-| `Request`                | `RestRequest`                                       | Request instance that was used to get the response.                                                                          |
-| `ContentType`            | `string?`                                           | Response content type. `Null` if response has no content.                                                                    |
-| `ContentLength`          | `long?`                                             | Response content length. `Null` if response has no content.                                                                  |
-| `ContentEncoding`        | `ICollection<string>`                               | Content encoding collection. Empty if response has no content.                                                               |
-| `Content`                | `string?`                                           | Response content as string. `Null` if response has no content.                                                               |
-| `IsSuccessfulStatusCode` | `bool`                                              | Indicates if response was successful, so no errors were reported by the server. Note that `404` response code means success. |
-| `ResponseStatus`         | `None`, `Completed`, `Error`, `TimedOut`, `Aborted` | Response completion status. Note that completed responses might still return errors.                                         |
-| `IsSuccessful`           | `bool`                                              | `True` when `IsSuccessfulStatusCode` is `true` and `ResponseStatus` is `Completed`.                                          |
-| `StatusDescription`      | `string?`                                           | Response status description, if available.                                                                                   |
-| `RawBytes`               | `byte[]?`                                           | Response content as byte array. `Null` if response has no content.                                                           |
-| `ResponseUri`            | `Uri?`                                              | URI of the response, which might be different from request URI in case of redirects.                                         |
-| `Server`                 | `string?`                                           | Server header value of the response.                                                                                         |
-| `Cookies`                | `CookieCollection?`                                 | Collection of cookies received with the response, if any.                                                                    |
-| `Headers`                | Collection of `HeaderParameter`                     | Response headers.                                                                                                            |
-| `ContentHeaders`         | Collection of `HeaderParameter`                     | Response content headers.                                                                                                    |
-| `ErrorMessage`           | `string?`                                           | Transport or another non-HTTP error generated while attempting request.                                                      |
-| `ErrorException`         | `Exception?`                                        | Exception thrown when executing the request, if any.                                                                         |
-| `Version`                | `Version?`                                          | HTTP protocol version of the request.                                                                                        |
-| `RootElement`            | `string?`                                           | Root element of the serialized response content, only works if deserializer supports it.                                     |
+| Property                 | Type                                                | Description                                                                              |
+|--------------------------|-----------------------------------------------------|------------------------------------------------------------------------------------------|
+| `Request`                | `RestRequest`                                       | Request instance that was used to get the response.                                      |
+| `ContentType`            | `string?`                                           | Response content type. `Null` if response has no content.                                |
+| `ContentLength`          | `long?`                                             | Response content length. `Null` if response has no content.                              |
+| `ContentEncoding`        | `ICollection<string>`                               | Content encoding collection. Empty if response has no content.                           |
+| `Content`                | `string?`                                           | Response content as string. `Null` if response has no content.                           |
+| `IsSuccessfulStatusCode` | `bool`                                              | Indicates if response was successful, so no errors were reported by the server.          |
+| `ResponseStatus`         | `None`, `Completed`, `Error`, `TimedOut`, `Aborted` | Response completion status. Note that completed responses might still return errors.     |
+| `IsSuccessful`           | `bool`                                              | `True` when `IsSuccessfulStatusCode` is `true` and `ResponseStatus` is `Completed`.      |
+| `StatusDescription`      | `string?`                                           | Response status description, if available.                                               |
+| `RawBytes`               | `byte[]?`                                           | Response content as byte array. `Null` if response has no content.                       |
+| `ResponseUri`            | `Uri?`                                              | URI of the response, which might be different from request URI in case of redirects.     |
+| `Server`                 | `string?`                                           | Server header value of the response.                                                     |
+| `Cookies`                | `CookieCollection?`                                 | Collection of cookies received with the response, if any.                                |
+| `Headers`                | Collection of `HeaderParameter`                     | Response headers.                                                                        |
+| `ContentHeaders`         | Collection of `HeaderParameter`                     | Response content headers.                                                                |
+| `ErrorMessage`           | `string?`                                           | Transport or another non-HTTP error generated while attempting request.                  |
+| `ErrorException`         | `Exception?`                                        | Exception thrown when executing the request, if any.                                     |
+| `Version`                | `Version?`                                          | HTTP protocol version of the request.                                                    |
+| `RootElement`            | `string?`                                           | Root element of the serialized response content, only works if deserializer supports it. |
 
 In addition, `RestResponse<T>` has one additional property:
 


### PR DESCRIPTION
## Description

Looking into the documentation on handling responses, I found a note on `IsSuccessfulStatusCode` mentioning "that `404` response code means succes". However, when checking implementation and tests, I found only that `ResponseStatus` will be `Completed` on `404` responses, but `IsSuccessfulStatusCode` should be `false`.

See also:
- https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpresponsemessage.issuccessstatuscode?view=net-9.0
- https://github.com/restsharp/RestSharp/blob/58180e8ce15fb7b1ba9ac6f1ffd92aa5f3e96723/src/RestSharp/Options/RestClientOptions.cs#L57-L63
- https://github.com/restsharp/RestSharp/blob/58180e8ce15fb7b1ba9ac6f1ffd92aa5f3e96723/test/RestSharp.Tests.Integrated/StatusCodeTests.cs#L68-L75

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
