### PR TITLE
Fix DefaultParameters not set up using a cached client instance

### DIFF
--- a/src/RestSharp/RestClient.cs
+++ b/src/RestSharp/RestClient.cs
@@ -86,6 +86,7 @@ public partial class RestClient : IRestClient {
             HttpClient         = GetClient();
         }
 
+        ConfigureDefaultParameters(options);
         return;
 
         HttpClient GetClient() {
@@ -97,7 +98,6 @@ public partial class RestClient : IRestClient {
             // We will use Options.Timeout in ExecuteAsInternalAsync method
             httpClient.Timeout = Timeout.InfiniteTimeSpan;
 
-            ConfigureDefaultParameters(options);
             configureDefaultHeaders?.Invoke(httpClient.DefaultRequestHeaders);
             return httpClient;
         }

--- a/test/RestSharp.Tests/RestClientTests.cs
+++ b/test/RestSharp.Tests/RestClientTests.cs
@@ -125,6 +125,42 @@ public class RestClientTests {
     }
 
     [Fact]
+    public void ConfigureDefaultParameters_sets_user_agent_using_factory_twice() {
+        // arrange
+        const string expectedAgentString = "Agent/1.0";
+
+        var clientOptions = new RestClientOptions
+        {
+            BaseUrl = new Uri("https://localhost:8888"),
+            UserAgent = expectedAgentString
+        };
+
+        // act
+        using var firstRestClient = new RestClient(clientOptions, useClientFactory: true);
+        using var secondRestClient = new RestClient(clientOptions, useClientFactory: true);
+
+        //assert
+        Assert.Single(
+            firstRestClient.DefaultParameters,
+            parameter => parameter is
+            {
+                Type: ParameterType.HttpHeader,
+                Name: KnownHeaders.UserAgent,
+                Value: expectedAgentString
+            }
+        );
+        Assert.Single(
+            secondRestClient.DefaultParameters,
+            parameter => parameter is
+            {
+                Type: ParameterType.HttpHeader,
+                Name: KnownHeaders.UserAgent,
+                Value: expectedAgentString
+            }
+        );
+    }
+
+    [Fact]
     public void Should_not_set_expect_continue_on_shared_http_client_default_headers() {
         // arrange
         var httpClient = new HttpClient();


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix default parameters initialization when using cached HttpClient factory
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## Description

Fixed issue:  https://github.com/restsharp/RestSharp/issues/2389

Moved the ConfigureDefaultParameters(options) call out of GetClient() and into the constructor body so it runs once per RestClient instance, regardless of whether the underlying HttpClient came from the factory cache. This decouples per-instance parameter setup from the shared HttpClient lifecycle.

Added ConfigureDefaultParameters_sets_user_agent_using_factory_twice, which creates two factory-backed clients with the same options and asserts both carry the User-Agent default parameter.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Ensure default parameters are configured once per RestClient instance, even with cached
  HttpClient.
• Decouple per-instance default parameter setup from shared HttpClient factory lifecycle.
• Add regression test validating User-Agent defaults for multiple factory-backed clients.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["RestClient ctor"] --> B["GetClient()"] --> C[("HttpClient (factory cache)")]
  A --> D["ConfigureDefaultParameters"] --> E["DefaultParameters"]

  subgraph Legend
    direction LR
    _code["Code"] ~~~ _db[("Shared resource")]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The chosen fix is the right approach: default parameters are per-RestClient state, so they should be configured during RestClient instance initialization rather than tied to HttpClient creation (which may be skipped when the factory returns a cached instance). Alternatives like re-running configuration on every request or mutating shared HttpClient headers would add overhead or risk cross-instance side effects.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>RestClient.cs</strong> <code>Configure default parameters in RestClient constructor (not HttpClient creation)</code> <code>+1/-1</code></summary>

<br/>

>Configure default parameters in RestClient constructor (not HttpClient creation)
>
><pre>
>• Moves ConfigureDefaultParameters(options) out of the local GetClient() method and into the RestClient constructor body. This ensures default parameters are set for every RestClient instance even when HttpClient is retrieved from a factory cache.
></pre>
>
><a href='https://github.com/restsharp/RestSharp/pull/2390/files#diff-e00edb0ffd0c39411486e45e69f01fc071d99a607cd06c9e27acebdd1241939c'>src/RestSharp/RestClient.cs</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>RestClientTests.cs</strong> <code>Add regression test for User-Agent defaults with factory-cached clients</code> <code>+36/-0</code></summary>

<br/>

>Add regression test for User-Agent defaults with factory-cached clients
>
><pre>
>• Adds a test that creates two RestClient instances with useClientFactory: true using the same options and asserts both instances contain the expected User-Agent default parameter. This guards against regressions when HttpClient reuse bypasses prior per-instance setup.
></pre>
>
><a href='https://github.com/restsharp/RestSharp/pull/2390/files#diff-07787694445e97ef64138fedd9cee4b151e9ab42c7b91803e1020b71408fb224'>test/RestSharp.Tests/RestClientTests.cs</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>