### PR TITLE
Fix XmlDeserializer when XML uses same tag in nested elements 

### DIFF
--- a/src/RestSharp.Serializers.Xml/XmlDeserializer.cs
+++ b/src/RestSharp.Serializers.Xml/XmlDeserializer.cs
@@ -40,8 +40,16 @@ public class XmlDeserializer : IXmlDeserializer, IWithRootElement, IWithDateForm
         var root        = doc.Root;
         var rootElement = response.RootElement ?? RootElement;
 
-        if (rootElement != null && doc.Root != null)
-            root = doc.Root.DescendantsAndSelf(rootElement.AsNamespaced(Namespace)).SingleOrDefault();
+        if (rootElement != null && doc.Root != null) {
+            var namespacedRoot = rootElement.AsNamespaced(Namespace);
+            // Prefer shallowest match to avoid nested elements with same name
+            root = namespacedRoot != null 
+                ? doc.Root.Element(namespacedRoot) 
+                    ?? doc.Root.DescendantsAndSelf(namespacedRoot)
+                        .OrderBy(e => e.Ancestors().Count())
+                        .FirstOrDefault()
+                : null;
+        }
 
         // autodetect xml namespace
         if (Namespace.IsEmpty())
@@ -76,8 +84,14 @@ public class XmlDeserializer : IXmlDeserializer, IWithRootElement, IWithDateForm
                                 ? new(XNamespace.None.GetName(a.Name.LocalName), a.Value)
                                 : a
                     )
+                    .Where(a => a != null)
             );
         }
+    }
+
+    static bool IsValidXmlElementName(string name) {
+        // Generic type names contain backtick (e.g., "List`1") which is invalid in XML element names
+        return !name.Contains('`');
     }
 
     protected virtual object Map(object x, XElement? root) {
@@ -236,7 +250,20 @@ public class XmlDeserializer : IXmlDeserializer, IWithRootElement, IWithDateForm
             }
             else if (type.IsGenericType) {
                 var list      = (IList)Activator.CreateInstance(asType)!;
-                var container = GetElementByName(root, name);
+                XElement? container = null;
+                
+                // First check if root itself is the container (matches property name)
+                if (root != null && name?.LocalName != null) {
+                    var rootName = root.Name.LocalName;
+                    if (rootName.Equals(name.LocalName, StringComparison.OrdinalIgnoreCase)) {
+                        container = root;
+                    }
+                }
+                
+                // If root is not the container, try to find it as a child element
+                if (container == null) {
+                    container = GetElementByName(root, name);
+                }
 
                 if (container?.HasElements == true) {
                     var first = container.Elements().FirstOrDefault();
@@ -306,37 +333,89 @@ public class XmlDeserializer : IXmlDeserializer, IWithRootElement, IWithDateForm
 
         var list = (IList)Activator.CreateInstance(type)!;
 
-        IList<XElement> elements = root.Descendants(t.Name.AsNamespaced(Namespace)).ToList();
-
         var name      = t.Name;
         var attribute = t.GetAttribute<DeserializeAsAttribute>();
 
         if (attribute != null)
             name = attribute.Name;
 
-        if (!elements.Any()) {
-            var lowerName = name?.ToLower(Culture).AsNamespaced(Namespace);
-
-            elements = root.Descendants(lowerName).ToList();
+        // Try to find a container element first using property name
+        XElement? container = null;
+        
+        // Try property name first (skip if it contains invalid XML name characters like ` in generic types)
+        if (IsValidXmlElementName(propName)) {
+            container = GetElementByName(root, propName.AsNamespaced(Namespace));
         }
-
-        if (!elements.Any()) {
-            var camelName = name?.ToCamelCase(Culture).AsNamespaced(Namespace);
-
-            elements = root.Descendants(camelName).ToList();
+        
+        // Check if root itself matches the container naming
+        if (container == null && IsValidXmlElementName(propName)) {
+            var rootName = root.Name.LocalName;
+            var propNameLower = propName.ToLower(Culture);
+            
+            if (rootName.Equals(propName, StringComparison.OrdinalIgnoreCase) ||
+                rootName.Equals(propNameLower, StringComparison.OrdinalIgnoreCase)) {
+                container = root;
+            }
         }
+        
+        IList<XElement> elements;
+        
+        // If we found a container, get only its direct children (Elements)
+        if (container != null && container.HasElements) {
+            // Try to match item elements by name variations
+            var itemName = t.Name.AsNamespaced(Namespace);
+            var directChildren = container.Elements(itemName).ToList();
+            
+            if (!directChildren.Any()) {
+                var lowerName = name?.ToLower(Culture).AsNamespaced(Namespace);
+                directChildren = container.Elements(lowerName).ToList();
+            }
+            
+            if (!directChildren.Any()) {
+                var camelName = name?.ToCamelCase(Culture).AsNamespaced(Namespace);
+                directChildren = container.Elements(camelName).ToList();
+            }
+            
+            if (!directChildren.Any()) {
+                directChildren = container.Elements()
+                    .Where(e => e.Name.LocalName.RemoveUnderscoresAndDashes() == name)
+                    .ToList();
+            }
+            
+            if (!directChildren.Any()) {
+                var lowerName = name?.ToLower(Culture);
+                directChildren = container.Elements()
+                    .Where(e => e.Name.LocalName.RemoveUnderscoresAndDashes() == lowerName)
+                    .ToList();
+            }
+            
+            elements = directChildren;
+        }
+        else {
+            // Fallback: No container found, use Descendants for backward compatibility
+            elements = root.Descendants(t.Name.AsNamespaced(Namespace)).ToList();
 
-        if (!elements.Any())
-            elements = root.Descendants()
-                .Where(e => e.Name.LocalName.RemoveUnderscoresAndDashes() == name)
-                .ToList();
+            if (!elements.Any()) {
+                var lowerName = name?.ToLower(Culture).AsNamespaced(Namespace);
+                elements = root.Descendants(lowerName).ToList();
+            }
 
-        if (!elements.Any()) {
-            var lowerName = name?.ToLower(Culture).AsNamespaced(Namespace);
+            if (!elements.Any()) {
+                var camelName = name?.ToCamelCase(Culture).AsNamespaced(Namespace);
+                elements = root.Descendants(camelName).ToList();
+            }
 
-            elements = root.Descendants()
-                .Where(e => e.Name.LocalName.RemoveUnderscoresAndDashes() == lowerName)
-                .ToList();
+            if (!elements.Any())
+                elements = root.Descendants()
+                    .Where(e => e.Name.LocalName.RemoveUnderscoresAndDashes() == name)
+                    .ToList();
+
+            if (!elements.Any()) {
+                var lowerName = name?.ToLower(Culture);
+                elements = root.Descendants()
+                    .Where(e => e.Name.LocalName.RemoveUnderscoresAndDashes() == lowerName)
+                    .ToList();
+            }
         }
 
         PopulateListFromElements(t, elements, list);

--- a/test/RestSharp.Tests.Serializers.Xml/SampleClasses/NestedElementTestClasses.cs
+++ b/test/RestSharp.Tests.Serializers.Xml/SampleClasses/NestedElementTestClasses.cs
@@ -1,0 +1,25 @@
+namespace RestSharp.Tests.Serializers.Xml.SampleClasses;
+
+// Test classes for nested element bugs
+
+public class Item {
+    public int Id { get; set; }
+    public List<Item> SubItems { get; set; }
+}
+
+public class ItemContainer {
+    public List<Item> Items { get; set; } = new();
+}
+
+public class ItemWithGroup {
+    public int Id { get; set; }
+    public ItemGroup Group { get; set; }
+}
+
+public class ItemGroup {
+    public List<Item> Items { get; set; }
+}
+
+public class ItemsResponse {
+    public List<ItemWithGroup> Items { get; set; } = new();
+}

--- a/test/RestSharp.Tests.Serializers.Xml/XmlDeserializerTests.cs
+++ b/test/RestSharp.Tests.Serializers.Xml/XmlDeserializerTests.cs
@@ -1076,4 +1076,168 @@ public class XmlDeserializerTests {
 
         Assert.Null(p.ReadOnlyProxy);
     }
+
+    [Fact]
+    public void Deserialize_Nested_List_Should_Not_Include_Deeply_Nested_Items() {
+        // Bug #1 test: HandleListDerivative should use Elements() on containers, not Descendants()
+        const string xml = """
+            <root>
+                <items>
+                    <item>
+                        <id>1</id>
+                        <subitems>
+                            <item><id>2</id></item>
+                            <item><id>3</id></item>
+                        </subitems>
+                    </item>
+                </items>
+            </root>
+            """;
+
+        var deserializer = new XmlDeserializer();
+        var result = deserializer.Deserialize<ItemContainer>(new RestResponse { Content = xml })!;
+
+        // Should only have 1 item (id=1), not 3 (id=1,2,3)
+        Assert.NotNull(result);
+        Assert.NotNull(result.Items);
+        Assert.Single(result.Items);
+        Assert.Equal(1, result.Items[0].Id);
+    }
+
+    [Fact]
+    public void Deserialize_RootElement_Should_Not_Throw_On_Duplicate_Nested_Names() {
+        // Bug #2 test: RootElement selection should handle duplicate names gracefully
+        const string xml = """
+            <root>
+                <items>
+                    <item>
+                        <id>72</id>
+                        <group>
+                            <items>
+                                <item><id>74</id></item>
+                            </items>
+                        </group>
+                    </item>
+                </items>
+            </root>
+            """;
+
+        var deserializer = new XmlDeserializer { RootElement = "items" };
+        
+        // Should not throw InvalidOperationException: Sequence contains more than one element
+        var exception = Record.Exception(() => 
+            deserializer.Deserialize<ItemsResponse>(new RestResponse { Content = xml })
+        );
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Deserialize_RootElement_Should_Prefer_Shallowest_Match() {
+        // Bug #2 test: When multiple elements match RootElement, prefer the shallowest one
+        const string xml = """
+            <root>
+                <items>
+                    <item>
+                        <id>72</id>
+                        <group>
+                            <items>
+                                <item><id>74</id></item>
+                            </items>
+                        </group>
+                    </item>
+                </items>
+            </root>
+            """;
+
+        var deserializer = new XmlDeserializer { RootElement = "items" };
+        var result = deserializer.Deserialize<ItemsResponse>(new RestResponse { Content = xml })!;
+
+        // Should deserialize from the top-level <items>, not the nested one
+        Assert.NotNull(result);
+        Assert.NotNull(result.Items);
+        Assert.Single(result.Items);
+        Assert.Equal(72, result.Items[0].Id);
+    }
+
+    [Fact]
+    public void Deserialize_RootElement_Should_Try_Direct_Child_First() {
+        // Bug #2 test: Should try Element() before DescendantsAndSelf()
+        const string xml = """
+            <root>
+                <data>
+                    <one>direct</one>
+                </data>
+            </root>
+            """;
+
+        var deserializer = new XmlDeserializer { RootElement = "data" };
+        var result = deserializer.Deserialize<SimpleStruct>(new RestResponse { Content = xml });
+
+        Assert.Equal("direct", result.One);
+    }
+
+    [Fact]
+    public void Deserialize_List_With_Container_Should_Use_Direct_Children_Only() {
+        // Test that container-based list deserialization uses Elements() not Descendants()
+        const string xml = """
+            <root>
+                <items>
+                    <item>
+                        <id>10</id>
+                        <subitems>
+                            <item><id>20</id></item>
+                        </subitems>
+                    </item>
+                    <item>
+                        <id>11</id>
+                    </item>
+                </items>
+            </root>
+            """;
+
+        var deserializer = new XmlDeserializer();
+        var result = deserializer.Deserialize<ItemContainer>(new RestResponse { Content = xml })!;
+
+        Assert.NotNull(result.Items);
+        Assert.Equal(2, result.Items.Count);
+        Assert.Equal(10, result.Items[0].Id);
+        Assert.Equal(11, result.Items[1].Id);
+    }
+
+    [Fact]
+    public void Deserialize_Nested_Items_Should_Also_Use_Direct_Children() {
+        // Test that nested subitems also correctly use direct children
+        const string xml = """
+            <root>
+                <items>
+                    <item>
+                        <id>1</id>
+                        <subitems>
+                            <item><id>2</id></item>
+                            <item>
+                                <id>3</id>
+                                <subitems>
+                                    <item><id>4</id></item>
+                                </subitems>
+                            </item>
+                        </subitems>
+                    </item>
+                </items>
+            </root>
+            """;
+
+        var deserializer = new XmlDeserializer();
+        var result = deserializer.Deserialize<ItemContainer>(new RestResponse { Content = xml })!;
+
+        Assert.NotNull(result.Items);
+        Assert.Single(result.Items);
+        
+        var topItem = result.Items[0];
+        Assert.Equal(1, topItem.Id);
+        Assert.NotNull(topItem.SubItems);
+        Assert.Equal(2, topItem.SubItems.Count);
+        Assert.Equal(2, topItem.SubItems[0].Id);
+        Assert.Equal(3, topItem.SubItems[1].Id);
+    }
 }


### PR DESCRIPTION
### **User description**
## Description
This pull request improves the robustness and correctness of XML deserialization in the `XmlDeserializer` class, particularly around handling nested elements and root element selection. It addresses bugs where nested lists were incorrectly flattened and where ambiguous root element names caused errors. The changes are thoroughly tested with new unit tests and supporting sample classes.

**Improvements to XML deserialization logic:**

* Updated root element selection to prefer the shallowest matching element, avoiding errors when multiple elements have the same name, and to check for direct child elements before searching descendants. This fixes issues where the wrong element was chosen as the root.
* Refined list deserialization to use only direct children of the container element (via `Elements()`) instead of all descendants (via `Descendants()`), preventing deeply nested items from being incorrectly included in top-level lists. [[1]](diffhunk://#diff-575d4d81acd193972719ee84495a018f9598a61e00840e4f58019fcc19e831c1L309-L325) [[2]](diffhunk://#diff-575d4d81acd193972719ee84495a018f9598a61e00840e4f58019fcc19e831c1L335-R419)
* Improved handling of generic type names and XML element name validity by introducing a check that skips invalid XML element names (such as those containing backticks).

**Bug fixes and test coverage:**

* Enhanced the mapping logic to correctly identify the container for generic collections, first checking if the root itself matches the property name before searching for a child element.
* Added comprehensive tests and sample classes to verify correct deserialization of nested lists, root element ambiguity, and container-based list handling, ensuring the fixes are robust and preventing regressions. [[1]](diffhunk://#diff-ca972954a9ceb65253b4bef08ade4ef90369948981b5204d6ad1f7a81504d720R1-R25) [[2]](diffhunk://#diff-2882e6f660a78859dd53b557c2616f1905eb54dd6f2e6d6ceba11a36453869d8R1079-R1242)* Fix XmlDeserializer nested element bugs

## Purposee
- Fix Bug HandleListDerivative now uses Elements() on containers instead of Descendants()
- Fix Bug Deserialize RootElement selection prefers shallowest match
- Fix Bug RemoveNamespace filters null values



## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


___

### **Auto-created Ticket**

[#2337](https://github.com/restsharp/RestSharp/issues/2337)

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix nested list deserialization using Elements() instead of Descendants()

- Improve root element selection to prefer shallowest matching element

- Filter null values in RemoveNamespace method

- Add validation for XML element names containing invalid characters

- Enhance container-based list handling with direct child element matching


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["XML Document"] -->|"Parse & Find Root"| B["Root Element Selection"]
  B -->|"Prefer Shallowest Match"| C["Selected Root Element"]
  C -->|"Deserialize Lists"| D["HandleListDerivative"]
  D -->|"Find Container"| E["Container Element"]
  E -->|"Use Elements() for Direct Children"| F["Deserialized List Items"]
  G["RemoveNamespace"] -->|"Filter Null Attributes"| H["Cleaned XML"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>XmlDeserializer.cs</strong><dd><code>Refactor root selection and list deserialization logic</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/RestSharp.Serializers.Xml/XmlDeserializer.cs

<ul><li>Modified root element selection to prefer shallowest matching element <br>using OrderBy on ancestor count<br> <li> Changed from SingleOrDefault() to Element() first, then <br>DescendantsAndSelf() with ordering<br> <li> Added IsValidXmlElementName() helper to skip invalid XML names <br>containing backticks<br> <li> Enhanced HandleListDerivative to find container element first before <br>searching descendants<br> <li> Updated list deserialization to use Elements() on containers instead <br>of Descendants()<br> <li> Added null filtering in RemoveNamespace to prevent null attribute <br>assignments<br> <li> Implemented multiple name variation matching strategies for direct <br>children only</ul>


</details>


  </td>
  <td><a href="https://github.com/restsharp/RestSharp/pull/2336/files#diff-575d4d81acd193972719ee84495a018f9598a61e00840e4f58019fcc19e831c1">+102/-23</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NestedElementTestClasses.cs</strong><dd><code>Add test sample classes for nested elements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/RestSharp.Tests.Serializers.Xml/SampleClasses/NestedElementTestClasses.cs

<ul><li>Added Item class with recursive SubItems list property<br> <li> Added ItemContainer class to hold list of items<br> <li> Added ItemWithGroup and ItemGroup classes for nested group testing<br> <li> Added ItemsResponse class for complex nested structure testing</ul>


</details>


  </td>
  <td><a href="https://github.com/restsharp/RestSharp/pull/2336/files#diff-ca972954a9ceb65253b4bef08ade4ef90369948981b5204d6ad1f7a81504d720">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>XmlDeserializerTests.cs</strong><dd><code>Add comprehensive tests for nested element fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/RestSharp.Tests.Serializers.Xml/XmlDeserializerTests.cs

<ul><li>Added test for nested lists not including deeply nested items<br> <li> Added test for RootElement handling duplicate nested names without <br>throwing<br> <li> Added test for RootElement preferring shallowest match<br> <li> Added test for RootElement trying direct child first<br> <li> Added test for container-based list using direct children only<br> <li> Added test for nested items also using direct children correctly</ul>


</details>


  </td>
  <td><a href="https://github.com/restsharp/RestSharp/pull/2336/files#diff-2882e6f660a78859dd53b557c2616f1905eb54dd6f2e6d6ceba11a36453869d8">+165/-1</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

