### PR TITLE
Add missing ConfigureAwait(false) to prevent deadlocks

### DIFF
--- a/src/RestSharp/Extensions/HttpResponseExtensions.cs
+++ b/src/RestSharp/Extensions/HttpResponseExtensions.cs
@@ -32,7 +32,7 @@ static class HttpResponseExtensions {
         var encoding       = encodingString != null ? TryGetEncoding(encodingString) : clientEncoding;
 
         using var reader = new StreamReader(new MemoryStream(bytes), encoding);
-        return await reader.ReadToEndAsync();
+        return await reader.ReadToEndAsync().ConfigureAwait(false);
         Encoding TryGetEncoding(string es) {
             try {
                 return Encoding.GetEncoding(es);

--- a/src/RestSharp/Response/RestResponse.cs
+++ b/src/RestSharp/Response/RestResponse.cs
@@ -54,7 +54,7 @@ public class RestResponse(RestRequest request) : RestResponseBase(request) {
 #endif
 
             var bytes   = stream == null ? null : await stream.ReadAsBytes(cancellationToken).ConfigureAwait(false);
-            var content = bytes == null ? null : await httpResponse.GetResponseString(bytes, options.Encoding);
+            var content = bytes == null ? null : await httpResponse.GetResponseString(bytes, options.Encoding).ConfigureAwait(false);
 
             return new(request) {
                 Content             = content,

--- a/src/RestSharp/RestClient.Extensions.cs
+++ b/src/RestSharp/RestClient.Extensions.cs
@@ -45,7 +45,7 @@ public static partial class RestClientExtensions {
             Ensure.NotNull(request, nameof(request));
 
             var response = await client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
-            return await client.Serializers.Deserialize<T>(request, response, client.Options, cancellationToken);
+            return await client.Serializers.Deserialize<T>(request, response, client.Options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -172,9 +172,9 @@ public static partial class RestClientExtensions {
             using var reader = new StreamReader(stream);
 
 #if NET7_0_OR_GREATER
-            while (await reader.ReadLineAsync(cancellationToken) is { } line && !cancellationToken.IsCancellationRequested) {
+            while (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line && !cancellationToken.IsCancellationRequested) {
 #else
-            while (await reader.ReadLineAsync() is { } line && !cancellationToken.IsCancellationRequested) {
+            while (await reader.ReadLineAsync().ConfigureAwait(false) is { } line && !cancellationToken.IsCancellationRequested) {
 #endif
                 if (string.IsNullOrWhiteSpace(line)) continue;
 

--- a/test/RestSharp.Tests.Integrated/SyncRequestTests.cs
+++ b/test/RestSharp.Tests.Integrated/SyncRequestTests.cs
@@ -1,0 +1,57 @@
+namespace RestSharp.Tests.Integrated;
+
+#pragma warning disable xUnit1031 // Blocking calls in tests are intentional — we are testing sync-over-async deadlock safety
+
+public sealed class SyncRequestTests(WireMockTestServer server) : IClassFixture<WireMockTestServer> {
+    [Fact]
+    public void Sync_execute_should_not_deadlock() {
+        // Regression test for https://github.com/restsharp/RestSharp/issues/2083
+        // Sync methods (ExecuteGet) could deadlock when await calls inside the pipeline
+        // did not use ConfigureAwait(false), causing continuations to try to marshal
+        // back to a captured SynchronizationContext.
+
+        using var client  = new RestClient(server.Url!);
+        var       request = new RestRequest("success");
+
+        RestResponse? response = null;
+
+        var completed = Task.Run(() => {
+            response = client.ExecuteGet(request);
+        }).Wait(TimeSpan.FromSeconds(10));
+
+        completed.Should().BeTrue("sync ExecuteGet should complete without deadlocking");
+        response.Should().NotBeNull();
+        response!.IsSuccessStatusCode.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Sync_execute_with_deserialization_should_not_deadlock() {
+        using var client  = new RestClient(server.Url!);
+        var       request = new RestRequest("success");
+
+        RestResponse<SuccessResponse>? response = null;
+
+        var completed = Task.Run(() => {
+            response = client.ExecuteGet<SuccessResponse>(request);
+        }).Wait(TimeSpan.FromSeconds(10));
+
+        completed.Should().BeTrue("sync ExecuteGet<T> should complete without deadlocking");
+        response.Should().NotBeNull();
+        response!.IsSuccessStatusCode.Should().BeTrue();
+        response.Data.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Sync_execute_from_multiple_threads_should_not_deadlock() {
+        using var client = new RestClient(server.Url!);
+        const int threadCount = 5;
+
+        var completed = Parallel.For(0, threadCount, _ => {
+            var request  = new RestRequest("success");
+            var response = client.ExecuteGet(request);
+            response.IsSuccessStatusCode.Should().BeTrue();
+        });
+
+        completed.IsCompleted.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds missing `.ConfigureAwait(false)` to all `await` calls in the RestSharp source that were missing it, preventing sync-over-async deadlocks on .NET Framework and environments with a `SynchronizationContext` (WinForms, WPF, ASP.NET classic)
- Fixes: `HttpResponseExtensions.GetResponseString`, `RestResponse.FromHttpResponse`, `RestClientExtensions.ExecuteAsync<T>`, and `RestClientExtensions.StreamJsonAsync<T>`

Fixes #2083

## Context

Reported by @deAtog in https://github.com/restsharp/RestSharp/issues/2083#issuecomment-4000159643 — when sync methods like `ExecuteGet` are used (which internally call `AsyncHelpers.RunSync`), any nested `await` without `.ConfigureAwait(false)` can capture the synchronization context and deadlock.

## Test plan

- [x] Solution builds with 0 errors
- [x] Verified no remaining `await` calls without `.ConfigureAwait(false)` in `src/RestSharp/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)