### PR TITLE
Fix HttpClient deadlocks: Addendum to #2367

### DIFF
--- a/src/RestSharp/AsyncHelpers.cs
+++ b/src/RestSharp/AsyncHelpers.cs
@@ -14,114 +14,20 @@
 //
 // Adapted from Rebus
 
-using System.Collections.Concurrent;
-using System.Runtime.ExceptionServices;
-
 namespace RestSharp;
 
 static class AsyncHelpers {
     /// <summary>
-    /// Executes a task synchronously on the calling thread by installing a temporary synchronization context that queues continuations
+    /// Executes a task on the thread pool, waits for it to complete, and then returns the result.
     /// </summary>
-    /// <param name="task">Callback for asynchronous task to run</param>
-    static void RunSync(Func<Task> task) {
-        var currentContext = SynchronizationContext.Current;
-        var customContext  = new CustomSynchronizationContext(task);
-
-        try {
-            SynchronizationContext.SetSynchronizationContext(customContext);
-            customContext.Run();
-        }
-        finally {
-            SynchronizationContext.SetSynchronizationContext(currentContext);
-        }
-    }
-
-    /// <summary>
-    /// Executes a task synchronously on the calling thread by installing a temporary synchronization context that queues continuations
-    /// </summary>
-    /// <param name="task">Callback for asynchronous task to run</param>
+    /// <param name="func">Callback for asynchronous task to run</param>
     /// <typeparam name="T">Return type for the task</typeparam>
     /// <returns>Return value from the task</returns>
-    public static T RunSync<T>(Func<Task<T>> task) {
-        T result = default!;
-        RunSync(async () => { result = await task(); });
-        return result;
-    }
-
-    /// <summary>
-    /// Synchronization context that can be "pumped" in order to have it execute continuations posted back to it
-    /// </summary>
-    class CustomSynchronizationContext : SynchronizationContext {
-        readonly ConcurrentQueue<Tuple<SendOrPostCallback, object?>> _items            = new();
-        readonly AutoResetEvent                                      _workItemsWaiting = new(false);
-        readonly Func<Task>                                          _task;
-        ExceptionDispatchInfo?                                       _caughtException;
-        bool                                                         _done;
-
-        /// <summary>
-        /// Constructor for the custom context
-        /// </summary>
-        /// <param name="task">Task to execute</param>
-        public CustomSynchronizationContext(Func<Task> task) =>
-            _task = task ?? throw new ArgumentNullException(nameof(task), "Please remember to pass a Task to be executed");
-
-        /// <summary>
-        /// When overridden in a derived class, dispatches an asynchronous message to a synchronization context.
-        /// </summary>
-        /// <param name="function">Callback function</param>
-        /// <param name="state">Callback state</param>
-        public override void Post(SendOrPostCallback function, object? state) {
-            _items.Enqueue(Tuple.Create(function, state));
-            _workItemsWaiting.Set();
-        }
-
-        /// <summary>
-        /// Enqueues the function to be executed and executes all resulting continuations until it is completely done
-        /// </summary>
-        public void Run() {
-            Post(PostCallback, null);
-
-            while (!_done) {
-                if (_items.TryDequeue(out var task)) {
-                    task.Item1(task.Item2);
-                    if (_caughtException == null) {
-                        continue;
-                    }
-                    _caughtException.Throw();
-                }
-                else {
-                    _workItemsWaiting.WaitOne();
-                }
-            }
-
-            return;
-
-            async void PostCallback(object? _) {
-                try {
-                    await _task().ConfigureAwait(false);
-                }
-                catch (Exception exception) {
-                    _caughtException = ExceptionDispatchInfo.Capture(exception);
-                    throw;
-                }
-                finally {
-                    Post(_ => _done = true, null);
-                }
-            }
-        }
-
-        /// <summary>
-        /// When overridden in a derived class, dispatches a synchronous message to a synchronization context.
-        /// </summary>
-        /// <param name="function">Callback function</param>
-        /// <param name="state">Callback state</param>
-        public override void Send(SendOrPostCallback function, object? state) => throw new NotSupportedException("Cannot send to same thread");
-
-        /// <summary>
-        /// When overridden in a derived class, creates a copy of the synchronization context. Not needed, so just return ourselves.
-        /// </summary>
-        /// <returns>Copy of the context</returns>
-        public override SynchronizationContext CreateCopy() => this;
+    /// <remarks>
+    /// Every RunSync call requires at least one thread pool thread. If multiple threads call
+    /// RunSync simultaneously, then there is a possibility the threadpool could be starved of threads.
+    /// </remarks>
+    public static T RunSync<T>(Func<Task<T>> func) {
+        return Task.Run(func).GetAwaiter().GetResult();
     }
 }


### PR DESCRIPTION
## Description

- Modifies RunAsync helper method to:
  1. Use Task.Run to force asynchronous tasks to run on the thread pool.
  2. This method avoids potential deadlocks at the cost of requiring at least one thread pool thread per task.
- Removes the now unused CustomSynchronizationContext that did not resolve deadlocks.

This https://learn.microsoft.com/en-us/archive/blogs/jpsanders/asp-net-do-not-use-task-result-in-main-context describes the approach taken here to resolve the deadlock. Instead of using Task.Wait, we use Task.GetAwaiter().GetResult() as it will unwrap all exceptions instead of throwing an AggregateException.

## Purpose

These changes prevent deadlocks from calling async methods synchronously by executing them on a thread pool thread and capturing the result after the task completes.

## History

The CustomSychronizationContext implementation was originally pulled from https://github.com/rebus-org/Rebus/blob/27b212a2380d55edc16a0036dfefd8e6b3ad9c2c/Rebus/Bus/Advanced/RebusAsyncHelpers.cs

Their implementation does not call `ConfigureAwait(false)` on the task executed from within the CustomSynchronizationContext to ensure any continuations are queued on the CustomSynchronnizationContext, not the thread pool. This implementation can only run tasks that do not need to run concurrently and use locks or other synchronization mechanisms to ensure thread safety. This implementation is not suitable for wrapping methods of the HttpClient and has been removed as a result.
