### PR TITLE
Fix #2400: AddObjectStatic throwing on null property values

### DIFF
--- a/src/RestSharp/Request/PropertyCache.Populator.cs
+++ b/src/RestSharp/Request/PropertyCache.Populator.cs
@@ -74,7 +74,15 @@ static partial class PropertyCache<T> where T : class {
 
             var populate = GetPopulate(getObject, property);
 
-            return new(property.Name, populate);
+            // Skip null property values so a DTO with unset optional properties doesn't throw.
+            // This matches the reflection-based AddObject.
+            return new(
+                property.Name,
+                (model, parameters) => {
+                    if (getObject(model) is null) return;
+                    populate(model, parameters);
+                }
+            );
         }
 
         static Action<T, ICollection<Parameter>> GetPopulate(Func<T, IFormattable> getFormattable, RequestProperty requestProperty)

--- a/test/RestSharp.Tests/Parameters/ObjectParameterTests.NullData.cs
+++ b/test/RestSharp.Tests/Parameters/ObjectParameterTests.NullData.cs
@@ -1,0 +1,61 @@
+namespace RestSharp.Tests.Parameters;
+
+public partial class ObjectParameterTests {
+    [Fact]
+    public void AddObjectStatic_skips_null_properties() {
+        var data = new NullableData { Kind = "set" };
+
+        var request = new RestRequest().AddObjectStatic(data);
+
+        request
+            .Parameters
+            .Should()
+            .ContainSingle()
+            .Which
+            .Should()
+            .BeEquivalentTo(new GetOrPostParameter(nameof(NullableData.Kind), "set"));
+    }
+
+    [Fact]
+    public void AddObjectStatic_keeps_non_null_properties_and_skips_null_ones() {
+        var data = new NullableData { Name = "Bob", Age = 30, Link = null, Values = null, Kind = "set" };
+
+        var request = new RestRequest().AddObjectStatic(data);
+
+        request
+            .Parameters
+            .Should()
+            .BeEquivalentTo(new[] {
+                new GetOrPostParameter(nameof(NullableData.Name), "Bob"),
+                new GetOrPostParameter(nameof(NullableData.Age), "30"),
+                new GetOrPostParameter(nameof(NullableData.Kind), "set")
+            });
+    }
+
+    [Fact]
+    public void AddObjectStatic_with_all_null_properties_yields_no_parameters() {
+        var data = new NullableData { Kind = null };
+
+        var request = new RestRequest().AddObjectStatic(data);
+
+        request.Parameters.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddObjectStatic_null_property_handling_matches_AddObject() {
+        var data = new NullableData { Name = null, Age = null, Link = null, Values = null, Kind = "set" };
+
+        var objStatic = new RestRequest().AddObjectStatic(data);
+        var reflection = new RestRequest().AddObject(data);
+
+        objStatic.Parameters.Should().BeEquivalentTo(reflection.Parameters);
+    }
+
+    class NullableData {
+        public string Name { get; set; }
+        public int? Age { get; set; }
+        public Uri Link { get; set; }
+        public List<int> Values { get; set; }
+        public string Kind { get; set; } = "set";
+    }
+}


### PR DESCRIPTION
## Description
Closes #2400 

## Problem

`AddObjectStatic` picks a conversion path from each property's static type but dereferences the runtime value without a null check. A DTO with an unset optional field therefore crashes while the request is being built.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)


## Checklist

- [x] I have added tests that prove my fix is effective
