### PR TITLE
#2308 In .NET 4.6.2, URLs do not execute Escape.

### DIFF
--- a/src/RestSharp/Request/UriExtensions.cs
+++ b/src/RestSharp/Request/UriExtensions.cs
@@ -31,7 +31,11 @@ static class UriExtensions {
 
         var usingBaseUri = baseUrl.AbsoluteUri[^1] == '/' || assembled.IsEmpty() ? baseUrl : new(baseUrl.AbsoluteUri + "/");
 
-        return assembled != null ? new(usingBaseUri, assembled) : baseUrl;
+#if NETSTANDARD2_0
+        return !string.IsNullOrWhiteSpace(assembled) ? new(usingBaseUri, assembled, true) : baseUrl;
+#else
+        return !string.IsNullOrWhiteSpace(assembled) ? new(usingBaseUri, assembled) : baseUrl;
+#endif
     }
 
     public static Uri AddQueryString(this Uri uri, string? query) {
@@ -50,7 +54,11 @@ static class UriExtensions {
         params ParametersCollection[] parametersCollections
     ) {
         var assembled = baseUri == null ? "" : resource;
-        var baseUrl   = baseUri ?? new Uri(resource);
+#if NETSTANDARD2_0
+        var baseUrl = baseUri ?? new Uri(resource, true);
+#else
+        var baseUrl = baseUri ?? new Uri(resource);
+#endif
 
         var hasResource = !assembled.IsEmpty();
 


### PR DESCRIPTION
### **User description**
#2308 In .NET 4.6.2, URLs do not execute Escape.

https://github.com/restsharp/RestSharp/issues/2308


___

### **PR Type**
Bug fix


___

### **Description**
- Fix URL encoding issue in .NET Framework 4.6.2 by enabling dontEscape parameter

- Add conditional compilation for NETSTANDARD2_0 to handle Uri constructor differences

- Ensure URLs with special characters (e.g., `%3A`) are properly escaped across frameworks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["URL with special chars<br/>e.g., %3A"] -->|NETSTANDARD2_0| B["Uri constructor<br/>dontEscape=true"]
  A -->|Other frameworks| C["Uri constructor<br/>default behavior"]
  B --> D["Properly escaped URL"]
  C --> D
  D --> E["Correct response<br/>from server"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UriExtensions.cs</strong><dd><code>Add dontEscape parameter for .NET Framework URL encoding</code>&nbsp; </dd></summary>
<hr>

src/RestSharp/Request/UriExtensions.cs

<ul><li>Modified <code>MergeBaseUrlAndResource</code> method to pass <code>true</code> as third <br>parameter to Uri constructor for NETSTANDARD2_0<br> <li> Modified <code>GetUrlSegmentParamsValues</code> method to pass <code>true</code> as second <br>parameter to Uri constructor for NETSTANDARD2_0<br> <li> Added conditional compilation directives to differentiate behavior <br>between NETSTANDARD2_0 and other frameworks<br> <li> Ensures proper URL escaping for special characters in .NET Framework <br>4.6.2</ul>


</details>


  </td>
  <td><a href="https://github.com/restsharp/RestSharp/pull/2327/files#diff-4e29686a2988e3e4b5d4834e947115d72d42f91151d44276cec58b4c982f3b88">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

